### PR TITLE
Implemented (set/get)TorquePid(s) methods

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -389,6 +389,7 @@ private:
     std::vector<GazeboYarpControlBoardDriver::PID> m_positionPIDs;
     std::vector<GazeboYarpControlBoardDriver::PID> m_velocityPIDs;
     std::vector<GazeboYarpControlBoardDriver::PID> m_impedancePosPDs;
+    std::vector<GazeboYarpControlBoardDriver::PID> m_torquePIDs;
 
     yarp::sig::Vector m_torqueOffsett;
     yarp::sig::Vector m_minStiffness;

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -53,6 +53,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_positionPIDs.reserve(m_numberOfJoints);
     m_velocityPIDs.reserve(m_numberOfJoints);
     m_impedancePosPDs.reserve(m_numberOfJoints);
+    m_torquePIDs.resize(m_numberOfJoints);
     m_torqueOffsett.resize(m_numberOfJoints);
     m_minStiffness.resize(m_numberOfJoints, 0.0);
     m_maxStiffness.resize(m_numberOfJoints, 1000.0);

--- a/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
@@ -73,17 +73,58 @@ bool GazeboYarpControlBoardDriver::getTorques(double* t)
     return true;
 }
 
+bool GazeboYarpControlBoardDriver::setTorquePid(int joint, const Pid &pid)
+{
+    if (joint < 0 || joint >= m_numberOfJoints) return false;
+    PID &currentPid = m_torquePIDs[joint];
+    currentPid.p = pid.kp;
+    currentPid.d = pid.kd;
+    currentPid.i = pid.ki;
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::setTorquePids(const Pid *newPids)
+{
+    for (unsigned i = 0; i < m_numberOfJoints; ++i) {
+        PID &currentPid = m_torquePIDs[i];
+        currentPid.p = newPids[i].kp;
+        currentPid.d = newPids[i].kd;
+        currentPid.i = newPids[i].ki;
+    }
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::getTorquePid(int joint, Pid *pid)
+{
+    if (joint < 0 || joint >= m_numberOfJoints) return false;
+    if (!pid) return false;
+    PID &currentPid = m_torquePIDs[joint];
+    pid->kp = currentPid.p;
+    pid->kd = currentPid.d;
+    pid->ki = currentPid.i;
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::getTorquePids(Pid *pids)
+{
+    if (!pids) return false;
+    for (unsigned j = 0; j < m_numberOfJoints; ++j) {
+        PID &currentPid = m_torquePIDs[j];
+        pids[j].kp = currentPid.p;
+        pids[j].kd = currentPid.d;
+        pids[j].ki = currentPid.i;
+    }
+    return true;
+}
+
 bool GazeboYarpControlBoardDriver::getTorqueRange(int, double*, double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorqueRanges(double *, double *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::setTorquePids(const Pid *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::setTorqueErrorLimit(int , double ){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::setTorqueErrorLimits(const double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorqueError(int , double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorqueErrors(double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorquePidOutput(int , double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorquePidOutputs(double *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::getTorquePid(int , Pid *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::getTorquePids(Pid *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorqueErrorLimit(int , double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getTorqueErrorLimits(double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::resetTorquePid(int ){return false;} //NOT IMPLEMENTED
@@ -92,4 +133,3 @@ bool GazeboYarpControlBoardDriver::enableTorquePid(int ){return false;} //NOT IM
 bool GazeboYarpControlBoardDriver::setTorqueOffset(int , double ){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::getBemfParam(int , double *){return false;} //NOT IMPLEMENTED
 bool GazeboYarpControlBoardDriver::setBemfParam(int , double ){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::setTorquePid(int , const Pid &){return false;} //NOT IMPLEMENTED


### PR DESCRIPTION
These methods do nothing from the control point of view. They simplify the test of modules which needed them.
These values are just stored internally during the set and retrieved during the get.