### PR TITLE
Add support for using gazebo-provided configuration parameters in yarp configuration files 

### DIFF
--- a/libraries/singleton/CMakeLists.txt
+++ b/libraries/singleton/CMakeLists.txt
@@ -14,6 +14,7 @@ add_gazebo_yarp_plugin_target(LIBRARY_NAME singleton
                               SYSTEM_INCLUDE_DIRS ${YARP_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
                               LINKED_LIBRARIES ${YARP_LIBRARIES} ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
                               HEADERS include/GazeboYarpPlugins/Handler.hh
+                                      include/GazeboYarpPlugins/ConfHelpers.hh
                               SOURCES src/Handler.cc
-                                 )
+                                      src/ConfHelpers.cc)
 

--- a/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2007-2013 Istituto Italiano di Tecnologia ADVR & iCub Facility
+ * Authors: Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro and Alessandro Settimi
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#ifndef GAZEBOYARP_CONFIGURATION_HELPERS_HH
+#define GAZEBOYARP_CONFIGURATION_HELPERS_HH
+
+#include <yarp/os/Semaphore.h>
+#include <boost/shared_ptr.hpp>
+
+namespace gazebo
+{
+    namespace sensors {
+        class Sensor;
+        typedef boost::shared_ptr<Sensor> SensorPtr;
+    }
+    namespace physics {
+        class Model;
+        typedef boost::shared_ptr<Model> ModelPtr;
+    }
+}
+
+namespace sdf {
+    class Element;
+    typedef boost::shared_ptr<Element> ElementPtr;
+}
+
+namespace yarp {
+    namespace os {
+        class Property;
+    }
+}
+
+namespace GazeboYarpPlugins {
+
+/**
+ * Load the configuration for a given model plugin,
+ * and save the configuration in the plugin_parameters output object.
+ * This involves calling addGazeboEnviromentalVariablesModel and then loading
+ * the yarp configuration file specified in the sdf with the yarpConfigurationFile tag.
+ */
+bool loadConfigModelPlugin(gazebo::physics::ModelPtr _parent,
+                           sdf::ElementPtr _sdf,
+                           yarp::os::Property & plugin_parameters);
+
+/**
+ * Add some Gazebo specific "enviromental variables" that it is possible
+ * to expand in .ini configuration file loaded using the ${variable} syntax,
+ * for writing configuration files where port names and other parameters
+ * depend on Gazebo names.
+ *
+ * This function add some model related "enviromental variables",
+ * copying their values from some ModelPtr methods :
+ *
+ * |  Yarp parameter name       | ModelPtr method    |
+ * |:--------------------------:|:------------------:|
+ * | gazeboYarpPluginsRobotName | model->GetName()   |
+ *
+ * @return true if all went well, false otherwise
+ */
+bool addGazeboEnviromentalVariablesModel(gazebo::physics::ModelPtr _parent,
+                                         sdf::ElementPtr _sdf,
+                                         yarp::os::Property & plugin_parameters);
+
+/**
+ * Load the configuration for a given sensor plugin,
+ * and save the configuration in the plugin_parameters output object.
+ * This involves calling addGazeboEnviromentalVariablesSensor and then loading
+ * the yarp configuration file specified in the sdf with the yarpConfigurationFile tag.
+ */
+bool loadConfigSensorPlugin(gazebo::sensors::SensorPtr _sensor,
+                            sdf::ElementPtr _sdf,
+                            yarp::os::Property & plugin_parameters);
+
+/**
+ * Add some Gazebo specific "enviromental variables" that it is possible
+ * to expand in .ini configuration file loaded using the ${variable} syntax,
+ * for writing configuration files where port names and other parameters
+ * depend on Gazebo names.
+ *
+ * This function add some Sensor related "enviromental variables",
+ * copying their values from some SensorPtr methods :
+ *
+ * |  Yarp parameter name        | SensorPtr method    |
+ * |:---------------------------:|:-------------------:|
+ * | gazeboYarpPluginsSensorName | sensor->GetName()   |
+ * | gazeboYarpPluginsRobotName  | Model name as extracted from sensor->GetScopedName()  |
+ *
+ * @return true if all went well, false otherwise
+ */
+bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
+                                          sdf::ElementPtr _sdf,
+                                          yarp::os::Property & plugin_parameters);
+
+
+
+}
+
+#endif  // GAZEBOYARP_CONFIGURATION_HELPERS_HH

