### PR TITLE
Ros topic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install cmake
   - sudo apt-get --force-yes install libace-dev
-  - if [ $USE_GAZEBO_THREE ]; then sudo apt-get install -qq libgazebo-dev libavcodec-dev libavformat-dev libswscale-dev; fi
-  - if [ $USE_GAZEBO_ONEDOTNINE ]; then sudo apt-get install -qq gazebo libtinyxml-dev libboost-system-dev; fi
+  - if [ $USE_GAZEBO_THREE ]; then sudo apt-get install -qq --force-yes libgazebo-dev libavcodec-dev libavformat-dev libswscale-dev; fi
+  - if [ $USE_GAZEBO_ONEDOTNINE ]; then sudo apt-get install -qq --force-yes gazebo libtinyxml-dev libboost-system-dev; fi
   # move to /home/travis/build/robotology/ directory
   - cd ..
   # install yarp

--- a/include/gazebo_yarp_plugins/ControlBoard.hh
+++ b/include/gazebo_yarp_plugins/ControlBoard.hh
@@ -50,11 +50,11 @@ private:
 
     yarp::dev::PolyDriver m_wrapper;
     yarp::dev::IMultipleWrapper* m_iWrap;
-    yarp::dev::PolyDriver * m_controlBoard;
+    yarp::dev::PolyDriverList m_controlBoards;
+
     yarp::os::Property m_parameters;
 
     std::string m_robotName;
-    std::string m_driverName;
 };
 
 }

--- a/include/gazebo_yarp_plugins/ControlBoard.hh
+++ b/include/gazebo_yarp_plugins/ControlBoard.hh
@@ -50,7 +50,7 @@ private:
 
     yarp::dev::PolyDriver m_wrapper;
     yarp::dev::IMultipleWrapper* m_iWrap;
-    yarp::dev::PolyDriver m_controlBoard;
+    yarp::dev::PolyDriver * m_controlBoard;
     yarp::os::Property m_parameters;
 
     std::string m_robotName;

--- a/include/gazebo_yarp_plugins/ControlBoard.hh
+++ b/include/gazebo_yarp_plugins/ControlBoard.hh
@@ -54,6 +54,7 @@ private:
     yarp::os::Property m_parameters;
 
     std::string m_robotName;
+    std::string m_driverName;
 };
 
 }

--- a/include/gazebo_yarp_plugins/ControlBoardDriver.h
+++ b/include/gazebo_yarp_plugins/ControlBoardDriver.h
@@ -311,6 +311,7 @@ private:
         double max;
     };
 
+    std::string deviceName;
     gazebo::physics::Model* m_robot;
     gazebo::event::ConnectionPtr m_updateConnection;
 

--- a/include/gazebo_yarp_plugins/Handler.hh
+++ b/include/gazebo_yarp_plugins/Handler.hh
@@ -90,18 +90,18 @@ public:
      *  If the device already exists and the pointer are the same return success, if pointers doesn't match returns error.
      * \param deviceName the name of the device to be added to the internal database
      * \param device the pointer of the device to be added to the internal database
-     * \return true if successfully added, or the model already exists. False otherwise.
+     * \return true if successfully added, or the device already exists. False otherwise.
      */
     bool setDevice(std::string deviceName, yarp::dev::PolyDriver* device2add);
 
-    /** Returns the  pointer to the sensor matching the sensor name
-     * \param deviceName sensor name to be looked for
+    /** Returns the pointer to the device matching the sensor name
+     * \param deviceName device name to be looked for
      * \return the pointer to the device
      */
     yarp::dev::PolyDriver* getDevice(const std::string& deviceName) const;
 
-    /** \brief Removes a sensor from the internal database
-     *  \param deviceName the name of the sensor to be removed
+    /** \brief Removes a device from the internal database
+     *  \param deviceName the name of the device to be removed
      */
     void removeDevice(const std::string& deviceName);
 

--- a/include/gazebo_yarp_plugins/Handler.hh
+++ b/include/gazebo_yarp_plugins/Handler.hh
@@ -26,6 +26,12 @@ namespace sdf {
     typedef boost::shared_ptr<Element> ElementPtr;
 }
 
