### PR TITLE
Enable plugin testing on travis file 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - cd icub-tests
   - mkdir build
   - cd build
-  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE}
+  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make 
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology/icub-tests/build/plugins
   - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suit

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ script:
   # test install/uninstall
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
-  - yarpserver
+  - yarpserver &
   # run tests
   - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
   - sudo make uninstall

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,9 @@ script:
   # test install/uninstall
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
+  - gzserver --verbose world/icub_fixed.world
   # run tests
-  - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
+  #- testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
   - sudo make uninstall
   - pkill yarpserver
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - if [ $RUN_TESTS ]; gzserver world/icub_fixed.world & ; fi
+  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & ; fi
   - sleep 10
   - yarp name list 
-  - if [ $RUN_TESTS ]; pkill gzserver; fi
+  - if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,29 @@ before_script:
   - cd robot-testing
   - mkdir build 
   - cd build 
-  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
+  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DENABLE_MIDDLEWARE_PLUGINS:BOOL=ON ..
   - make 
+  - sudo make install
   - cd ../..
+  
+  # install icub-tests 
+  - git clone https://github.com/robotology/icub-tests
+  - cd icub-tests
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE}
+  - make 
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology/icub-tests/build/plugins
+  - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suit
+  - cd ../..
+  
   # install icub-gazebo (for testing)
   - git clone https://github.com/robotology-playground/icub-gazebo
   - export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:/home/travis/build/robotology/icub-gazebo
+  # export icub-gazebo in GAZEBO_RESOURCE_PATH (see https://bitbucket.org/osrf/gazebo/issue/1607/gazebo-does-not-start-if-the#comment-18101826 )
+  - source /usr/share/gazebo/setup.sh
+  - export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH}:/home/travis/build/robotology/icub-gazebo
+  
   # compile gazebo-yarp-plugins
   - cd gazebo-yarp-plugins
   - mkdir build
@@ -53,11 +70,14 @@ before_script:
 
 script: 
   - make
-  # set GAZEBO_PLUGIN_PATH for running the tests
-  - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/home/travis/build/robotology/gazebo-yarp-plugins/build
   # test install/uninstall
   - sudo make install
+  - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
+  - yarpserver
+  # run tests
+  - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
   - sudo make uninstall
+  - pkill yarperver
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,9 +82,8 @@ script:
   # test install/uninstall
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
-  - gzserver --verbose world/icub_fixed.world
   # run tests
-  #- testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
+  - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
   - sudo make uninstall
   - pkill yarpserver
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  #- if [ $RUN_TESTS ]; then gzserver & fi
-  #- sleep 10
+  - if [ $RUN_TESTS ]; then gzserver & fi
+  - sleep 10
   # - yarp name list 
-  #- if [ $RUN_TESTS ]; then pkill gzserver; fi
+  - if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - cd yarp
   - mkdir build
   - cd build
-  - cmake -DCREATE_SHARED_LIBRARY:BOOL=ON -DYARP_USE_OPENCV:BOOL=OFF -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
+  - cmake -DCREATE_SHARED_LIBRARY:BOOL=ON -DCREATE_LIB_MATH:BOOL=ON -DYARP_USE_OPENCV:BOOL=OFF -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make
   - sudo make install
   - sudo ldconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_script:
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DENABLE_MIDDLEWARE_PLUGINS:BOOL=ON ..
   - make 
   - sudo make install
+  - sudo ldconfig
   - cd ../..
   
   # install icub-tests 
@@ -52,6 +53,7 @@ before_script:
   - make 
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology/icub-tests/build/plugins
   - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suit
+  - sudo ldconfig
   - cd ../..
   
   # install icub-gazebo (for testing)

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,8 @@ before_script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make 
-  - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suit
+  - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suits
+  - export LD_LIBRARY_PATH:${LD_LIBRARY_PATH}/home/travis/build/robotology/icub-tests/build/plugins
   - sudo ldconfig
   - cd ../..
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & ; fi
+  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
   - sleep 10
   - yarp name list 
   - if [ $RUN_TESTS ]; then pkill gzserver; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - if [ $RUN_TESTS ]; then gzserver & fi
-  - sleep 10
+  #- if [ $RUN_TESTS ]; then gzserver & fi
+  #- sleep 10
   # - yarp name list 
-  - if [ $RUN_TESTS ]; then pkill gzserver; fi
+  #- if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  # - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
+  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
   - sleep 10
   # - yarp name list 
-  # - if [ $RUN_TESTS ]; then pkill gzserver; fi
+  - if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - sudo add-apt-repository -y ppa:robotology/ppa
   - sudo apt-get update
   - sudo apt-get install cmake
