### PR TITLE
References once & trajectory generation

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -372,6 +372,8 @@ private:
                                                  they can be set directly or indirectly
                                                  through the trajectory generator.
                                                  [Degrees] */
+    yarp::sig::Vector m_oldReferencePositions; // used to store last reference and check if a new ref has been commanded
+    yarp::sig::Vector m_positionThreshold;  // Threshold under which trajectory generator stops computing new values
 
     yarp::sig::Vector m_referenceTorques; /**< desired reference torques for torque control mode [NetwonMeters] */
     yarp::sig::Vector m_referenceVelocities; /**< desired reference velocities for velocity control mode [Degrees/Seconds] */

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -20,7 +20,8 @@ using namespace yarp::sig;
 using namespace yarp::dev;
 
 
-const double RobotPositionTolerance = 0.9;
+const double RobotPositionTolerance_revolute = 0.9;      // Degrees
+const double RobotPositionTolerance_linear   = 0.004;    // Meters
 
 GazeboYarpControlBoardDriver::GazeboYarpControlBoardDriver() : deviceName("") {}
 GazeboYarpControlBoardDriver::~GazeboYarpControlBoardDriver() {}
@@ -46,6 +47,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_torques.resize(m_numberOfJoints); m_torques.zero();
     m_trajectoryGenerationReferenceSpeed.resize(m_numberOfJoints);
     m_referencePositions.resize(m_numberOfJoints);
+    m_oldReferencePositions.resize(m_numberOfJoints);
     m_trajectoryGenerationReferencePosition.resize(m_numberOfJoints);
     m_trajectoryGenerationReferenceAcceleraton.resize(m_numberOfJoints);
     m_referenceTorques.resize(m_numberOfJoints);
@@ -59,13 +61,9 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_minDamping.resize(m_numberOfJoints, 0.0);
     m_maxDamping.resize(m_numberOfJoints, 100.0);
     m_jointTypes.resize(m_numberOfJoints);
+    m_positionThreshold.resize(m_numberOfJoints);
 
-    if(!configureJointType() )
-        return false;
-
-    setMinMaxPos();
-    setMinMaxImpedance();
-    setPIDs();
+    // Initial zeroing of all vectors
     m_positions.zero();
     m_zeroPosition.zero();
     m_referenceVelocities.zero();
@@ -76,16 +74,37 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_trajectoryGenerationReferenceAcceleraton.zero();
     m_referenceTorques.zero();
     amp = 1; // initially on - ok for simulator
-    started = false;
     m_controlMode = new int[m_numberOfJoints];
     m_interactionMode = new int[m_numberOfJoints];
     m_isMotionDone = new bool[m_numberOfJoints];
     m_clock = 0;
     m_torqueOffsett = 0;
+
     for (unsigned int j = 0; j < m_numberOfJoints; ++j)
+    {
         m_controlMode[j] = VOCAB_CM_POSITION;
-    for (unsigned int j = 0; j < m_numberOfJoints; ++j)
         m_interactionMode[j] = VOCAB_IM_STIFF;
+        m_jointTypes[j] = JointType_Unknown;
+        m_isMotionDone[j] = true;
+        // Set an old reference value surely out of range. This will force the setting of initial reference at startup
+        m_oldReferencePositions[j] = m_jointLimits[j].max *2;
+    }
+    // End zeroing of vectors
+
+    // This must be after zeroing of vectors
+    if(!configureJointType() )
+        return false;
+
+    setMinMaxPos();
+    for (unsigned int j = 0; j < m_numberOfJoints; ++j)
+    {
+        // Set an old reference value surely out of range. This will force the setting of initial reference at startup
+        // NOTE: This has to be after setMinMaxPos function
+        m_oldReferencePositions[j] = m_jointLimits[j].max *2;
+    }
+
+    setMinMaxImpedance();
+    setPIDs();
 
     this->m_updateConnection =
     gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpControlBoardDriver::onUpdate,
@@ -115,16 +134,11 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         }
         std::cout<<"INITIAL CONFIGURATION IS: "<<initial_config.toString()<<std::endl;
 
-        for (unsigned int i = 0; i < m_numberOfJoints; ++i) {
-#if GAZEBO_MAJOR_VERSION >= 4
-            m_jointPointers[i]->SetPosition(0,initial_config[i]);
-#else
-            gazebo::math::Angle a;
-            a.SetFromRadian(initial_config[i]);
-            m_jointPointers[i]->SetAngle(0,a);
-#endif
-        }
+        // Set initial reference
+        for (unsigned int j = 0; j < m_numberOfJoints; ++j)
+            sendPositionToGazebo (j, m_positions[j]);
     }
