### PR TITLE
Revert "Fix position direct and improve compliance with yarp controlboar...

### DIFF
--- a/include/gazebo_yarp_plugins/ControlBoardDriver.h
+++ b/include/gazebo_yarp_plugins/ControlBoardDriver.h
@@ -329,28 +329,23 @@ private:
      */
     yarp::sig::Vector m_zeroPosition;
 
-    yarp::sig::Vector m_positions; /*<! joint positions [Degrees] */
-    yarp::sig::Vector m_velocities; /*<! joint velocities [Degrees/Seconds] */
-    yarp::sig::Vector m_torques; /*<! joint torques [Netwon Meters] */
+    yarp::sig::Vector m_positions; /*<! joint positions */
+    yarp::sig::Vector m_velocities; /*<! joint velocities */
+    yarp::sig::Vector m_torques; /*<! joint torques */
 
     yarp::os::Stamp m_lastTimestamp; /*<! timestamp, updated with simulation time at each onUpdate call */
 
     yarp::sig::Vector amp;
 
     //Desired Control variables
-    yarp::sig::Vector m_referencePositions; /*<! desired reference positions.
-                                                 Depending on the position mode,
-                                                 they can be set directly or indirectly
-                                                 through the trajectory generator.
-                                                 [Degrees] */
-
-    yarp::sig::Vector m_referenceTorques; /*<! desired reference torques for torque control mode [NetwonMeters] */
-    yarp::sig::Vector m_referenceVelocities; /*<! desired reference velocities for velocity control mode [Degrees/Seconds] */
+    yarp::sig::Vector m_referencePositions; /*<! desired reference positions. Depending on the position mode, they can be set directly or indirectly through the trajectory generator */
+    yarp::sig::Vector m_referenceTorques; /*<! desired reference torques for torque control mode */
+    yarp::sig::Vector m_referenceVelocities; /*<! desired reference velocities for velocity control mode */
 
     //trajectory generator
-    yarp::sig::Vector m_trajectoryGenerationReferencePosition; /*<! reference position for trajectory generation in position mode [Degrees] */
-    yarp::sig::Vector m_trajectoryGenerationReferenceSpeed; /*<! reference speed for trajectory generation in position mode [Degrees/Seconds]*/
-    yarp::sig::Vector m_trajectoryGenerationReferenceAcceleraton; /*<! reference acceleration for trajectory generation in position mode. Currently NOT USED in trajectory generation! [Degrees/Seconds^2] */
+    yarp::sig::Vector m_trajectoryGenerationReferencePosition; /*<! reference position for trajectory generation in position mode */
+    yarp::sig::Vector m_trajectoryGenerationReferenceSpeed; /*<! reference speed for trajectory generation in position mode */
+    yarp::sig::Vector m_trajectoryGenerationReferenceAcceleraton; /*<! reference acceleration for trajectory generation in position mode. Currently NOT USED in trajectory generation! */
 
     std::vector<std::string> m_jointNames;
     gazebo::transport::NodePtr m_gazeboNode;

--- a/src/yarp_drivers/ControlBoardDriver.cpp
+++ b/src/yarp_drivers/ControlBoardDriver.cpp
@@ -85,9 +85,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
 
     std::cout << "gazebo_init set pid done!" << std::endl;
 
-    this->m_updateConnection
-        = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpControlBoardDriver::onUpdate,
-                                                                     this, _1));
+    this->m_updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(                                                                           boost::bind(&GazeboYarpControlBoardDriver::onUpdate, this, _1));
 
     m_gazeboNode = gazebo::transport::NodePtr(new gazebo::transport::Node);
     m_gazeboNode->Init(this->m_robot->GetWorld()->GetName());
