### PR TITLE
Fix setControlMode(VOCAB_CM_FORCE_IDLE)

### DIFF
--- a/src/yarp_drivers/ControlBoardDriverControlMode.cpp
+++ b/src/yarp_drivers/ControlBoardDriverControlMode.cpp
@@ -102,21 +102,24 @@ bool GazeboYarpControlBoardDriver::setControlMode(const int j, const int mode)
         return false;
     }
     
+    
+    int desired_mode = mode;
+    
     // Convert VOCAB_CM_FORCE_IDLE (that as a special meaning in real robots 
     //   subjects to hardware fault) to VOCAB_CM_IDLE
     // This is necessary for having a working "idle" button in the robotMotorGui
     if (mode == VOCAB_CM_FORCE_IDLE) {
-        mode = VOCAB_CM_IDLE;
+        desired_mode = VOCAB_CM_IDLE;
     }
     // If the joint is already in the selected control mode
     // don't perform switch specific actions
-    if (m_controlMode[j] == mode) return true;
+    if (m_controlMode[j] == desired_mode) return true;
 
     prepareResetJointMsg(j);
-    m_controlMode[j] = mode;
+    m_controlMode[j] = desired_mode;
 
     // mode specific switching actions
-    switch (mode) {
+    switch (desired_mode) {
         case VOCAB_CM_POSITION :
         case VOCAB_CM_POSITION_DIRECT :
             m_referencePositions[j] = m_positions[j];


### PR DESCRIPTION
Improve compliance with new control mode specifications (http://wiki.icub.org/wiki/File:ICub_Control_Modes_1_1.pdf) and also solve fix bug related to robotMotorGui "Idle" button, that is ignored at the moment. 