+
     return true;
 }
 
@@ -140,6 +154,7 @@ bool GazeboYarpControlBoardDriver::configureJointType()
             {
                 std::cout << "Joint type is HINGE_JOINT  (should correspond to revolute in the SDF)" << std::endl;
                 m_jointTypes[i] = JointType_Revolute;
+                m_positionThreshold[i] = RobotPositionTolerance_revolute;
                 break;
             }
 
@@ -147,6 +162,7 @@ bool GazeboYarpControlBoardDriver::configureJointType()
             {
                 std::cout << "Joint type is SLIDER_JOINT (should correspond to prismatic in the SDF)" << std::endl;
                 m_jointTypes[i] = JointType_Prismatic;
+                m_positionThreshold[i] = RobotPositionTolerance_linear;
                 break;
             }
 
@@ -164,17 +180,34 @@ bool GazeboYarpControlBoardDriver::configureJointType()
 
 void GazeboYarpControlBoardDriver::computeTrajectory(const int j)
 {
-    if ((m_referencePositions[j] - m_trajectoryGenerationReferencePosition[j]) < -RobotPositionTolerance) {
-        if (m_trajectoryGenerationReferenceSpeed[j] !=0)
-            m_referencePositions[j] += (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod * _T_controller;
-        m_isMotionDone[j] = false;
-    } else if ((m_referencePositions[j] - m_trajectoryGenerationReferencePosition[j]) > RobotPositionTolerance) {
-        if (m_trajectoryGenerationReferenceSpeed[j] != 0)
-            m_referencePositions[j]-= (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod * _T_controller;
-        m_isMotionDone[j] = false;
-    } else {
-        m_referencePositions[j] = m_trajectoryGenerationReferencePosition[j];
-        m_isMotionDone[j] = true;
+
+    double step = (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod * _T_controller;
+    double error_abs = fabs(m_referencePositions[j] - m_trajectoryGenerationReferencePosition[j]);
+
+    // if delta is bigger then threshold, in some cases this will never converge to an end.
+    // Check to prevent those cases
+    if(error_abs)
+    {
+        // Watch out for problem
+        if((error_abs < m_positionThreshold[j]) || ( error_abs < step) )    // This id both 'normal ending condition' and safe procedure when step > threshold causing infinite oscillation around final position
+        {
+            // Just go to final position
+            m_referencePositions[j] = m_trajectoryGenerationReferencePosition[j];
+            m_isMotionDone[j] = true;
+            return;
+        }
+
+        if (m_trajectoryGenerationReferencePosition[j] > m_referencePositions[j])
+        {
+            m_referencePositions[j] += step;
+            m_isMotionDone[j] = false;
+        }
+        else
+        {
+            m_referencePositions[j] -= step;
+            m_isMotionDone[j] = false;
+        }
+
     }
 }
 
@@ -182,11 +215,6 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _i
 {
     m_clock++;
 
-    if (!started) {//This is a simple way to start with the robot in standing position
-        started = true;
-        for (unsigned int j = 0; j < m_numberOfJoints; ++j)
-            sendPositionToGazebo (j, m_positions[j]);
-    }
 
     // Sensing position & torque
     for (unsigned int jnt_cnt = 0; jnt_cnt < m_jointPointers.size(); jnt_cnt++) {
@@ -404,9 +432,15 @@ bool GazeboYarpControlBoardDriver::sendPositionsToGazebo(Vector &refs)
 bool GazeboYarpControlBoardDriver::sendPositionToGazebo(int j,double ref)
 {
     gazebo::msgs::JointCmd j_cmd;
-    prepareJointMsg(j_cmd,j,ref);
-    m_jointCommandPublisher->WaitForConnection();
-    m_jointCommandPublisher->Publish(j_cmd);
+
+    if(ref != m_oldReferencePositions[j])
+    {
+        // std::cout << "Sending new command: new ref is " << ref << "; old ref was " << m_oldReferencePositions[j] << std::endl;
+        prepareJointMsg(j_cmd,j,ref);
+        m_jointCommandPublisher->WaitForConnection();
+        m_jointCommandPublisher->Publish(j_cmd);
+        m_oldReferencePositions[j] = ref;
+    }
     return true;
 }
 

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -159,7 +159,6 @@ bool GazeboYarpControlBoardDriver::configureJointType()
         {
             case ( gazebo::physics::Entity::HINGE_JOINT  |  gazebo::physics::Entity::JOINT):
             {
-                std::cout << "Joint type is HINGE_JOINT  (should correspond to revolute in the SDF)" << std::endl;
                 m_jointTypes[i] = JointType_Revolute;
                 m_positionThreshold[i] = RobotPositionTolerance_revolute;
                 break;
@@ -167,7 +166,6 @@ bool GazeboYarpControlBoardDriver::configureJointType()
 
             case ( gazebo::physics::Entity::SLIDER_JOINT |  gazebo::physics::Entity::JOINT):
             {
-                std::cout << "Joint type is SLIDER_JOINT (should correspond to prismatic in the SDF)" << std::endl;
                 m_jointTypes[i] = JointType_Prismatic;
                 m_positionThreshold[i] = RobotPositionTolerance_linear;
                 break;

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -34,11 +34,11 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     assert(m_robot);
     if (!m_robot) return false;
 
-    // this function also fills in the m_jointPointers vector
     this->m_robotRefreshPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
-    if (!setJointNames()) return false;
+    if (!setJointNames()) return false;      // this function also fills in the m_jointPointers vector
 
     m_numberOfJoints = m_jointNames.size();
+
     m_positions.resize(m_numberOfJoints);
     m_zeroPosition.resize(m_numberOfJoints);
     m_referenceVelocities.resize(m_numberOfJoints);
@@ -116,8 +116,9 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
 
     _T_controller = 1;
 
-    std::stringstream ss(m_pluginParameters.find("initialConfiguration").toString());
-    if (!(m_pluginParameters.find("initialConfiguration") == "")) {
+    if(m_pluginParameters.check("initialConfiguration") )
+    {
+        std::stringstream ss(m_pluginParameters.find("initialConfiguration").toString());
         double tmp = 0.0;
         yarp::sig::Vector initial_config(m_numberOfJoints);
         unsigned int counter = 1;
@@ -562,7 +563,8 @@ double GazeboYarpControlBoardDriver::convertGazeboToUser(int joint, gazebo::math
 
         default:
         {
-            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported";
+            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported for axes " <<
+                                m_jointNames[joint] << " type is " << m_jointTypes[joint];
             break;
         }
     }
@@ -589,7 +591,8 @@ double GazeboYarpControlBoardDriver::convertGazeboToUser(int joint, double value
 
         default:
         {
-            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported";
+            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported for axes " <<
+                                m_jointNames[joint] << " type is " << m_jointTypes[joint];
             break;
         }
     }
@@ -622,7 +625,7 @@ double GazeboYarpControlBoardDriver::convertUserToGazebo(int joint, double value
 
         default:
         {
-            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported";
+            yError() << "Cannot convert measure from User to Gazebo units, type of joint not supported";
             break;
         }
     }
@@ -681,7 +684,8 @@ double GazeboYarpControlBoardDriver::convertGazeboGainToUserGain(int joint, doub
 
         default:
         {
-            yError() << "Cannot convert measure from Gazebo to User units, type of joint not supported";
+            yError() << "Cannot convert measure from Gazebo gains to User gain units, type of joint not supported for axes " <<
+                                m_jointNames[joint] << " type is " << m_jointTypes[joint];
             break;
         }
     }

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -136,10 +136,16 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         std::cout<<"INITIAL CONFIGURATION IS: "<<initial_config.toString()<<std::endl;
 
         // Set initial reference
-        for (unsigned int j = 0; j < m_numberOfJoints; ++j)
-            sendPositionToGazebo (j, m_positions[j]);
+        for (unsigned int i = 0; i < m_numberOfJoints; ++i) {
+#if GAZEBO_MAJOR_VERSION >= 4
+            m_jointPointers[i]->SetPosition(0,initial_config[i]);
+#else
+            gazebo::math::Angle a;
+            a.SetFromRadian(initial_config[i]);
+            m_jointPointers[i]->SetAngle(0,a);
+#endif
+        }
     }
-
     return true;
 }
 


### PR DESCRIPTION
Thi PR aims to fix a problem on trajectories and improve the way references are sent to Gazebo internal simulation core in the following ways:

- If there is no new reference does not publish new ref to Gazebo. This is required for
  CER robot because 2 plugins will use the same Gazebo Joint and otherwise they will
  always conflict onto each other

- Previous trajectory generator had the following problem: if vel is very high and threshold to stop the   generator very small it could happend that the minimum increment step is higher than the threshold used
to  stop the trajectory. In this case it'll oscillate around the final position but never converge.

- Also uses new way of setting position references to set initial configuration