--- a/libraries/singleton/src/ConfHelpers.cc
+++ b/libraries/singleton/src/ConfHelpers.cc
@@ -22,18 +22,25 @@ using namespace gazebo;
 namespace GazeboYarpPlugins {
 
 /**
- * Split a string in a vector of string given a delimiter
+ * Split a string in a vector of string given a (single char) delimiter
  */
-std::vector<std::string> splitString(const std::string &s, const std::string &delims)
+std::vector<std::string> splitString(const std::string &s, const std::string &delim)
 {
-    std::vector<std::string> result;
-    std::string::size_type pos = 0;
-    while (std::string::npos != (pos = s.find_first_not_of(delims, pos))) {
-        auto pos2 = s.find_first_of(delims, pos);
-        result.emplace_back(s.substr(pos, std::string::npos == pos2 ? pos2 : pos2 - pos));
-        pos = pos2;
+    std::vector<std::string> retVec;
+
+    size_t start = s.find_first_not_of(delim), end=start;
+
+    while (start != std::string::npos)
+    {
+        // Find next occurence of delimiter
+        end = s.find(delim, start);
+        // Push back the token found into vector
+        retVec.push_back(s.substr(start, end-start));
+        // Skip all occurences of the delimiter to find new start
+        start = s.find_first_not_of(delim, end);
     }
-    return result;
+
+    return retVec;
 }
 
 bool addGazeboEnviromentalVariablesModel(gazebo::physics::ModelPtr _parent,
@@ -82,7 +89,7 @@ bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
 
     // Extract the robot name from the sensor scoped name
     std::string scopedSensorName = _sensor->GetScopedName();
-    std::vector<std::string> explodedScopedSensorName = splitString(scopedSensorName,"::");
+    std::vector<std::string> explodedScopedSensorName = splitString(scopedSensorName,":");
 
     // The vector should be at least of 3 elements because
     // scopedSensorName should be something similar to
@@ -96,6 +103,7 @@ bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
 
     std::string gazeboYarpPluginsRobotName = explodedScopedSensorName[explodedScopedSensorName.size()-3];
     plugin_parameters.put("gazeboYarpPluginsRobotName",gazeboYarpPluginsRobotName.c_str());
+
     return true;
 }
 

--- a/libraries/singleton/src/ConfHelpers.cc
+++ b/libraries/singleton/src/ConfHelpers.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2007-2013 Istituto Italiano di Tecnologia ADVR & iCub Facility
+ * Authors: Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro, Alberto Cardellino and Alessandro Settimi
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+ */
+
+#include "ConfHelpers.hh"
+
+#include <yarp/dev/PolyDriver.h>
+
+#include <gazebo/physics/Entity.hh>
+#include <gazebo/sensors/sensors.hh>
+#include <gazebo/common/common.hh>
+
+#include <yarp/os/Property.h>
+
+#include <string>
+#include <vector>
+
+using namespace gazebo;
+
+namespace GazeboYarpPlugins {
+
+/**
+ * Split a string in a vector of string given a delimiter
+ */
+std::vector<std::string> splitString(const std::string &s, const std::string &delims)
+{
+    std::vector<std::string> result;
+    std::string::size_type pos = 0;
+    while (std::string::npos != (pos = s.find_first_not_of(delims, pos))) {
+        auto pos2 = s.find_first_of(delims, pos);
+        result.emplace_back(s.substr(pos, std::string::npos == pos2 ? pos2 : pos2 - pos));
+        pos = pos2;
+    }
+    return result;
+}
+
+bool addGazeboEnviromentalVariablesModel(gazebo::physics::ModelPtr _parent,
+                                         sdf::ElementPtr _sdf,
+                                         yarp::os::Property & plugin_parameters)
+{
+    // Prefill the property object with some gazebo-yarp-plugins "Enviromental Variables"
+    // (not using the env variable in fromConfigFile(const ConstString& fname, Searchable& env, bool wipe)
+    // method because we want the variable defined here to be overwritable by the user configuration file
+    std::string gazeboYarpPluginsRobotName = _parent->GetName();
+    plugin_parameters.put("gazeboYarpPluginsRobotName",gazeboYarpPluginsRobotName.c_str());
+    return true;
+}
+
+bool loadConfigModelPlugin(physics::ModelPtr _model,
+                           sdf::ElementPtr _sdf,
+                           yarp::os::Property& plugin_parameters)
+{
+    if (_sdf->HasElement("yarpConfigurationFile")) {
+        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
+        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+
+        GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_model,_sdf,plugin_parameters);
+
+        bool wipe = false;
+        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe)) {
+            return true;
+        } else {
+            std::cerr << "GazeboYarpPlugins error: failure in loading configuration for model " << _model->GetName() << std::endl
+                      << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << std::endl
+                      << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path << std::endl;
+            return false;
+        }
+    }
+}
+
+bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
+                                         sdf::ElementPtr _sdf,
+                                         yarp::os::Property & plugin_parameters)
+{
+    // Prefill the property object with some gazebo-yarp-plugins "Enviromental Variables"
+    // (not using the env variable in fromConfigFile(const ConstString& fname, Searchable& env, bool wipe)
+    // method because we want the variable defined here to be overwritable by the user configuration file
+    std::string gazeboYarpPluginsSensorName = _sensor->GetName();
+    plugin_parameters.put("gazeboYarpPluginsSensorName",gazeboYarpPluginsSensorName.c_str());
+
+    // Extract the robot name from the sensor scoped name
+    std::string scopedSensorName = _sensor->GetScopedName();
+    std::vector<std::string> explodedScopedSensorName = splitString(scopedSensorName,"::");
+
+    // The vector should be at least of 3 elements because
+    // scopedSensorName should be something similar to
+    // worldName::modelName::linkOrJointName::sensorName
+    if( explodedScopedSensorName.size() < 3 )
+    {
+        std::cerr << "GazeboYarpPlugins warning: unexpected scopedSensorName " << scopedSensorName << std::endl;
+        std::cerr << "GazeboYarpPlugins warning: gazeboYarpPluginsRobotName not set in sensor " << gazeboYarpPluginsSensorName << std::endl;
+        return false;
+    }
+
+    std::string gazeboYarpPluginsRobotName = explodedScopedSensorName[explodedScopedSensorName.size()-3];
+    plugin_parameters.put("gazeboYarpPluginsRobotName",gazeboYarpPluginsRobotName.c_str());
+    return true;
+}
+
+bool loadConfigSensorPlugin(sensors::SensorPtr _sensor,
+                            sdf::ElementPtr _sdf,
+                            yarp::os::Property& plugin_parameters)
+{
+    if (_sdf->HasElement("yarpConfigurationFile")) {
+        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
+        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+
+        GazeboYarpPlugins::addGazeboEnviromentalVariablesSensor(_sensor,_sdf,plugin_parameters);
+
+        bool wipe = false;
+        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe)) {
+            return true;
+        } else {
+            std::cerr << "GazeboYarpPlugins error: failure in loading configuration for sensor " << _sensor->GetName() << std::endl
+                      << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << std::endl
+                      << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path << std::endl;
+            return false;
+        }
+    }
+}
+
+
+}