-  - sudo apt-get --force-yes install libace-dev
+  - sudo apt-get --force-yes install libace-dev libgsl0-dev
   - if [ $USE_GAZEBO_THREE ]; then sudo apt-get install -qq --force-yes libgazebo-dev libavcodec-dev libavformat-dev libswscale-dev; fi
   - if [ $USE_GAZEBO_ONEDOTNINE ]; then sudo apt-get install -qq --force-yes gazebo libtinyxml-dev libboost-system-dev; fi
   # move to /home/travis/build/robotology/ directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Debug USE_GAZEBO_ONEDOTNINE=TRUE
+      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Debug USE_GAZEBO_ONEDOTNINE=TRUE 
     - compiler: gcc
-      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Release USE_GAZEBO_THREE=TRUE
+      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Release USE_GAZEBO_THREE=TRUE RUN_TESTS=TRUE
     - compiler: clang
-      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Debug USE_GAZEBO_THREE=TRUE
+      env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Debug USE_GAZEBO_THREE=TRUE RUN_TESTS=TRUE
     - compiler: clang
       env: GAZEBO_YARP_PLUGINS_BUILD_TYPE=Release USE_GAZEBO_ONEDOTNINE=TRUE
 
@@ -83,7 +83,11 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
+  - if [ $RUN_TESTS ]; gzserver world/icub_fixed.world & ; fi
+  - sleep 10
+  - yarp name list 
+  - if [ $RUN_TESTS ]; pkill gzserver; fi
+  - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ before_script:
   - sudo make install
   - sudo ldconfig
   - cd ../..
+  
+  # launch yarp while you install everything else
+  - yarpserver &
+  
   # install robot-testing framework
   - git clone https://github.com/robotology/robot-testing
   - cd robot-testing
@@ -41,6 +45,9 @@ before_script:
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} -DENABLE_MIDDLEWARE_PLUGINS:BOOL=ON ..
   - make 
   - sudo make install
+  # by default /usr/local/lib is not in the search path of dlopen
+  # so we add it to LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
   - sudo ldconfig
   - cd ../..
   
@@ -51,7 +58,6 @@ before_script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make 
-  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/travis/build/robotology/icub-tests/build/plugins
   - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suit
   - sudo ldconfig
   - cd ../..
@@ -75,11 +81,10 @@ script:
   # test install/uninstall
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
-  - yarpserver &
   # run tests
   - testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml 
   - sudo make uninstall
-  - pkill yarperver
+  - pkill yarpserver
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
-  - sleep 10
-  - yarp name list 
-  - if [ $RUN_TESTS ]; then pkill gzserver; fi
+  # - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
+  # - sleep 10
+  # - yarp name list 
+  # - if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi
   - sudo make uninstall
   - pkill yarpserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
   - sudo make install
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
-  - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
+  - if [ $RUN_TESTS ]; then gzserver & fi
   - sleep 10
   # - yarp name list 
   - if [ $RUN_TESTS ]; then pkill gzserver; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ script:
   - export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH}:/usr/local/lib 
   # run tests
   # - if [ $RUN_TESTS ]; then gzserver world/icub_fixed.world & fi
-  # - sleep 10
+  - sleep 10
   # - yarp name list 
   # - if [ $RUN_TESTS ]; then pkill gzserver; fi
   - if [ $RUN_TESTS ]; then testrunner --verbose --suit ../../icub-tests/suits/basics-icubGazeboSim.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ before_script:
   - cd build
   - cmake -DCMAKE_BUILD_TYPE=${GAZEBO_YARP_PLUGINS_BUILD_TYPE} ..
   - make 
-  - export YARP_DATA_DIRS=$YARP_DATA_DIRS:/home/travis/build/robotology/icub-tests/suits
-  - export LD_LIBRARY_PATH:${LD_LIBRARY_PATH}/home/travis/build/robotology/icub-tests/build/plugins
+  - export YARP_DATA_DIRS=${YARP_DATA_DIRS}:/home/travis/build/robotology/icub-tests/suits
+  - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/home/travis/build/robotology/icub-tests/build/plugins
   - sudo ldconfig
   - cd ../..
   


### PR DESCRIPTION
Using [RTF](https://github.com/robotology/robot-testing) and [icub-tests](https://github.com/robotology/icub-tests). 

Currently the tests are running the https://github.com/robotology/icub-tests/blob/master/suits/basics-icubGazeboSim.xml suite, but this can be changed and we can eventually provide a suite directly in the `gazebo-yarp-plugins` repository. 

Curiously, the gazebo fixture does not work unless we start (and then kill) an instance of gzserver before launching the server (this should be properly investigated). 