### PR TITLE
[imu, camera] Update Stamp count only when sending data

### DIFF
--- a/plugins/camera/include/yarp/dev/CameraDriver.h
+++ b/plugins/camera/include/yarp/dev/CameraDriver.h
@@ -107,7 +107,8 @@ private:
     bool m_display_time_box;
     bool m_display_timestamp;
 
-    yarp::os::Stamp m_lastTimestamp; //buffer for last timestamp data
+    double m_lastTimestamp;          //buffer for last timestamp data
+    yarp::os::Stamp m_lastStamp;     //timestamp updated for counting frames
     yarp::os::Semaphore m_dataMutex; //mutex for accessing the data
 
     unsigned char *m_imageBuffer;

--- a/plugins/camera/src/CameraDriver.cpp
+++ b/plugins/camera/src/CameraDriver.cpp
@@ -122,7 +122,8 @@ bool GazeboYarpCameraDriver::open(yarp::os::Searchable& config)
     m_dataMutex.wait();
     m_imageBuffer = new unsigned char[3*m_width*m_height];
     memset(m_imageBuffer, 0x00, 3*m_width*m_height);
-    m_lastTimestamp.update();
+    m_lastTimestamp = this->m_parentSensor->GetLastUpdateTime().Double();
+    m_lastStamp.update(m_lastTimestamp);
     m_dataMutex.post();
 
     //Connect the driver to the gazebo simulation
@@ -156,7 +157,7 @@ bool GazeboYarpCameraDriver::captureImage(const unsigned char *_image,
     if(m_parentSensor->IsActive())
         memcpy(m_imageBuffer, m_parentSensor->GetImageData(), m_bufferSize);
 
-    m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
+    m_lastTimestamp = this->m_parentSensor->GetLastUpdateTime().Double();
 
     if (m_display_timestamp)
     {
@@ -263,7 +264,8 @@ int GazeboYarpCameraDriver::width() const
 //PRECISELY TIMED
 yarp::os::Stamp GazeboYarpCameraDriver::getLastInputStamp()
 {
-    return m_lastTimestamp;
+    m_lastStamp.update(m_lastTimestamp);
+    return m_lastStamp;
 }
 
 int GazeboYarpCameraDriver::getRawBufferSize()

--- a/plugins/imu/include/yarp/dev/IMUDriver.h
+++ b/plugins/imu/include/yarp/dev/IMUDriver.h
@@ -69,7 +69,8 @@ public:
 
 private:
     yarp::sig::Vector m_imuData; //buffer for imu data
-    yarp::os::Stamp m_lastTimestamp; //buffer for last timestamp data
+    double m_lastTimestamp;      //buffer for last timestamp data
+    yarp::os::Stamp m_lastStamp; //timestamp updated for counting frames
     yarp::os::Semaphore m_dataMutex; //mutex for accessing the data
     
     gazebo::sensors::ImuSensor* m_parentSensor;

--- a/plugins/imu/src/IMUDriver.cpp
+++ b/plugins/imu/src/IMUDriver.cpp
@@ -43,7 +43,7 @@ void GazeboYarpIMUDriver::onUpdate(const gazebo::common::UpdateInfo &/*_info*/)
     angular_velocity = this->m_parentSensor->GetAngularVelocity();
     
     /** \todo TODO ensure that the timestamp is the right one */
-    m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
+    m_lastTimestamp = this->m_parentSensor->GetLastUpdateTime().Double();
     
     m_dataMutex.wait();
     
@@ -130,5 +130,6 @@ bool GazeboYarpIMUDriver::calibrate(int /*ch*/, double /*v*/)
 //PRECISELY TIMED
 yarp::os::Stamp GazeboYarpIMUDriver::getLastInputStamp()
 {
-    return m_lastTimestamp;
+    m_lastStamp.update(m_lastTimestamp);
+    return m_lastStamp;
 }


### PR DESCRIPTION
I'm not sure if this is correct, but I think that the stamp count should be updated only when the data is sent by yarp, and not when it is generated by gazebo...
That makes it easier to count if any data was missed because of YARP

Implemented only for imu and camera plugins, I don't know what the other plugins do.