--- a/plugins/camera/src/Camera.cc
+++ b/plugins/camera/src/Camera.cc
@@ -9,6 +9,7 @@
 #include "CameraDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
 
 #include <gazebo/sensors/CameraSensor.hh>
 #include <yarp/dev/PolyDriver.h>
@@ -21,12 +22,10 @@ namespace gazebo {
 
 GazeboYarpCamera::GazeboYarpCamera() : CameraPlugin(), m_yarp()
 {
-    std::cout << "*** GazeboYarpCamera contructor ***" << std::endl;
 }
 
 GazeboYarpCamera::~GazeboYarpCamera()
 {
-    std::cout << "*** GazeboYarpCamera closing ***" << std::endl;
     m_cameraDriver.close();
     GazeboYarpPlugins::Handler::getHandler()->removeSensor(m_sensorName);
 }
@@ -37,39 +36,27 @@ void GazeboYarpCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
         std::cerr << "GazeboYarpCamera::Load error: yarp network does not seem to be available, is the yarpserver running?"<<std::endl;
         return;
     }
-    
-    std::cout << "*** GazeboYarpCamera plugin started ***" << std::endl;
-    
+
+
     if (!_sensor) {
         gzerr << "GazeboYarpCamera plugin requires a CameraSensor." << std::endl;
         return;
     }
 
     _sensor->SetActive(true);
-    
+
     // Add my gazebo device driver to the factory.
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpCameraDriver>
                                         ("gazebo_camera", "grabber", "GazeboYarpCameraDriver"));
-    
-    
+
+
     //Getting .ini configuration file from sdf
-    bool configuration_loaded = false;
-    
-    if (_sdf->HasElement("yarpConfigurationFile")) {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-        
-        if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str())) {
-            std::cout << "Found yarpConfigurationFile: loading from " << ini_file_path << std::endl;
-            configuration_loaded = true;
-        }
-    }
-    
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor,_sdf,m_parameters);
+
     if (!configuration_loaded) {
-        std::cout << "File .ini not found, quitting" << std::endl;
         return;
     }