+namespace yarp {
+    namespace dev {
+        class PolyDriver;
+    }
+}
+
 namespace GazeboYarpPlugins {
 
 /** \class Handler
@@ -54,12 +60,12 @@ public:
      * \return the model matching the passed name
      */
     gazebo::physics::Model* getRobot(const std::string& robotName) const;
-    
+
     /** \brief Removes a robot from the internal database
      *  \param robotName the name of the robot to be removed
      */
     void removeRobot(const std::string& robotName);
-    
+
     /** \brief Adds a new sensorPointer to the "database".
      *
      *  If the sensor already exists and the pointer are the same return success, if pointers doesn't match returns error.
@@ -67,24 +73,44 @@ public:
      * \return true if successfully added, or the model already exists. False otherwise.
      */
     bool setSensor(gazebo::sensors::Sensor* _sensor);
-    
+
     /** Returns the  pointer to the sensor matching the sensor name
      * \param sensorScopedName sensor name to be looked for
      * \return the sensor matching the passed name
      */
     gazebo::sensors::Sensor* getSensor(const std::string& sensorScopedName) const;
-    
+
     /** \brief Removes a sensor from the internal database
      *  \param sensorName the name of the sensor to be removed
      */
     void removeSensor(const std::string& sensorName);
+
+    /** \brief Adds a new yarp device pointer to the "database".
+     *
+     *  If the device already exists and the pointer are the same return success, if pointers doesn't match returns error.
+     * \param deviceName the name of the device to be added to the internal database
+     * \param device the pointer of the device to be added to the internal database
+     * \return true if successfully added, or the model already exists. False otherwise.
+     */
+    bool setDevice(std::string deviceName, yarp::dev::PolyDriver* device2add);
+
+    /** Returns the  pointer to the sensor matching the sensor name
+     * \param deviceName sensor name to be looked for
+     * \return the pointer to the device
+     */
+    yarp::dev::PolyDriver* getDevice(const std::string& deviceName) const;
+
+    /** \brief Removes a sensor from the internal database
+     *  \param deviceName the name of the sensor to be removed
+     */
+    void removeDevice(const std::string& deviceName);
 
     /** Destructor
      */
     ~Handler();
 
 private:
-    
+
     template <class T>
     class ReferenceCountingObject
     {
@@ -92,30 +118,34 @@ private:
         unsigned short m_count;
     public:
         ReferenceCountingObject(T object): m_object(object), m_count(1) {}
-        
+
         T object() const { return m_object; }
         unsigned short count() const { return m_count; }
         void incrementCount() { m_count++; }
         void decrementCount() { m_count--; }
     };
-    
+
     typedef ReferenceCountingObject<gazebo::physics::Model*> ReferenceCountingModel;
     typedef ReferenceCountingObject<gazebo::sensors::Sensor*> ReferenceCountingSensor;
-    
+    typedef ReferenceCountingObject<yarp::dev::PolyDriver*> ReferenceCountingDevice;
+
     typedef std::map<std::string, ReferenceCountingModel> RobotsMap;
     typedef std::map<std::string, ReferenceCountingSensor> SensorsMap;
-    
+    // store list of yarp decices
+    typedef std::map<std::string, ReferenceCountingDevice> DevicesMap;
+
     // singleton stuff
     static Handler* s_handle;
     static yarp::os::Semaphore& mutex();
-    
+
 
     Handler();
     RobotsMap m_robotMap;      // map of known robots
     SensorsMap m_sensorsMap;    // map of known sensors
+    DevicesMap m_devicesMap;    // map of known yarp devices
 
     bool findRobotName(sdf::ElementPtr sdf, std::string* robotName);
-    
+
 };
 
 }

--- a/src/gazebo_plugins/ControlBoard.cc
+++ b/src/gazebo_plugins/ControlBoard.cc
@@ -128,7 +128,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             }
             else
             {
-                std::cout << "Opening new device " << deviceName << std::endl;
+                std::cout << "Opening new device " << newPoly.key.c_str() << std::endl;
                 driver_group = m_parameters.findGroup(newPoly.key.c_str());
                 if (driver_group.isNull()) {
                     fprintf(stderr, "GazeboYarpControlBoard::Load  Error: [%s] group not found in config file. Closing wrapper \n", newPoly.key.c_str());

--- a/src/gazebo_plugins/ControlBoard.cc
+++ b/src/gazebo_plugins/ControlBoard.cc
@@ -78,6 +78,13 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     printf("GazeboYarpControlBoard::Load  Error: [WRAPPER] group not found in config file\n");
                     return;
                 }
+                std::cout << "\n\nm_parameters.findGroup(ROS): \n\t" << m_parameters.findGroup("ROS").toString() << std::endl;
+                if(m_parameters.check("ROS"))
+                {
+                    yarp::os::ConstString ROS;
+                    ROS = yarp::os::ConstString ("(") + m_parameters.findGroup("ROS").toString() + yarp::os::ConstString (")");
+                    wrapper_group.append(yarp::os::Bottle(ROS));
+                }
                 configuration_loaded = true;
             }
         }

