### PR TITLE
Fix compilation with Gazebo 7

### DIFF
--- a/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
@@ -7,9 +7,13 @@
 #ifndef GAZEBOYARP_CONFIGURATION_HELPERS_HH
 #define GAZEBOYARP_CONFIGURATION_HELPERS_HH
 
-#include <yarp/os/Semaphore.h>
+#include <sdf/sdf_config.h>
 
+#if SDF_MAJOR_VERSION >= 3
 #include <sdf/Element.hh>
+#else
+#include <sdf/SDFImpl.hh>
+#endif
 
 #include <boost/shared_ptr.hpp>
 

--- a/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
@@ -7,15 +7,23 @@
 #ifndef GAZEBOYARP_CONFIGURATION_HELPERS_HH
 #define GAZEBOYARP_CONFIGURATION_HELPERS_HH
 
+#include <boost/shared_ptr.hpp>
+
 #include <sdf/sdf_config.h>
 
 #if SDF_MAJOR_VERSION >= 3
+
 #include <sdf/Element.hh>
+
 #else
-#include <sdf/SDFImpl.hh>
+
+namespace sdf {
+   class Element;
+   typedef boost::shared_ptr<Element> ElementPtr;
+}
+
 #endif
 
-#include <boost/shared_ptr.hpp>
 
 namespace gazebo
 {

--- a/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
@@ -8,6 +8,9 @@
 #define GAZEBOYARP_CONFIGURATION_HELPERS_HH
 
 #include <yarp/os/Semaphore.h>
+
+#include <sdf/Element.hh>
+
 #include <boost/shared_ptr.hpp>
 
 namespace gazebo
@@ -20,11 +23,6 @@ namespace gazebo
         class Model;
         typedef boost::shared_ptr<Model> ModelPtr;
     }
-}
-
-namespace sdf {
-    class Element;
-    typedef boost::shared_ptr<Element> ElementPtr;
 }
 
 namespace yarp {

--- a/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
@@ -12,9 +12,17 @@
 #include <sdf/sdf_config.h>
 
 #if SDF_MAJOR_VERSION >= 3
+
 #include <sdf/Element.hh>
+
 #else
-#include <sdf/SDFImpl.hh>
+
+#include <boost/shared_ptr.hpp>
+namespace sdf {
+   class Element;
+   typedef boost::shared_ptr<Element> ElementPtr;
+}
+
 #endif
 
 #include <yarp/os/Semaphore.h>

--- a/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
@@ -9,7 +9,13 @@
 
 #include <map>
 
+#include <sdf/sdf_config.h>
+
+#if SDF_MAJOR_VERSION >= 3
 #include <sdf/Element.hh>
+#else
+#include <sdf/SDFImpl.hh>
+#endif
 
 #include <yarp/os/Semaphore.h>
 

--- a/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
@@ -8,8 +8,10 @@
 #define GAZEBOYARP_HANDLER_HH
 
 #include <map>
+
+#include <sdf/Element.hh>
+
 #include <yarp/os/Semaphore.h>
-#include <boost/shared_ptr.hpp>
 
 namespace gazebo
 {
@@ -19,11 +21,6 @@ namespace gazebo
     namespace physics {
         class Model;
     }
-}
-
-namespace sdf {
-    class Element;
-    typedef boost::shared_ptr<Element> ElementPtr;
 }
 
 namespace yarp {

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(forcetorque)
 add_subdirectory(imu)
 add_subdirectory(jointsensors)
 add_subdirectory(showmodelcom)
+
 if( GAZEBO_VERSION VERSION_GREATER 3.9 )
     add_subdirectory(worldinterface)
 else()

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -98,7 +98,11 @@ void ApplyExternalWrench::UpdateChild()
         math::Matrix4 rotation = math::Matrix4 ( newX[0],newY[0],newZ[0],0,newX[1],newY[1],newZ[1],0,newX[2],newY[2],newZ[2],0, 0, 0, 0, 1 );
         math::Quaternion forceOrientation = rotation.GetRotation();
         math::Pose linkCoGPose ( linkCoGPos - rotation*math::Vector3 ( 0,0,.15 ), forceOrientation );
+#if GAZEBO_MAJOR_VERSION >= 7
+        msgs::Set ( m_visualMsg.mutable_pose(), linkCoGPose.Ign() );
+#else
         msgs::Set ( m_visualMsg.mutable_pose(), linkCoGPose );
+#endif
         msgs::Set ( m_visualMsg.mutable_material()->mutable_ambient(),common::Color ( 1,0,0,0.3 ) );
         m_visualMsg.set_visible ( 1 );
         m_visPub->Publish ( m_visualMsg );

--- a/plugins/showmodelcom/src/ShowModelCoM.cc
+++ b/plugins/showmodelcom/src/ShowModelCoM.cc
@@ -74,7 +74,11 @@ namespace gazebo
         gazebo::math::Pose WorldCoGPose = gazebo::math::Pose::Zero;
         WorldCoGPose.pos = wordlCoGModel;
 
+#if GAZEBO_MAJOR_VERSION >= 7
+        msgs::Set(m_visualMsg.mutable_pose(), WorldCoGPose.Ign());
+#else
         msgs::Set(m_visualMsg.mutable_pose(), WorldCoGPose);
+#endif
         msgs::Set(m_visualMsg.mutable_material()->mutable_ambient(),common::Color(1,0,0,0.3));
         m_visualMsg.set_visible(1);
         m_visPub->Publish(m_visualMsg);


### PR DESCRIPTION
In particular :
  * Address function that are migrating to ignition-math classes
  * Address migration of SDF from boost::shared_ptr to std::shared_ptr