@@ -164,15 +162,12 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _i
 
     for (unsigned int j = 0; j < m_numberOfJoints; ++j) {
         //set pos joint value, set m_referenceVelocities joint value
-        if ((m_controlMode[j] == VOCAB_CM_POSITION || m_controlMode[j] == VOCAB_CM_POSITION_DIRECT)
-            && (m_interactionMode[j] == VOCAB_IM_STIFF)) {
+        if (   (m_controlMode[j] == VOCAB_CM_POSITION) && (m_interactionMode[j] == VOCAB_IM_STIFF) ){
             if (m_clock % _T_controller == 0) {
-                if (m_controlMode[j] == VOCAB_CM_POSITION) {
-                    computeTrajectory(j);
-                }
+                computeTrajectory(j);
                 sendPositionToGazebo(j, m_referencePositions[j]);
             }
-        } else if ((m_controlMode[j] == VOCAB_CM_VELOCITY) && (m_interactionMode[j] == VOCAB_IM_STIFF)) {//set vmo joint value
+        } else if ( (m_controlMode[j] == VOCAB_CM_VELOCITY)  && (m_interactionMode[j] == VOCAB_IM_STIFF) ) {//set vmo joint value
             if (m_clock % _T_controller == 0) {
                 sendVelocityToGazebo(j, m_referenceVelocities[j]);
             }
@@ -186,12 +181,9 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _i
             if (m_clock % _T_controller == 0) {
                 sendTorqueToGazebo(j, m_referenceTorques[j]);
             }
-        } else if ((m_controlMode[j] == VOCAB_CM_POSITION || m_controlMode[j] == VOCAB_CM_POSITION_DIRECT)
-            && (m_interactionMode[j] == VOCAB_IM_COMPLIANT)) {
+        } else if ( ( m_controlMode[j] == VOCAB_CM_POSITION) && (m_interactionMode[j] == VOCAB_IM_COMPLIANT) ) {
             if (m_clock % _T_controller == 0) {
-                if (m_controlMode[j] == VOCAB_CM_POSITION) {
-                    computeTrajectory(j);
-                }
+                computeTrajectory(j);
                 sendImpPositionToGazebo(j, m_referencePositions[j]);
             }
         }

--- a/src/yarp_drivers/ControlBoardDriverControlMode.cpp
+++ b/src/yarp_drivers/ControlBoardDriverControlMode.cpp
@@ -10,8 +10,6 @@
 #include <gazebo/physics/Joint.hh>
 #include <gazebo/transport/Publisher.hh>
 
-#include <yarp/os/Vocab.h>
-
 
 using namespace yarp::dev;
 
@@ -24,19 +22,28 @@ void GazeboYarpControlBoardDriver::prepareResetJointMsg(int j)
     this->m_jointCommandPublisher->Publish(j_cmd);
 }
 
-bool GazeboYarpControlBoardDriver::setPositionMode(int j)
+bool GazeboYarpControlBoardDriver::setPositionMode(int j) //WORKS
 {
-    return this->setControlMode(j, VOCAB_CM_POSITION);
+    if (j < 0 || j >= (int)m_numberOfJoints) return false;
+    prepareResetJointMsg(j);
+    m_controlMode[j] = VOCAB_CM_POSITION;
+    std::cout<<"control mode = position "<<j<<std::endl;
+    return true;
 }
 
-bool GazeboYarpControlBoardDriver::setVelocityMode(int j)
+bool GazeboYarpControlBoardDriver::setVelocityMode(int j) //WORKS
 {
-    return this->setControlMode(j, VOCAB_CM_VELOCITY);
+    if (j < 0 || j >= (int)m_numberOfJoints) return false;
+    prepareResetJointMsg(j);
+    m_controlMode[j] = VOCAB_CM_VELOCITY;
+    std::cout<<"control mode = speed "<<j<<std::endl;
+    return true;
 }
 
-bool GazeboYarpControlBoardDriver::getControlMode(int j, int *mode)
+bool GazeboYarpControlBoardDriver::getControlMode(int j, int *mode) //WORKS
 {
-    if (!mode || j < 0 || j >= (int)m_numberOfJoints)
+    if (!mode
+        || j < 0 || j >= (int)m_numberOfJoints)
         return false;
     *mode = m_controlMode[j];
     return true;
@@ -51,17 +58,24 @@ bool GazeboYarpControlBoardDriver::getControlModes(int *modes) //NOT TESTED
     return true;
 }
 
-bool GazeboYarpControlBoardDriver::setTorqueMode(int j)
+bool GazeboYarpControlBoardDriver::setTorqueMode(int j) //NOT TESTED
 {
-    return this->setControlMode(j, VOCAB_CM_TORQUE);
+    if (j < 0 || j >= (int)m_numberOfJoints) return false;
+    prepareResetJointMsg(j);
+    m_controlMode[j]=VOCAB_CM_TORQUE;
+    std::cout<<"control mode = torque "<<j<<std::endl;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::setImpedancePositionMode(int j)//NOT TESTED
 {
-    bool ret = true;
-    ret = ret && this->setControlMode(j, VOCAB_CM_POSITION);
-    ret = ret && this->setInteractionMode(j, VOCAB_IM_COMPLIANT);
-    return ret;
+    if (j < 0 || j >= (int)m_numberOfJoints) return false;
+    prepareResetJointMsg(j);
+    m_controlMode[j] = VOCAB_CM_POSITION;
+    m_interactionMode[j] = VOCAB_IM_COMPLIANT;
+
+    std::cout<<"control mode = impedance position "<<j<<std::endl;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::setImpedanceVelocityMode(int) //NOT IMPLEMENTED
@@ -71,13 +85,17 @@ bool GazeboYarpControlBoardDriver::setImpedanceVelocityMode(int) //NOT IMPLEMENT
 
 bool GazeboYarpControlBoardDriver::setOpenLoopMode(int j) //NOT IMPLEMENTED
 {
-    return this->setControlMode(j, VOCAB_CM_OPENLOOP);
+    if (j < 0 || j >= (int)m_numberOfJoints) return false;
+    prepareResetJointMsg(j);
+    m_controlMode[j] = VOCAB_CM_OPENLOOP;
+    std::cout<<"control mode = openloop "<<j<<std::endl;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::getControlModes(const int n_joint, const int *joints, int *modes)
 {
     bool ret = true;
-    for (int i = 0; i < n_joint; i++)
+    for(int i=0; i<n_joint; i++)
         ret = ret && getControlMode(joints[i], &modes[i]);
     return ret;
 }
@@ -85,53 +103,16 @@ bool GazeboYarpControlBoardDriver::getControlModes(const int n_joint, const int 
 bool GazeboYarpControlBoardDriver::setControlMode(const int j, const int mode)
 {
     if (j < 0 || j >= (int)m_numberOfJoints) return false;
-
-    // Only accept supported control modes
-    // The only not supported control mode is
-    // (for now) VOCAB_CM_MIXED
-    if (!(mode == VOCAB_CM_POSITION
-          || mode == VOCAB_CM_POSITION_DIRECT
-          || mode == VOCAB_CM_VELOCITY
-          || mode == VOCAB_CM_TORQUE
-          || mode == VOCAB_CM_OPENLOOP
-          || mode == VOCAB_CM_IDLE)) {
-        std::cerr << "[WARN] request control mode "
-                  << yarp::os::Vocab::decode(mode) << " that is not supported by "
-                  << " gazebo_yarp_controlboard plugin." << std::endl;
-        return false;
-    }
-
-    // If the joint is already in the selected control mode
-    // don't perform switch specific actions
-    if (m_controlMode[j] == mode) return true;
-
     prepareResetJointMsg(j);
     m_controlMode[j] = mode;
-
-    // mode specific switching actions
-    switch (mode) {
-        case VOCAB_CM_POSITION :
-        case VOCAB_CM_POSITION_DIRECT :
-            m_referencePositions[j] = m_positions[j];
-            m_trajectoryGenerationReferencePosition[j] = m_positions[j];
-        break;
-        case VOCAB_CM_VELOCITY :
-            m_referenceVelocities[j] = 0.0;
-        break;
-        case VOCAB_CM_TORQUE :
-        case VOCAB_CM_OPENLOOP :
-            m_referenceTorques[j] = m_torques[j];
-        break;
-        default :
-        break;
-    }
+    std::cout<<"control mode = openloop "<<j<<std::endl;
     return true;
 }
 
 bool GazeboYarpControlBoardDriver::setControlModes(const int n_joint, const int *joints, int *modes)
 {
     bool ret = true;
-    for (int i = 0; i < n_joint; i++)
+    for(int i=0; i<n_joint; i++)
         ret = ret && setControlMode(joints[i], modes[i]);
     return ret;
 }
@@ -139,7 +120,9 @@ bool GazeboYarpControlBoardDriver::setControlModes(const int n_joint, const int 
 bool GazeboYarpControlBoardDriver::setControlModes(int *modes)
 {
     bool ret = true;
-    for (int i = 0; i < (int)m_numberOfJoints; i++)
+    for(int i=0; i<(int)m_numberOfJoints; i++)
         ret = ret && setControlMode(i, modes[i]);
     return ret;
 }
+
+

--- a/src/yarp_drivers/ControlBoardDriverOpenLoop.cpp
+++ b/src/yarp_drivers/ControlBoardDriverOpenLoop.cpp
@@ -48,7 +48,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getOutputs(double *v)
         {
             if (!v) return false;
-            for (unsigned int j = 0; j < m_numberOfJoints; ++j) {
+            for(unsigned int j = 0; j < m_numberOfJoints; ++j) {
                 v[j] = m_torques[j];
             }
             return true;
@@ -67,7 +67,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getRefOutputs(double *v)
         {
             if (!v) return false;
-            for (unsigned int j = 0; j < m_numberOfJoints; ++j) {
+            for(unsigned int j = 0; j < m_numberOfJoints; ++j) {
                 v[j] = m_referenceTorques[j];
             }
             return true;
@@ -76,11 +76,10 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::setOpenLoopMode()
         {
-            bool ret = true;
-            for (unsigned int j = 0; j < m_numberOfJoints; j++) {
-                ret = ret && this->setControlMode(j, VOCAB_CM_OPENLOOP);
+            for(unsigned int j = 0; j < m_numberOfJoints; j++) {
+                this->setOpenLoopMode(j);
             }
-            return ret;
+            return true;
         }
 
     }

--- a/src/yarp_drivers/ControlBoardDriverPositionControl.cpp
+++ b/src/yarp_drivers/ControlBoardDriverPositionControl.cpp
@@ -108,7 +108,8 @@ bool GazeboYarpControlBoardDriver::checkMotionDone(bool *flag) //NOT TESTED
     if (!flag) return false;
     bool temp_flag = true;
     //*flag=true;
-    for (unsigned int j = 0; j < m_numberOfJoints; ++j) {
+    for(unsigned int j = 0; j < m_numberOfJoints; ++j)
+    {
         temp_flag = temp_flag && m_isMotionDone[j];
     }
     *flag = temp_flag;
@@ -117,11 +118,11 @@ bool GazeboYarpControlBoardDriver::checkMotionDone(bool *flag) //NOT TESTED
 
 bool GazeboYarpControlBoardDriver::setPositionMode() //NOT TESTED
 {
-    bool ret = true;
-    for (unsigned int j = 0; j < m_numberOfJoints; j++) {
-        ret = ret && this->setControlMode(j, VOCAB_CM_POSITION);
+    for (unsigned int j=0; j<m_numberOfJoints; j++)
+    {
+        this->setPositionMode(j);
     }
-    return ret;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::setRefSpeeds(const double *spds) //NOT TESTED
@@ -173,7 +174,8 @@ bool GazeboYarpControlBoardDriver::getRefAccelerations(double *accs) //NOT IMPLE
 bool GazeboYarpControlBoardDriver::positionMove(const int n_joint, const int *joints, const double *refs) //NOT IMPLEMENTED
 {
     bool ret = true;
-    for (int i = 0; i < n_joint; i++) {
+    for(int i = 0; i < n_joint; i++)
+    {
         ret = ret && positionMove(joints[i], refs[i]);
     }
     return ret;
@@ -221,43 +223,29 @@ bool GazeboYarpControlBoardDriver::stop(const int n_joint, const int *joints) //
 
 
 // IPOSITION DIRECT
-bool GazeboYarpControlBoardDriver::setPositionDirectMode()
+bool GazeboYarpControlBoardDriver::setPositionDirectMode() //NOT IMPLEMENTED -> Is it the same as setPositionMode?
 {
-    bool ret = true;
-    for (int j = 0; j < (int)m_numberOfJoints; j++)  {
-        ret = ret && this->setControlMode(j, VOCAB_CM_POSITION_DIRECT);
-    }
-    return ret;
+    return false;
 }
 
 bool GazeboYarpControlBoardDriver::setPosition(int j, double ref)
 {
-    if (m_controlMode[j] == VOCAB_CM_POSITION_DIRECT) {
-        if (j >= 0 && j < (int)m_numberOfJoints) {
-            m_referencePositions[j] = ref;
-            return true;
-        }
-    } else {
-        std::cerr << "[WARN] gazebo_yarp_controlboard: you tried to call setPosition" << std::endl;
-        std::cerr << "[WARN] for a joint that is not in POSITION_DIRECT control mode." << std::endl;
+    if (j >= 0 && j < (int)m_numberOfJoints)
+    {
+        m_referencePositions[j] = ref;
+        return positionMove(j, ref);
     }
     return false;
 }
 
 bool GazeboYarpControlBoardDriver::setPositions(const int n_joint, const int *joints, double *refs)
 {
-    bool ret = true;
-    for (int i = 0; i < n_joint; i++) {
-        ret = ret && setPosition(joints[i], refs[i]);
-    }
-    return ret;
+    for (unsigned int i = 0; i < m_numberOfJoints; ++i)
+        m_referencePositions[i] = refs[i];
+    return positionMove(n_joint, joints, refs);
 }
 
 bool GazeboYarpControlBoardDriver::setPositions(const double *refs)
 {
-    bool ret = true;
-    for (int j = 0; j < this->m_numberOfJoints; j++ ) {
-        ret = ret && setPosition(j, refs[j]);
-    }
-    return ret;
+    return positionMove(refs);
 }

--- a/src/yarp_drivers/ControlBoardDriverVelocityControl.cpp
+++ b/src/yarp_drivers/ControlBoardDriverVelocityControl.cpp
@@ -13,11 +13,10 @@ using namespace yarp::dev;
 
 bool GazeboYarpControlBoardDriver::setVelocityMode() //NOT TESTED
 {
-    bool ret = true;
-    for (unsigned int j = 0; j < m_numberOfJoints; j++) {
-        ret = ret && this->setControlMode(j, VOCAB_CM_VELOCITY);
+    for(unsigned int j=0; j<m_numberOfJoints; j++) {
+        this->setVelocityMode(j);
     }
-    return ret;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::velocityMove(int j, double sp) //NOT TESTED
@@ -32,7 +31,7 @@ bool GazeboYarpControlBoardDriver::velocityMove(int j, double sp) //NOT TESTED
 bool GazeboYarpControlBoardDriver::velocityMove(const double *sp) //NOT TESTED
 {
     if (!sp) return false;
-    for (unsigned int i = 0; i < m_numberOfJoints; ++i) {
+    for (unsigned int i=0; i < m_numberOfJoints; ++i) {
         m_referenceVelocities[i] = sp[i];
     }
     return true;

--- a/src/yarp_drivers/ControlBoardTorqueDriverControl.cpp
+++ b/src/yarp_drivers/ControlBoardTorqueDriverControl.cpp
@@ -30,11 +30,10 @@ bool GazeboYarpControlBoardDriver::setRefTorques(const double* t)
 
 bool GazeboYarpControlBoardDriver::setTorqueMode()
 {
-    bool ret = true;
-    for (unsigned int j = 0; j < m_numberOfJoints; j++) {
-        ret = ret && this->setControlMode(j, VOCAB_CM_TORQUE);
+    for(unsigned int j = 0; j < m_numberOfJoints; j++) {
+        this->setTorqueMode(j);
     }
-    return ret;
+    return true;
 }
 
 bool GazeboYarpControlBoardDriver::getRefTorque(int j, double* t)
@@ -44,7 +43,7 @@ bool GazeboYarpControlBoardDriver::getRefTorque(int j, double* t)
         return true;
     }
     return false;
-}
+} 
 
 bool GazeboYarpControlBoardDriver::getRefTorques(double* t)
 {
@@ -53,7 +52,7 @@ bool GazeboYarpControlBoardDriver::getRefTorques(double* t)
         t[j] = m_referenceTorques[j];
     }
     return true;
-}
+} 
 
 bool GazeboYarpControlBoardDriver::getTorque(int j, double* t)
 {
@@ -62,12 +61,12 @@ bool GazeboYarpControlBoardDriver::getTorque(int j, double* t)
         return true;
     }
     return false;
-}
+} 
 
 bool GazeboYarpControlBoardDriver::getTorques(double* t)
 {
     if (!t) return false;
-    for (unsigned int j = 0; j < m_numberOfJoints; ++j) {
+    for(unsigned int j = 0; j < m_numberOfJoints; ++j) {
         t[j] = m_torques[j];
     }
     return true;
@@ -93,3 +92,4 @@ bool GazeboYarpControlBoardDriver::setTorqueOffset(int , double ){return false;}
 bool GazeboYarpControlBoardDriver::getBemfParam(int , double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::setBemfParam(int , double ){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::setTorquePid(int , const Pid &){return false;} //NOT IMPLEMENTED
+


### PR DESCRIPTION
Reverts robotology/gazebo-yarp-plugins#138
I did an error. Just tried the right version and I have WARNINGS and ERRORS and the robot does not move at all:

Error while trying to command a streaming position direct message on all joints
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
[WARN] gazebo_yarp_controlboard: you tried to call setPosition
[WARN] for a joint that is not in POSITION_DIRECT control mode.