--- a/src/gazebo_plugins/ControlBoard.cc
+++ b/src/gazebo_plugins/ControlBoard.cc
@@ -84,7 +84,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     printf("GazeboYarpControlBoard::Load  Error: [WRAPPER] group not found in config file\n");
                     return;
                 }
-                std::cout << "\n\nm_parameters.findGroup(ROS): \n\t" << m_parameters.findGroup("ROS").toString() << std::endl;
                 if(m_parameters.check("ROS"))
                 {
                     yarp::os::ConstString ROS;

--- a/src/gazebo_plugins/Handler.cc
+++ b/src/gazebo_plugins/Handler.cc
@@ -47,7 +47,7 @@ bool Handler::setRobot(gazebo::physics::Model* _model)
     bool ret = false;
     std::string scopedRobotName = _model->GetScopedName();
     std::cout << "GazeboYarpPlugins::Handler: Inserting Robot : " << scopedRobotName << std::endl;
-    
+
     RobotsMap::iterator robot = m_robotMap.find(scopedRobotName);
     if (robot != m_robotMap.end()) {
         //robot already exists. Increment reference counting
@@ -75,7 +75,7 @@ gazebo::physics::Model* Handler::getRobot(const std::string& robotName) const
 {
     gazebo::physics::Model* tmp = NULL;
     std::cout << "Looking for robot : " << robotName << std::endl;
-    
+
     RobotsMap::const_iterator robot = m_robotMap.find(robotName);
     if (robot != m_robotMap.end()) {
         std::cout << "Robot " << robotName << " was happily found!" << std::endl;
@@ -107,7 +107,7 @@ bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
     bool ret = false;
     std::string scopedSensorName = _sensor->GetScopedName();
     std::cout << "GazeboYarpPlugins::Handler: Inserting Sensor : " << scopedSensorName << std::endl;
-    
+
     SensorsMap::iterator sensor = m_sensorsMap.find(scopedSensorName);
     if (sensor != m_sensorsMap.end()) {
         //sensor already exists. Increment reference counting
@@ -129,13 +129,13 @@ bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
     }
     return ret;
 }
-    
+
 // return the sensor pointer given the sensor scoped namespac
 gazebo::sensors::Sensor* Handler::getSensor(const std::string& sensorScopedName) const
 {
     gazebo::sensors::Sensor* tmp = NULL;
     std::cout << "Looking for sensor : " << sensorScopedName << std::endl;
-    
+
     SensorsMap::const_iterator sensor = m_sensorsMap.find(sensorScopedName);
     if (sensor != m_sensorsMap.end()) {
         std::cout << "Sensor " << sensorScopedName << " was happily found!" << std::endl;
@@ -170,7 +170,7 @@ bool Handler::setDevice(std::string deviceName, yarp::dev::PolyDriver* device2ad
         if(device->second.object() == device2add)
         {
             device->second.incrementCount();
-            std::cout << "Device already registered, pointers match." << std::endl;
+            std::cout << "Device already registered, incrementing usage counter." << std::endl;
             ret = true;
         }
         else
@@ -218,8 +218,12 @@ void Handler::removeDevice(const std::string& deviceName)
             std::cout << "Removing device " << deviceName << std::endl;
             m_devicesMap.erase(device);
         }
+        else
+        {
+            std::cout << "Not removing device yet 'cause it is still used bu other guys" << deviceName << std::endl;
+        }
     } else {
-        std::cout << "Could not remove sensor " << deviceName << ". Sensor was not found" << std::endl;
+        std::cout << "Could not remove device " << deviceName << ". Device was not found" << std::endl;
     }
     return;
 }

--- a/src/gazebo_plugins/Handler.cc
+++ b/src/gazebo_plugins/Handler.cc
@@ -6,6 +6,7 @@
 
 #include "Handler.hh"
 
+#include <yarp/dev/PolyDriver.h>
 #include <gazebo/physics/Entity.hh>
 #include <gazebo/sensors/sensors.hh>
 
@@ -216,6 +217,7 @@ void Handler::removeDevice(const std::string& deviceName)
         device->second.decrementCount();
         if (!device->second.count()) {
             std::cout << "Removing device " << deviceName << std::endl;
+            device->second.object()->close();
             m_devicesMap.erase(device);
         }
         else

--- a/src/gazebo_plugins/Handler.cc
+++ b/src/gazebo_plugins/Handler.cc
@@ -171,7 +171,7 @@ bool Handler::setDevice(std::string deviceName, yarp::dev::PolyDriver* device2ad
         if(device->second.object() == device2add)
         {
             device->second.incrementCount();
-            std::cout << "Device already registered, incrementing usage counter." << std::endl;
+            std::cout << "Device '" << deviceName << "' already registered, incrementing usage counter to " << device->second.count() << std::endl;
             ret = true;
         }
         else
@@ -204,7 +204,6 @@ yarp::dev::PolyDriver* Handler::getDevice(const std::string& deviceName) const
         std::cout << "Device " << deviceName << " was happily found!" << std::endl;
         tmp = device->second.object();
     } else {
-        std::cout << "Device was not found: " << deviceName << std::endl;
         tmp = NULL;
     }
     return tmp;
@@ -222,7 +221,7 @@ void Handler::removeDevice(const std::string& deviceName)
         }
         else
         {
-            std::cout << "Not removing device yet 'cause it is still used bu other guys" << deviceName << std::endl;
+            std::cout << "Not removing device '" << deviceName << "' yet because it is still used by other devices, Decremented counter to " << device->second.count() << std::endl;
         }
     } else {
         std::cout << "Could not remove device " << deviceName << ". Device was not found" << std::endl;

--- a/src/yarp_drivers/ControlBoardDriver.cpp
+++ b/src/yarp_drivers/ControlBoardDriver.cpp
@@ -22,7 +22,7 @@ using namespace yarp::dev;
 
 const double RobotPositionTolerance = 0.9;
 
-GazeboYarpControlBoardDriver::GazeboYarpControlBoardDriver() {}
+GazeboYarpControlBoardDriver::GazeboYarpControlBoardDriver() : deviceName("") {}
 GazeboYarpControlBoardDriver::~GazeboYarpControlBoardDriver() {}
 
 bool GazeboYarpControlBoardDriver::gazebo_init()

--- a/src/yarp_drivers/ControlBoardDriverDeviceDriver.cpp
+++ b/src/yarp_drivers/ControlBoardDriverDeviceDriver.cpp
@@ -14,9 +14,12 @@ using namespace yarp::dev;
 using namespace gazebo;
 
 
-bool GazeboYarpControlBoardDriver::open(yarp::os::Searchable& config) 
+bool GazeboYarpControlBoardDriver::open(yarp::os::Searchable& config)
 {
     m_pluginParameters.fromString(config.toString().c_str());
+
+    deviceName = m_pluginParameters.find("name").asString().c_str();
+    std::cout << "Opening  GazeboYarpControlBoardDriver named " << deviceName << std::endl;
 
     std::string robotName(m_pluginParameters.find("robotScopedName").asString().c_str());
     std::cout << "DeviceDriver is looking for robot " << robotName << "..." << std::endl;
@@ -26,18 +29,19 @@ bool GazeboYarpControlBoardDriver::open(yarp::os::Searchable& config)
         std::cout << "GazeboYarpControlBoardDriver error: robot was not found" << std::endl;
         return false;
     }
-    
+
     return gazebo_init();
 }
 
 bool GazeboYarpControlBoardDriver::close()
 {
+    std::cout << "Closing device " << deviceName  << std::endl;
     //unbinding events
     if (this->m_updateConnection.get()) {
         gazebo::event::Events::DisconnectWorldUpdateBegin (this->m_updateConnection);
         this->m_updateConnection = gazebo::event::ConnectionPtr();
     }
-    
+
     delete [] m_controlMode;
     delete [] m_interactionMode;
     delete [] m_isMotionDone;


### PR DESCRIPTION
This pull request add 2 new features:
1- A wrapper can be instantiated on his own and attach to an already existing controlBoard, just by setting the wrapper configuration like:

joints 10
networks (left_arm left_hand)
left_arm      0 6  0 6
left_hand    0 2  0 2

The wrapper will search the singleton for two devices called left_arm and left_hand and, if found, attach to them.
If the devices are not found, it simply fails the open and it closes down. No magic here yet, this could be improved somehow in the future if needed. To use this, verify the wrapper-only is the last device in the sdf file.

2- If a [ROS] group parameter is found in the config file, it is propagated to the wrapper configuration. This is useful to enable controlBoardWrapper2 to dinamically create a ROS compatible topic. This feature is under testing on a yarp branch (checkout to yarp 'mergePortname_and_ROS' branch if you want to test it before it is released)