-    
+
     m_sensorName = _sensor->GetScopedName();
     m_sensor = (gazebo::sensors::CameraSensor*)_sensor.get();
     if(m_sensor == NULL)
@@ -84,17 +71,15 @@ void GazeboYarpCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
     std::cout << "sensor scoped name is " << m_sensorName.c_str() << std::endl;
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
-    
+
     m_parameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
-    
+
     //Open the driver
     if (m_cameraDriver.open(m_parameters)) {
         std::cout << "Loaded GazeboYarpCamera Plugin correctly" << std::endl;
     } else {
         std::cout << "GazeboYarpCamera Plugin Load failed: error in opening yarp driver" << std::endl;
     }
-    
-    std::cout << "Trying to get the GazeboYarpCameraDriver interface from the device" << std::endl;
 
     m_cameraDriver.view(iFrameGrabberImage);
     if(iFrameGrabberImage == NULL)
@@ -103,8 +88,6 @@ void GazeboYarpCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
         return;
     }
 
-    std::cout << "GazeboYarpCamera parameters" << std::endl;
-    std::cout << m_parameters.toString() << std::endl;
 }
-    
+
 }

--- a/plugins/controlboard/include/gazebo/ControlBoard.hh
+++ b/plugins/controlboard/include/gazebo/ControlBoard.hh
@@ -47,7 +47,6 @@ public:
     void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
 private:
-
     yarp::dev::PolyDriver m_wrapper;
     yarp::dev::IMultipleWrapper* m_iWrap;
     yarp::dev::PolyDriverList m_controlBoards;

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -136,8 +136,9 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 printf("controlBoard %s already opened\n", newPoly.key.c_str());
 
             }
-            else {
-                driver_group = m_parameters.findGroup(deviceName.c_str());
+            else 
+            {
+                driver_group = m_parameters.findGroup(newPoly.key.c_str());
                 if (driver_group.isNull()) {
                     fprintf(stderr, "GazeboYarpControlBoard::Load  Error: [%s] group not found in config file. Closing wrapper \n", newPoly.key.c_str());
                     m_wrapper.close();

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -8,7 +8,7 @@
 #include "ControlBoardDriver.h"
 #include <GazeboYarpPlugins/common.h>
 #include <GazeboYarpPlugins/Handler.hh>
-
+#include <GazeboYarpPlugins/ConfHelpers.hh>
 
 #include <gazebo/physics/Model.hh>
 #include <yarp/dev/Wrapper.h>
@@ -74,7 +74,11 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
             std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
 
-            if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str())) {
+            GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_parent,_sdf,m_parameters);
+
+            bool wipe = false;
+            if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str(),wipe))
+            {
                 std::cout << "GazeboYarpControlBoard: Found yarpConfigurationFile: loading from " << ini_file_path << std::endl;
                 m_parameters.put("gazebo_ini_file_path",ini_file_path.c_str());
 
@@ -91,7 +95,9 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 }
                 configuration_loaded = true;
             }
+
         }
+
         if (!configuration_loaded) {
             std::cout << "GazeboYarpControlBoard: File .ini not found, quitting\n" << std::endl;
             return;
@@ -130,10 +136,8 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 printf("controlBoard %s already opened\n", newPoly.key.c_str());
 
             }
