### PR TITLE
Remove a lot of unnecessary output to the terminal

### DIFF
--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -33,7 +33,6 @@ Handler* Handler::getHandler()
 {
     mutex().wait();
     if (!s_handle) {
-        std::cout << "Calling GazeboYarpPlugins::Handler Constructor" << std::endl;
         s_handle = new Handler();
         if (!s_handle)
             std::cout << "Error while calling GazeboYarpPluginHandler constructor" << std::endl;
@@ -47,13 +46,11 @@ bool Handler::setRobot(gazebo::physics::Model* _model)
 {
     bool ret = false;
     std::string scopedRobotName = _model->GetScopedName();
-    std::cout << "GazeboYarpPlugins::Handler: Inserting Robot : " << scopedRobotName << std::endl;
 
     RobotsMap::iterator robot = m_robotMap.find(scopedRobotName);
     if (robot != m_robotMap.end()) {
         //robot already exists. Increment reference counting
         robot->second.incrementCount();
-        std::cout << "Robot already registered, pointers match." << std::endl;
         ret = true;
     }
     else {
@@ -66,7 +63,6 @@ bool Handler::setRobot(gazebo::physics::Model* _model)
             ret = false;
         } else {
             ret = true;
-            std::cout << "Singleton: Added a new robot " << scopedRobotName << "." << std::endl;
         }
     }
     return ret;
@@ -75,11 +71,9 @@ bool Handler::setRobot(gazebo::physics::Model* _model)
 gazebo::physics::Model* Handler::getRobot(const std::string& robotName) const
 {
     gazebo::physics::Model* tmp = NULL;
-    std::cout << "Looking for robot : " << robotName << std::endl;
 
     RobotsMap::const_iterator robot = m_robotMap.find(robotName);
     if (robot != m_robotMap.end()) {
-        std::cout << "Robot " << robotName << " was happily found!" << std::endl;
         tmp = robot->second.object();
     }
     else {
@@ -95,7 +89,6 @@ void Handler::removeRobot(const std::string& robotName)
     if (robot != m_robotMap.end()) {
         robot->second.decrementCount();
         if (!robot->second.count()) {
-            std::cout << "Removing robot " << robotName << std::endl;
             m_robotMap.erase(robot);
         }
     } else {
@@ -107,13 +100,11 @@ bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
 {
     bool ret = false;
     std::string scopedSensorName = _sensor->GetScopedName();
-    std::cout << "GazeboYarpPlugins::Handler: Inserting Sensor : " << scopedSensorName << std::endl;
 
     SensorsMap::iterator sensor = m_sensorsMap.find(scopedSensorName);
     if (sensor != m_sensorsMap.end()) {
         //sensor already exists. Increment reference counting
         sensor->second.incrementCount();
-        std::cout << "Sensor already registered, pointers match." << std::endl;
         ret = true;
     } else {
         //sensor does not exists. Add to map
@@ -125,7 +116,6 @@ bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
             ret = false;
         } else {
             ret = true;
-            std::cout << "Singleton: Added a new sensor " << scopedSensorName << "." << std::endl;
         }
     }
     return ret;
@@ -135,11 +125,9 @@ bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
 gazebo::sensors::Sensor* Handler::getSensor(const std::string& sensorScopedName) const
 {
     gazebo::sensors::Sensor* tmp = NULL;
-    std::cout << "Looking for sensor : " << sensorScopedName << std::endl;
 
     SensorsMap::const_iterator sensor = m_sensorsMap.find(sensorScopedName);
     if (sensor != m_sensorsMap.end()) {
-        std::cout << "Sensor " << sensorScopedName << " was happily found!" << std::endl;
         tmp = sensor->second.object();
     } else {
         std::cout << "Sensor was not found: " << sensorScopedName << std::endl;
@@ -171,7 +159,6 @@ bool Handler::setDevice(std::string deviceName, yarp::dev::PolyDriver* device2ad
         if(device->second.object() == device2add)
         {
             device->second.incrementCount();
-            std::cout << "Device '" << deviceName << "' already registered, incrementing usage counter to " << device->second.count() << std::endl;
             ret = true;
         }
         else
@@ -188,7 +175,6 @@ bool Handler::setDevice(std::string deviceName, yarp::dev::PolyDriver* device2ad
             ret = false;
         } else {
             ret = true;
-            std::cout << "Singleton: Added a new device " << deviceName << "." << std::endl;
         }
     }
     return ret;
@@ -197,11 +183,9 @@ bool Handler::setDevice(std::string deviceName, yarp::dev::PolyDriver* device2ad
 yarp::dev::PolyDriver* Handler::getDevice(const std::string& deviceName) const
 {
     yarp::dev::PolyDriver* tmp = NULL;
-    std::cout << "Looking for device : " << deviceName << std::endl;
 
     DevicesMap::const_iterator device = m_devicesMap.find(deviceName);
     if (device != m_devicesMap.end()) {
-        std::cout << "Device " << deviceName << " was happily found!" << std::endl;
         tmp = device->second.object();
     } else {
         tmp = NULL;
@@ -215,7 +199,6 @@ void Handler::removeDevice(const std::string& deviceName)
     if (device != m_devicesMap.end()) {
         device->second.decrementCount();
         if (!device->second.count()) {
-            std::cout << "Removing device " << deviceName << std::endl;
             device->second.object()->close();
             m_devicesMap.erase(device);
         }

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -52,7 +52,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             std::cerr << "GazeboYarpControlBoard::Load error: yarp network does not seem to be available, is the yarpserver running?"<<std::endl;
             return;
         }
-        std::cout<<"*** GazeboYarpControlBoard plugin started ***"<<std::endl;
 
         if (!_parent) {
             gzerr << "GazeboYarpControlBoard plugin requires a parent.\n";
@@ -87,12 +86,14 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     printf("GazeboYarpControlBoard::Load  Error: [WRAPPER] group not found in config file\n");
                     return;
                 }
+
                 if(m_parameters.check("ROS"))
                 {
                     yarp::os::ConstString ROS;
                     ROS = yarp::os::ConstString ("(") + m_parameters.findGroup("ROS").toString() + yarp::os::ConstString (")");
                     wrapper_group.append(yarp::os::Bottle(ROS));
                 }
+
                 configuration_loaded = true;
             }
 
@@ -107,8 +108,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
 
         if (!m_wrapper.isValid())
             fprintf(stderr, "GazeboYarpControlBoard: wrapper did not open\n");
-        else
-            fprintf(stderr, "GazeboYarpControlBoard: wrapper opened correctly\n");
 
         if (!m_wrapper.view(m_iWrap)) {
             printf("Wrapper interface not found\n");
@@ -136,7 +135,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 printf("controlBoard %s already opened\n", newPoly.key.c_str());
 
             }
-            else 
+            else
             {
                 driver_group = m_parameters.findGroup(newPoly.key.c_str());
                 if (driver_group.isNull()) {
@@ -148,8 +147,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 m_parameters.put("name", newPoly.key.c_str());
                 m_parameters.fromString(driver_group.toString(), false);
                 m_parameters.put("robotScopedName", m_robotName);
-                std::cout << "GazeboYarpControlBoard: setting robotScopedName " << m_robotName << std::endl;
-                 //std::cout << "before open: params are " << m_parameters.toString() << std::endl;
 
                 if (_sdf->HasElement("initialConfiguration")) {
                     //std::cout<<"Found initial Configuration: "<<std::endl;
@@ -169,10 +166,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     m_wrapper.close();
                     return;
                 }
-                else
-                {
-                    printf("controlBoard %s opened correctly\n", newPoly.key.c_str());
-                }
             }
             GazeboYarpPlugins::Handler::getHandler()->setDevice(scopedDeviceName, newPoly.poly);
             m_controlBoards.push(newPoly);
@@ -188,9 +181,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             }
             return;
         }
-
-        printf("Device initialized correctly, now sitting and waiting cause I am just the main of the yarp device, and the robot is linked to the onUpdate event of gazebo\n");
-        std::cout<<"Loaded GazeboYarpControlBoard Plugin"<<std::endl;
     }
 
 }

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -33,10 +33,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     assert(m_robot);
     if (!m_robot) return false;
 
-    std::cout<<"Robot Name: "<<m_robot->GetName() <<std::endl;
-    std::cout<<"# Joints: "<<m_robot->GetJoints().size() <<std::endl;
-    std::cout<<"# Links: "<<m_robot->GetLinks().size() <<std::endl;
-
     this->m_robotRefreshPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
     if (!setJointNames()) return false;
 
@@ -85,8 +81,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         m_controlMode[j] = VOCAB_CM_POSITION;
     for (unsigned int j = 0; j < m_numberOfJoints; ++j)
         m_interactionMode[j] = VOCAB_IM_STIFF;
-
-    std::cout << "gazebo_init set pid done!" << std::endl;
 
     this->m_updateConnection =
     gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpControlBoardDriver::onUpdate,

--- a/plugins/controlboard/src/ControlBoardDriverDeviceDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverDeviceDriver.cpp
@@ -19,10 +19,8 @@ bool GazeboYarpControlBoardDriver::open(yarp::os::Searchable& config)
     m_pluginParameters.fromString(config.toString().c_str());
 
     deviceName = m_pluginParameters.find("name").asString().c_str();
-    std::cout << "Opening  GazeboYarpControlBoardDriver named " << deviceName << std::endl;
 
     std::string robotName(m_pluginParameters.find("robotScopedName").asString().c_str());
-    std::cout << "DeviceDriver is looking for robot " << robotName << "..." << std::endl;
 
     m_robot = GazeboYarpPlugins::Handler::getHandler()->getRobot(robotName);
     if(!m_robot) {
@@ -35,7 +33,6 @@ bool GazeboYarpControlBoardDriver::open(yarp::os::Searchable& config)
 
 bool GazeboYarpControlBoardDriver::close()
 {
-    std::cout << "Closing device " << deviceName  << std::endl;
     //unbinding events
     if (this->m_updateConnection.get()) {
         gazebo::event::Events::DisconnectWorldUpdateBegin (this->m_updateConnection);

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -139,10 +139,8 @@ void ApplyExternalWrench::Load ( physics::ModelPtr _model, sdf::ElementPtr _sdf 
         std::string iniRobotNamePath =  gazebo::common::SystemPaths::Instance()->FindFileURI ( iniRobotName );
 
         if ( iniRobotNamePath != "" && this->m_iniParams.fromConfigFile ( iniRobotNamePath.c_str() ) ) {
-            std::cout << "ApplyExternalWrench: Found robotNamefromConfigFile in "<< iniRobotNamePath << std::endl;
             yarp::os::Value robotNameParam = m_iniParams.find ( "gazeboYarpPluginsRobotName" );
             this->robotName = robotNameParam.asString();
-            printf ( "ApplyExternalWrench: robotName is %s \n",robotName.c_str() );
             m_rpcThread.setRobotName  ( robotName );
             m_rpcThread.setScopedName ( this->m_modelScope );
             gazebo::physics::Link_V links = _model->GetLinks();
@@ -154,9 +152,7 @@ void ApplyExternalWrench::Load ( physics::ModelPtr _model, sdf::ElementPtr _sdf 
             return;
         }
     } else {
-            std::cout << "ApplyExternalWrench: robot name from sdf description will be used!"<<std::endl;
             this->robotName = _model->GetName();
-            printf ( "ApplyExternalWrench: robotName is %s \n",robotName.c_str() );
             m_rpcThread.setRobotName ( robotName );
             m_rpcThread.setScopedName ( this->m_modelScope );
             gazebo::physics::Link_V links = _model->GetLinks();
@@ -246,8 +242,6 @@ void RPCServerThread::setDefaultLink(const std::string &defaultLink)
 bool RPCServerThread::threadInit()
 {
 
-    printf ( "Starting RPCServerThread\n" );
-    printf ( "Opening rpc port\n" );
     if ( !m_rpcPort.open ( std::string ( "/"+m_robotName + "/applyExternalWrench/rpc:i" ).c_str() ) ) {
         printf ( "ERROR opening RPC port /applyExternalWrench\n" );
         return false;
@@ -307,7 +301,6 @@ void RPCServerThread::threadRelease()
 {
     yarp::os::Thread::threadRelease();
     m_rpcPort.close();
-    printf ( "Goodbye from RPC thread\n" );
 }
 yarp::os::Bottle RPCServerThread::getCmd()
 {

--- a/plugins/imu/src/IMU.cc
+++ b/plugins/imu/src/IMU.cc
@@ -26,7 +26,6 @@ GazeboYarpIMU::GazeboYarpIMU() : SensorPlugin()
 
 GazeboYarpIMU::~GazeboYarpIMU()
 {
-    std::cout << "*** GazeboYarpIMU closing ***" << std::endl;
     m_imuDriver.close();
     GazeboYarpPlugins::Handler::getHandler()->removeSensor(m_sensorName);
     yarp::os::Network::fini();

--- a/plugins/jointsensors/src/JointSensors.cc
+++ b/plugins/jointsensors/src/JointSensors.cc
@@ -26,7 +26,6 @@ GazeboYarpJointSensors::GazeboYarpJointSensors() : ModelPlugin(), m_iWrap(0)
 
 GazeboYarpJointSensors::~GazeboYarpJointSensors()
 {
-    std::cout << "*** GazeboYarpJointSensors closing ***" << std::endl;
     if (m_iWrap) {
         m_iWrap->detachAll();
         m_iWrap = 0;
@@ -46,7 +45,6 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
        std::cerr << "GazeboYarpJointSensors::Load error: yarp network does not seem to be available, is the yarpserver running?" << std::endl;
        return;
     }
-    std::cout << "*** GazeboYarpJointSensors plugin started ***" << std::endl;
 
     if (!_parent) {
         gzerr << "GazeboYarpJointSensors plugin requires a parent.\n";
@@ -80,9 +78,7 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
     //Open the wrapper
     //Force the wrapper to be of type "analogServer" (it make sense? probably no)
     wrapper_properties.put("device","analogServer");
-    if (m_jointsensorsWrapper.open(wrapper_properties)) {
-        std::cout << "GazeboYarpJointSensors Plugin: correcly opened GazeboYarpJointSensorsDriver wrapper" << std::endl;
-    } else {
+    if (!m_jointsensorsWrapper.open(wrapper_properties)) {
         std::cout << "GazeboYarpJointSensors Plugin failed: error in opening yarp driver wrapper" << std::endl;
         return;
     }
@@ -90,9 +86,7 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
     //Open the driver
     //Force the device to be of type "gazebo_jointsensors" (it make sense? probably yes)
     driver_properties.put("device","gazebo_jointsensors");
-    if (m_jointsensorsDriver.open(driver_properties)) {
-        std::cout << "GazeboYarpJointSensors Plugin: correcly opened GazeboYarpJointSensorsDriver" << std::endl;
-    } else {
+    if (!m_jointsensorsDriver.open(driver_properties)) {
         std::cout << "GazeboYarpJointSensors Plugin failed: error in opening yarp driver" << std::endl;
         return;
     }
@@ -108,7 +102,6 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
     driver_list.push(&m_jointsensorsDriver, "dummy");
 
     if (m_iWrap->attachAll(driver_list)) {
-        std::cerr << "GazeboYarpJointSensors : wrapper was connected with driver " << std::endl;
     } else {
         std::cerr << "GazeboYarpJointSensors : error in connecting wrapper and device " << std::endl;
     }


### PR DESCRIPTION
The unnecessary output renders the users unable to see the real warnings and/or errors.

The reaming outputs should then be migrate to yarp/gazebo specific streams, see https://github.com/robotology/gazebo-yarp-plugins/issues/87 . 

cc @francesco-romano @barbalberto @EnricoMingo 