### PR TITLE
[controlboard] implemented function to set/get position pids

### DIFF
--- a/libraries/common/include/GazeboYarpPlugins/common.h
+++ b/libraries/common/include/GazeboYarpPlugins/common.h
@@ -32,6 +32,20 @@ namespace GazeboYarpPlugins {
     double convertRadiansToDegrees(double radians);
 
     /**
+     * \brief convert a degrees-based gain to a radians-based gain
+     * \param gainsWrtDegrees degrees-based gain
+     * \return the gain converted in radians-based units
+     */
+    double convertDegreesGainsToRadiansGains(double gainsWrtDegrees);
+
+    /**
+     * \brief convert a radians-based gain to a degrees-based gain
+     * \param gainsWrtRadians radians-based gain
+     * \return the gain converted in degrees-based units
+     */
+    double convertRadiansGainsToDegreesGains(double gainsWrtRadians);
+
+    /**
      * \brief check if a string has a certaing ending
      * \param fullString the full string
      * \param ending the candidate ending
@@ -52,6 +66,17 @@ namespace GazeboYarpPlugins {
             return false;
         }
     }
+
+    inline double convertDegreesGainsToRadiansGains(double gainsWrtDegrees)
+    {
+        return gainsWrtDegrees * 180.0 / pi;
+    }
+
+    inline double convertRadiansGainsToDegreesGains(double gainsWrtRadians)
+    {
+        return gainsWrtRadians / 180.0 * pi;
+    }
+
 }
 
 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -155,7 +155,7 @@ public:
     virtual bool velocityMove(int j, double sp); //NOT TESTED
     virtual bool velocityMove(const double *sp); //NOT TESTED
     virtual bool velocityMove(const int n_joint, const int *joints, const double *spds);
-    
+
     virtual bool setVelPid(int j, const yarp::dev::Pid &pid);
     virtual bool setVelPids(const yarp::dev::Pid *pids);
     virtual bool getVelPid(int j, yarp::dev::Pid *pid);
@@ -290,6 +290,21 @@ public:
 private:
 
     /* PID structures */
+
+    /**
+     * Internal PID gains structure used in
+     * GazeboYarpPlugins.
+     * The gains are stored in radians based units
+     * for joint whose configuration space is given
+     * by an anguar quantity, and meter based units
+     * for joints whose configuratios space is given
+     * by a linear quantity.
+     *
+     * \note The gains for angular quantities in YARP
+     *       are instead usually expressed in degrees-
+     *       based quantity, so an appropriate conversion
+     *       is used in the setPids/getPids functions.
+     */
     struct PID {
         double p;
         double i;
@@ -315,8 +330,8 @@ private:
     gazebo::physics::Model* m_robot;
     gazebo::event::ConnectionPtr m_updateConnection;
 
-    
-    
+
+
     yarp::os::Property m_pluginParameters; /**< Contains the parameters of the device contained in the yarpConfigurationFile .ini file */
 
     unsigned int m_robotRefreshPeriod; //ms

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -259,8 +259,6 @@ void GazeboYarpControlBoardDriver::setPIDsForGroup(std::string pidGroupName,
 {
     yarp::os::Property prop;
     if (m_pluginParameters.check(pidGroupName.c_str())) {
-        std::cout<<"Found PID information in plugin parameters group " << pidGroupName << std::endl;
-
         for (unsigned int i = 0; i < m_numberOfJoints; ++i) {
             std::stringstream property_name;
             property_name<<"Pid";
@@ -281,9 +279,7 @@ void GazeboYarpControlBoardDriver::setPIDsForGroup(std::string pidGroupName,
 
 
             pids.push_back(pidValue);
-            std::cout<<"  P: "<<pidValue.p<<" I: "<<pidValue.i<<" D: "<<pidValue.d<<" maxInt: "<<pidValue.maxInt<<" maxOut: "<<pidValue.maxOut<<std::endl;
         }
-        std::cout<<"OK!"<<std::endl;
     } else {
         double default_p = pidTerms & PIDFeedbackTermProportionalTerm ? 500.0 : 0;
         double default_i = pidTerms & PIDFeedbackTermIntegrativeTerm ? 0.1 : 0;

--- a/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
@@ -7,37 +7,75 @@
 //
 
 #include "ControlBoardDriver.h"
+#include <GazeboYarpPlugins/common.h>
 
 namespace yarp {
     namespace dev {
-        
-        bool GazeboYarpControlBoardDriver::setPid (int /*j*/, const Pid &/*pid*/) { return false; }
-        bool GazeboYarpControlBoardDriver::setPids (const Pid */*pids*/) { return false; }
+
+        bool GazeboYarpControlBoardDriver::setPid (int j, const Pid &pid)
+        {
+            // Converting all gains for degrees-based unit to radians-based
+            m_positionPIDs[j].p = GazeboYarpPlugins::convertDegreesGainsToRadiansGains(pid.kp);
+            m_positionPIDs[j].i = GazeboYarpPlugins::convertDegreesGainsToRadiansGains(pid.ki);
+            m_positionPIDs[j].d = GazeboYarpPlugins::convertDegreesGainsToRadiansGains(pid.kd);
+            // The output limits are only related to the output, so they don't need to be converted
+            m_positionPIDs[j].maxInt = pid.max_int;
+            m_positionPIDs[j].maxOut = pid.max_output;
+        }
+
+        bool GazeboYarpControlBoardDriver::setPids (const Pid *pids)
+        {
+            for(int j=0; j< m_numberOfJoints; j++)
+                setPid(j, (pids[j]));
+            return true;
+        }
+
         bool GazeboYarpControlBoardDriver::setReference (int /*j*/, double /*ref*/) { return false; }
         bool GazeboYarpControlBoardDriver::setReferences (const double */*refs*/) { return false; }
         bool GazeboYarpControlBoardDriver::setErrorLimit (int /*j*/, double /*limit*/) { return false; }
         bool GazeboYarpControlBoardDriver::setErrorLimits (const double */*limits*/) { return false; }
         bool GazeboYarpControlBoardDriver::getError (int /*j*/, double */*err*/) { return false; }
         bool GazeboYarpControlBoardDriver::getErrors (double */*errs*/) { return false; }
-        bool GazeboYarpControlBoardDriver::getPid (int /*j*/, Pid */*pid*/) { return false; }
-        bool GazeboYarpControlBoardDriver::getPids (Pid */*pids*/) { return false; }
+
+        bool GazeboYarpControlBoardDriver::getPid (int j, Pid *pid)
+        {
+            // Converting all gains for degrees-based unit to radians-based
+            pid->kp = GazeboYarpPlugins::convertRadiansGainsToDegreesGains(m_positionPIDs[j].p);
+            pid->ki = GazeboYarpPlugins::convertRadiansGainsToDegreesGains(m_positionPIDs[j].i);
+            pid->kd = GazeboYarpPlugins::convertRadiansGainsToDegreesGains(m_positionPIDs[j].d);
+
+            // The output limits are only related to the output, so they don't need to be converted
+            pid->max_int = m_positionPIDs[j].maxInt;
+            pid->max_output = m_positionPIDs[j].maxOut;
+            return true;
+        }
+
+        bool GazeboYarpControlBoardDriver::getPids (Pid * pids)
+        {
+            for(int j=0; j< m_numberOfJoints; j++)
+                getPid(j, &(pids[j]));
+            return true;
+        }
+
         bool GazeboYarpControlBoardDriver::getReference (int j, double *ref)
         {
             *ref = m_referencePositions[j];
             return true;
         }
+
         bool GazeboYarpControlBoardDriver::getReferences (double *refs)
         {
             for(int j=0; j< m_numberOfJoints; j++)
                 getReference(j, &refs[j]);
             return true;
         }
+
         bool GazeboYarpControlBoardDriver::getErrorLimit (int /*j*/, double */*limit*/) { return false; }
         bool GazeboYarpControlBoardDriver::getErrorLimits (double */*limits*/) { return false; }
         bool GazeboYarpControlBoardDriver::resetPid (int /*j*/) { return false; }
         bool GazeboYarpControlBoardDriver::disablePid (int /*j*/) { return false; }
         bool GazeboYarpControlBoardDriver::enablePid (int /*j*/) { return false; }
         bool GazeboYarpControlBoardDriver::setOffset (int /*j*/, double /*v*/) { return false; }
-        
+
     }
 }


### PR DESCRIPTION
Implemented the setPid/getPid for setting position pids. 

cc @francesco-romano 

Two question for @randaz81 : 
 * The IPidControl methods just have influence on position gains, regardless of the controlmode in which the controlboard is right? 
 * I have implemented them such that the unit of measurement of the gains are degrees-based for revolute joints because I remember that with EMS-based robots we will migrate to "metric" gains.. I am forgetting right or I am doing something wrong?