-            else
-            {
-                std::cout << "Opening new device " << newPoly.key.c_str() << std::endl;
-                driver_group = m_parameters.findGroup(newPoly.key.c_str());
+            else {
+                driver_group = m_parameters.findGroup(deviceName.c_str());
                 if (driver_group.isNull()) {
                     fprintf(stderr, "GazeboYarpControlBoard::Load  Error: [%s] group not found in config file. Closing wrapper \n", newPoly.key.c_str());
                     m_wrapper.close();

--- a/plugins/forcetorque/src/ForceTorque.cc
+++ b/plugins/forcetorque/src/ForceTorque.cc
@@ -9,6 +9,7 @@
 #include "ForceTorqueDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
 
 #include <gazebo/sensors/ForceTorqueSensor.hh>
 #include <yarp/dev/PolyDriver.h>
@@ -26,7 +27,6 @@ GazeboYarpForceTorque::GazeboYarpForceTorque() : SensorPlugin(), m_iWrap(0)
 
 GazeboYarpForceTorque::~GazeboYarpForceTorque()
 {
-    std::cout<<"*** GazeboYarpForceTorque closing ***"<<std::endl;
     if(m_iWrap) { m_iWrap->detachAll(); m_iWrap = 0; }
     if( m_forcetorqueWrapper.isValid() ) m_forcetorqueWrapper.close();
     if( m_forceTorqueDriver.isValid() ) m_forceTorqueDriver.close();
@@ -41,8 +41,7 @@ void GazeboYarpForceTorque::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
        std::cerr << "GazeboYarpForceTorque::Load error: yarp network does not seem to be available, is the yarpserver running?"<<std::endl;
        return;
     }
-    std::cout<<"*** GazeboYarpForceTorque plugin started ***"<<std::endl;
-    
+
     if (!_sensor)
     {
         gzerr << "GazeboYarpForceTorque plugin requires a ForceTorqueSensor.\n";
@@ -54,54 +53,44 @@ void GazeboYarpForceTorque::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     // Add my gazebo device driver to the factory.
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpForceTorqueDriver>
                                       ("gazebo_forcetorque", "analogServer", "GazeboYarpForceTorqueDriver"));
-        
+
     //Getting .ini configuration file from sdf
     ::yarp::os::Property wrapper_properties;
     ::yarp::os::Property driver_properties;
-    bool configuration_loaded = false;
-        
-    if(_sdf->HasElement("yarpConfigurationFile") )
-    {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor,_sdf,driver_properties);
 
-        if( ini_file_path != "" && driver_properties.fromConfigFile(ini_file_path.c_str()) )
-        {
-            std::cout << "Found yarpConfigurationFile: loading from " << ini_file_path << std::endl;
-            configuration_loaded = true;
-        }
-    }
-    
+    if (!configuration_loaded) {
+        return;
+    };
+
+
     ///< \todo TODO handle in a better way the parameters that are for the wrapper and the one that are for driver
     wrapper_properties = driver_properties;
-        
+
     if( !configuration_loaded )
     {
-        std::cout << "File .ini not found, quitting\n" << std::endl;
         return;
     }
-    
+
     m_sensorName = _sensor->GetScopedName();
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(boost::get_pointer(_sensor));
-    
+
     driver_properties.put(YarpForceTorqueScopedName.c_str(), m_sensorName.c_str());
-    
+
     //Open the wrapper
     //Force the wrapper to be of type "analogServer" (it make sense? probably no)
     wrapper_properties.put("device","analogServer");
     if( m_forcetorqueWrapper.open(wrapper_properties) ) {
-        std::cout<<"GazeboYarpForceTorque Plugin: correcly opened GazeboYarpForceTorqueDriver wrapper"<<std::endl;
     } else {
         std::cout<<"GazeboYarpForceTorque Plugin failed: error in opening yarp driver wrapper"<<std::endl;
         return;
     }
-   
+
     //Open the driver
     //Force the device to be of type "gazebo_forcetorque" (it make sense? probably yes)
     driver_properties.put("device","gazebo_forcetorque");
     if( m_forceTorqueDriver.open(driver_properties) ) {
-        std::cout<<"GazeboYarpForceTorque Plugin: correcly opened GazeboYarpForceTorqueDriver"<<std::endl;
     } else {
         std::cout<<"GazeboYarpForceTorque Plugin failed: error in opening yarp driver"<<std::endl;
         return;
@@ -109,20 +98,19 @@ void GazeboYarpForceTorque::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
     //Attach the driver to the wrapper
     ::yarp::dev::PolyDriverList driver_list;
-    
+
     if( !m_forcetorqueWrapper.view(m_iWrap) ) {
         std::cerr << "GazeboYarpForceTorque : error in loading wrapper" << std::endl;
         return;
     }
-    
+
     driver_list.push(&m_forceTorqueDriver,"dummy");
-    
+
     if( m_iWrap->attachAll(driver_list) ) {
-        std::cerr << "GazeboYarpForceTorque : wrapper was connected with driver " << std::endl;
     } else {
         std::cerr << "GazeboYarpForceTorque : error in connecting wrapper and device " << std::endl;
     }
-    
+
 }
 
 }

--- a/plugins/imu/src/IMU.cc
+++ b/plugins/imu/src/IMU.cc
@@ -4,11 +4,12 @@
  * CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
  */
 
-
 #include "IMU.hh"
 #include "IMUDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
+
 
 #include <gazebo/sensors/ImuSensor.hh>
 
@@ -38,56 +39,35 @@ void GazeboYarpIMU::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
         std::cerr << "GazeboYarpIMU::Load error: yarp network does not seem to be available, is the yarpserver running?"<<std::endl;
         return;
     }
