### PR TITLE
Adding continuous integration based on the robot-testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - sleep 10
   # launch tests 
   - ../../robot-testing/build/bin/robot-testing --from ../../robot-testing/app/iCubTest/test-gazebo.ini
-  - pkill gazebo
+  - pkill gzserver
   - pkill yarpserver
   # test install/uninstall
   - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,38 @@ before_script:
   - make
   - sudo make install
   - cd ../..
+  # install robot-testing framework
+  - git clone https://github.com/robotology/robot-testing
+  - cd robot-testing
+  - mkdir build 
+  - cd build 
+  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
+  - make 
+  - cd ../..
+  # install icub-gazebo (for testing)
+  - git clone https://github.com/robotology-playground/icub-gazebo
+  - export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/home/travis/gazebo-yarp-plugins/icub-gazebo
+  # compile gazebo-yarp-plugins
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DALLOW_IDL_GENERATION:BOOL=OFF ./..
+  - pwd
+  
 
 
 script: 
   - make
+  # set GAZEBO_PLUGIN_PATH for running the tests
+  - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/home/travis/gazebo-yarp-plugins/build
+  # launch yarpserver, gazebo and wait
+  - yarpserver & 
+  - gzserver ../icub-gazebo/world/icub_fixed.world &
+  - sleep 10
+  # launch tests 
+  - ../robot-testing/build/bin/robot-testing --from ../robot-testing/app/iCubTest/test-gazebo.ini
+  - pkill gazebo
+  - pkill yarpserver
+  # test install/uninstall
   - sudo make install
   - sudo make uninstall
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ before_script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DALLOW_IDL_GENERATION:BOOL=OFF ./..
   - pwd
-  
-
 
 script: 
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - cmake -DCREATE_SHARED_LIBRARY:BOOL=ON -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make
   - sudo make install
+  - sudo ldconfig
   - cd ../..
   # install robot-testing framework
   - git clone https://github.com/robotology/robot-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
   - git clone https://github.com/robotology-playground/icub-gazebo
   - export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/home/travis/build/robotology/icub-gazebo
   # compile gazebo-yarp-plugins
-  - cd gazebo-yar-plugins
+  - cd gazebo-yarp-plugins
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DALLOW_IDL_GENERATION:BOOL=OFF ./..

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - gzserver ../../icub-gazebo/world/icub_fixed.world &
   - sleep 10
   # launch tests 
-  - ../robot-testing/build/bin/robot-testing --from ../robot-testing/app/iCubTest/test-gazebo.ini
+  - ../../robot-testing/build/bin/robot-testing --from ../../robot-testing/app/iCubTest/test-gazebo.ini
   - pkill gazebo
   - pkill yarpserver
   # test install/uninstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_script:
   - sudo apt-get --force-yes install libace-dev
   - if [ $USE_GAZEBO_THREE ]; then sudo apt-get install -qq libgazebo-dev libavcodec-dev libavformat-dev libswscale-dev; fi
   - if [ $USE_GAZEBO_ONEDOTNINE ]; then sudo apt-get install -qq gazebo libtinyxml-dev libboost-system-dev; fi
-  #check gazebo version
-  #- gazebo --version
+  # move to /home/travis/build/robotology/ directory
+  - cd ..
+  # install yarp
   - git clone https://github.com/robotology/yarp
   - cd yarp
   - mkdir build
@@ -41,8 +42,9 @@ before_script:
   - cd ../..
   # install icub-gazebo (for testing)
   - git clone https://github.com/robotology-playground/icub-gazebo
-  - export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/home/travis/gazebo-yarp-plugins/icub-gazebo
+  - export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/home/travis/build/robotology/icub-gazebo
   # compile gazebo-yarp-plugins
+  - cd gazebo-yar-plugins
   - mkdir build
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DALLOW_IDL_GENERATION:BOOL=OFF ./..
@@ -51,10 +53,10 @@ before_script:
 script: 
   - make
   # set GAZEBO_PLUGIN_PATH for running the tests
-  - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/home/travis/gazebo-yarp-plugins/build
+  - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/home/travis/build/robotology/gazebo-yarp-plugins/build
   # launch yarpserver, gazebo and wait
   - yarpserver & 
-  - gzserver ../icub-gazebo/world/icub_fixed.world &
+  - gzserver ../../icub-gazebo/world/icub_fixed.world &
   - sleep 10
   # launch tests 
   - ../robot-testing/build/bin/robot-testing --from ../robot-testing/app/iCubTest/test-gazebo.ini


### PR DESCRIPTION
Adding testing on gazebo-yarp-plugins functionalities using the robot-testing framework ( https://github.com/robotology/robot-testing ). Currently only the force torque sensors are tested, but new unit tests can be easily added. 