### PR TITLE
Use gazebo simulated time for getEncodersTimed

### DIFF
--- a/include/gazebo_yarp_plugins/ControlBoardDriver.h
+++ b/include/gazebo_yarp_plugins/ControlBoardDriver.h
@@ -18,6 +18,7 @@
 #include <yarp/sig/Vector.h>
 #include <yarp/os/Time.h>
 #include <yarp/os/Semaphore.h>
+#include <yarp/os/Stamp.h>
 #include <string>
 #include <vector>
 
@@ -315,6 +316,8 @@ private:
     yarp::sig::Vector m_positions; /*<! joint positions */
     yarp::sig::Vector m_velocities; /*<! joint velocities */
     yarp::sig::Vector m_torques; /*<! joint torques */
+
+    yarp::os::Stamp m_lastTimestamp; /*<! timestamp, updated with simulation time at each onUpdate call */
 
     yarp::sig::Vector amp;
 

--- a/src/yarp_drivers/ControlBoardDriver.cpp
+++ b/src/yarp_drivers/ControlBoardDriver.cpp
@@ -134,7 +134,7 @@ void GazeboYarpControlBoardDriver::computeTrajectory(const int j)
     }
 }
 
-void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& /*_info*/)
+void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _info)
 {
     m_clock++;
 
@@ -151,6 +151,9 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& /*
         m_velocities[jnt_cnt] = GazeboYarpPlugins::convertRadiansToDegrees(this->m_robot->GetJoint(m_jointNames[jnt_cnt])->GetVelocity(0));
         m_torques[jnt_cnt] = this->m_robot->GetJoint(m_jointNames[jnt_cnt])->GetForce(0u);
     }
+
+    // Updating timestamp
+    m_lastTimestamp.update(_info.simTime.Double());
 
     //logger.log(m_velocities[2]);
 

--- a/src/yarp_drivers/ControlBoardDriverEncoders.cpp
+++ b/src/yarp_drivers/ControlBoardDriverEncoders.cpp
@@ -36,14 +36,14 @@ bool GazeboYarpControlBoardDriver::getEncodersTimed(double *encs, double *time)
         encs[i] = m_positions[i]-m_zeroPosition[i];  //should we just use memcopy here?
         time[i] = my_time;
     }
-    
+
     return true;
 }
 
 /**
  * Read the instantaneous acceleration of the specified axis
  * @param j axis index
- * @param encs pointer to double 
+ * @param encs pointer to double
  * @param time corresponding timestamp (pointer to)
  * @return true if all goes well, false if anything bad happens.
  */
@@ -51,7 +51,7 @@ bool GazeboYarpControlBoardDriver::getEncoderTimed(int j, double *encs, double *
 {
     if (time && encs && j >= 0 && j < (int)m_numberOfJoints) {
         *encs = m_positions[j]-m_zeroPosition[j];
-        *time = yarp::os::Time::now();
+        *time = m_lastTimestamp.getTime();
         return true;
     }
     return false;


### PR DESCRIPTION
 instead of yarp::os::Time::now() .