-    
-    std::cout << "*** GazeboYarpIMU plugin started ***" << std::endl;
-    
+
     if (!_sensor) {
         gzerr << "GazeboYarpIMU plugin requires a IMUSensor." << std::endl;
         return;
     }
-    
+
     _sensor->SetActive(true);
-    
+
     // Add my gazebo device driver to the factory.
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpIMUDriver>
                                         ("gazebo_imu", "inertial", "GazeboYarpIMUDriver"));
-    
-    
-    //Getting .ini configuration file from sdf
-    bool configuration_loaded = false;
-    
-    if (_sdf->HasElement("yarpConfigurationFile")) {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-        
-        if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str())) {
-            std::cout << "Found yarpConfigurationFile: loading from " << ini_file_path << std::endl;
-            configuration_loaded = true;
-        }
-    }
-    
+
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor,_sdf,m_parameters);
+
     if (!configuration_loaded) {
-        std::cout << "File .ini not found, quitting" << std::endl;
         return;
     }
-    
+
     m_sensorName = _sensor->GetScopedName();
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
-    
+
     m_parameters.put(YarpIMUScopedName.c_str(), m_sensorName.c_str());
-    
+
     //Open the driver
     if (m_imuDriver.open(m_parameters)) {
-        std::cout << "Loaded GazeboYarpIMU Plugin correctly" << std::endl;
     } else {
         std::cout << "GazeboYarpIMU Plugin Load failed: error in opening yarp driver" << std::endl;
     }
-    
-    std::cout << "GazeboYarpIMU original parameters" << std::endl;
-    std::cout << m_parameters.toString() << std::endl;
-    std::cout << "GazeboYarpIMU getOptions" << std::endl;
-    std::cout << m_imuDriver.getOptions().toString() << std::endl;
 }
-    
+
 }

--- a/plugins/jointsensors/src/JointSensors.cc
+++ b/plugins/jointsensors/src/JointSensors.cc
@@ -9,6 +9,8 @@
 #include "JointSensors.hh"
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
+
 
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/dev/Wrapper.h>
@@ -58,25 +60,16 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
     //Getting .ini configuration file from sdf
     ::yarp::os::Property wrapper_properties;
     ::yarp::os::Property driver_properties;
-    bool configuration_loaded = false;
 
-    if (_sdf->HasElement("yarpConfigurationFile")) {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent,_sdf,driver_properties);
 
-        if (ini_file_path != "" && driver_properties.fromConfigFile(ini_file_path.c_str())) {
-            std::cout << "Found yarpConfigurationFile: loading from " << ini_file_path << std::endl;
-            configuration_loaded = true;
-        }
-    }
+    if (!configuration_loaded) {
+        return;
+    };
 
     ///< \todo TODO handle in a better way the parameters that are for the wrapper and the one that are for driver
     wrapper_properties = driver_properties;
 
-    if (!configuration_loaded) {
-        std::cout << "File .ini not found, quitting\n" << std::endl;
-        return;
-    }
 
     m_robotName = _parent->GetScopedName();
     //Insert the pointer in the singleton handler for retriving it in the yarp driver


### PR DESCRIPTION
To simplify passing using Gazebo values (such as the runtime robot
name or sensor name) in yarp configuration files, now some special
yarp configuration values (for now gazeboYarpPluginsRobotName and
gazeboYarpPluginsSensorName) are present when loading the plugins
configuration file. 

In this way the user can either ignore them,
either use them using the ${variableName} syntax, either overwriting
them specifying explicit value for them in the configuration files.

To understand the use of this feature, take the icub model from 
https://github.com/robotology-playground/icub-gazebo/tree/master/icub 
and comment out the `gazeboYarpPluginsRobotName icubGazeboSim` in
 https://github.com/robotology-playground/icub-gazebo/blob/master/icub/conf/gazebo_icub_robotname.ini . In this way the gazeboYarpPluginsRobotName 
configuration value is not overwritten by the user configuration files, and so its value
(and hence the prefix of all the ports opened by the robot)  will be the one of the robot in Gazebo .
Given that any robot has a unique name in Gazebo, using this feature is possible to 
spawn multiple robots from the same model without yarp port names conflicts. 

Whitespace-free diff available at https://github.com/robotology/gazebo-yarp-plugins/pull/204/files . 

cc @EnricoMingo 