### PR TITLE
Show model CoM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,6 @@ install(TARGETS gazebo_yarp_singleton
                 gazebo_yarp_externalwrench
                 gazebo_yarp_showmodelcom
                 gazebo_yarp_camera
-                gazebo_yarp_showmodelcom
                 DESTINATION lib)
 
 # Add uninstall target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,12 @@ set(externalwrench_headers  include/gazebo_yarp_plugins/ApplyExternalWrench.hh)
 SOURCE_GROUP("Source Files" FILES ${externalwrench_source})
 SOURCE_GROUP("Header Files" FILES ${externalwrench_headers})
 
+set(showmodelcom_source   src/gazebo_plugins/ShowModelCoM.cc)
+set(showmodelcom_headers  include/gazebo_yarp_plugins/ShowModelCoM.hh)
+
+SOURCE_GROUP("Source Files" FILES ${showmodelcom_source})
+SOURCE_GROUP("Header Files" FILES ${showmodelcom_headers})
+
 
 set(camera_headers          include/gazebo_yarp_plugins/Camera.hh
                             include/gazebo_yarp_plugins/CameraDriver.h)
@@ -129,6 +135,7 @@ add_library(gazebo_yarp_jointsensors SHARED ${jointSensors_source} ${jointSensor
 add_library(gazebo_yarp_clock        SHARED ${clock_source}        ${clock_headers})
 add_library(gazebo_yarp_camera       SHARED ${camera_source}       ${camera_headers})
 add_library(gazebo_yarp_externalwrench SHARED ${externalwrench_source}	${externalwrench_headers})
+add_library(gazebo_yarp_showmodelcom SHARED ${showmodelcom_source}	${showmodelcom_headers})
 
 
 target_link_libraries(gazebo_yarp_singleton ${YARP_LIBRARIES} ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES})
@@ -138,6 +145,7 @@ target_link_libraries(gazebo_yarp_imu           gazebo_yarp_singleton ${YARP_LIB
 target_link_libraries(gazebo_yarp_jointsensors  gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(gazebo_yarp_clock         gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(gazebo_yarp_externalwrench gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(gazebo_yarp_showmodelcom gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
 target_link_libraries(gazebo_yarp_camera        gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} CameraPlugin)
 
 
@@ -148,8 +156,10 @@ install(TARGETS gazebo_yarp_singleton
                 gazebo_yarp_imu
                 gazebo_yarp_jointsensors
                 gazebo_yarp_clock
-				gazebo_yarp_externalwrench
+                gazebo_yarp_externalwrench
+                gazebo_yarp_showmodelcom
                 gazebo_yarp_camera
+                gazebo_yarp_showmodelcom
                 DESTINATION lib)
 
 # Add uninstall target

--- a/include/gazebo_yarp_plugins/ShowModelCoM.hh
+++ b/include/gazebo_yarp_plugins/ShowModelCoM.hh
@@ -39,6 +39,8 @@ protected:
 
 
 private:
+    yarp::os::Network       m_yarpNet;
+
     physics::ModelPtr       m_myModel;
 
     std::string             m_modelScope;
@@ -46,6 +48,8 @@ private:
 
     transport::PublisherPtr m_visPub;
     msgs::Visual            m_visualMsg;
+
+    yarp::os::Port          m_com_port;
 
 };
 

--- a/include/gazebo_yarp_plugins/ShowModelCoM.hh
+++ b/include/gazebo_yarp_plugins/ShowModelCoM.hh
@@ -1,0 +1,56 @@
+#ifndef SHOWMODELCOM_HH
+#define SHOWMODELCOM_HH
+
+#include <iostream>
+#include <string>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/transport.hh>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/RpcServer.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/os/Thread.h>
+#include <yarp/os/Time.h>
+#include <yarp/os/Vocab.h>
+
+namespace gazebo
+{
+class ShowModelCoM : public ModelPlugin
+{
+private:
+  transport::NodePtr m_node;
+
+public:
+    ShowModelCoM();
+    virtual ~ShowModelCoM();
+    std::string retrieveSubscope(gazebo::physics::Link_V& v, std::string  scope);
+
+    /// \brief Robot name that will be used to open rpc port
+    std::string          robotName;
+    double               timeIni;
+
+protected:
+    // Inherited
+    void Load ( physics::ModelPtr _model, sdf::ElementPtr _sdf );
+    // Inherited
+    virtual void UpdateChild();
+
+
+private:
+    physics::ModelPtr       m_myModel;
+
+    std::string             m_modelScope;
+    event::ConnectionPtr    m_updateConnection;
+
+    transport::PublisherPtr m_visPub;
+    msgs::Visual            m_visualMsg;
+
+};
+
+}
+
+
+
+#endif

--- a/src/gazebo_plugins/ShowModelCoM.cc
+++ b/src/gazebo_plugins/ShowModelCoM.cc
@@ -1,0 +1,68 @@
+#include "gazebo_yarp_plugins/ShowModelCoM.hh"
+
+namespace gazebo
+{
+
+GZ_REGISTER_MODEL_PLUGIN ( ShowModelCoM )
+
+ShowModelCoM::ShowModelCoM()
+{
+
+}
+
+ShowModelCoM::~ShowModelCoM()
+{
+    printf ( "*** GazeboYarpShowModelCoM closing ***\n" );
+    gazebo::event::Events::DisconnectWorldUpdateBegin ( this->m_updateConnection );
+    printf ( "Goodbye from ShowModelCoM plugin\n" );
+}
+
+void ShowModelCoM::UpdateChild()
+{
+    gazebo::physics::Link_V links = m_myModel->GetLinks();
+
+    double mass_acc = 0.0;
+    gazebo::math::Vector3 weighted_position_acc = gazebo::math::Pose::Zero.pos;
+    for(unsigned int i = 0; i < links.size(); ++i)
+    {
+        gazebo::physics::LinkPtr link = links[i];
+        gazebo::math::Vector3 wordlCoG_i = link->GetWorldCoGPose().pos;
+        double mass_i = link->GetInertial()->GetMass();
+
+        weighted_position_acc += mass_i*wordlCoG_i;
+        mass_acc += mass_i;
+    }
+
+
+    gazebo::math::Vector3 wordlCoGModel = weighted_position_acc/mass_acc;
+
+
+}
+
+void ShowModelCoM::Load ( physics::ModelPtr _model, sdf::ElementPtr _sdf )
+{
+    // What is the parent name??
+    this->m_modelScope = _model->GetScopedName();
+    printf ( "Scoped name: %s\n",this->m_modelScope.c_str() );
+
+    // Copy the pointer to the model to access later from UpdateChild
+    this->m_myModel = _model;
+
+    bool configuration_loaded = false;
+
+    // Read robot name
+    std::cout << "ShowModelCoM: robot name from sdf description will be used!"<<std::endl;
+    this->robotName = _model->GetName();
+    printf ( "ShowModelCoM: robotName is %s \n",robotName.c_str() );
+    configuration_loaded = true;
+
+    // Listen to the update event. This event is broadcast every
+    // simulation iteration.
+    this->m_updateConnection = event::Events::ConnectWorldUpdateBegin ( boost::bind ( &ShowModelCoM::UpdateChild, this ) );
+}
+
+}
+
+
+
+


### PR DESCRIPTION
The plugin permits to show & broadcast in YARP the position of the CoM of the robot wrt the (gazebo)world. The positon is broadcasted in yarp through a simple port. 
What is missing is: the "default" way to take the robot name from the config file (now the sdf name is used) and eventually a marker of the pose of the world in gazebo.