### PR TITLE
Fix gazebo7

### DIFF
--- a/libraries/singleton/src/ConfHelpers.cc
+++ b/libraries/singleton/src/ConfHelpers.cc
@@ -85,11 +85,20 @@ bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
     // Prefill the property object with some gazebo-yarp-plugins "Enviromental Variables"
     // (not using the env variable in fromConfigFile(const ConstString& fname, Searchable& env, bool wipe)
     // method because we want the variable defined here to be overwritable by the user configuration file
+#if GAZEBO_MAJOR_VERSION >= 7
+    std::string gazeboYarpPluginsSensorName = _sensor->Name();
+#else
     std::string gazeboYarpPluginsSensorName = _sensor->GetName();
+#endif
     plugin_parameters.put("gazeboYarpPluginsSensorName",gazeboYarpPluginsSensorName.c_str());
 
     // Extract the robot name from the sensor scoped name
+#if GAZEBO_MAJOR_VERSION >= 7
+    std::string scopedSensorName = _sensor->ScopedName();
+#else
     std::string scopedSensorName = _sensor->GetScopedName();
+#endif
+
     std::vector<std::string> explodedScopedSensorName = splitString(scopedSensorName,":");
 
     // The vector should be at least of 3 elements because
@@ -119,10 +128,18 @@ bool loadConfigSensorPlugin(sensors::SensorPtr _sensor,
         GazeboYarpPlugins::addGazeboEnviromentalVariablesSensor(_sensor,_sdf,plugin_parameters);
 
         bool wipe = false;
-        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe)) {
+        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe))
+        {
             return true;
-        } else {
-            std::cerr << "GazeboYarpPlugins error: failure in loading configuration for sensor " << _sensor->GetName() << std::endl
+        }
+        else
+        {
+#if GAZEBO_MAJOR_VERSION >= 7
+    std::string sensorName = _sensor->Name();
+#else
+    std::string sensorName = _sensor->GetName();
+#endif
+            std::cerr << "GazeboYarpPlugins error: failure in loading configuration for sensor " << sensorName << std::endl
                       << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << std::endl
                       << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path << std::endl;
             return false;

--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -99,8 +99,11 @@ void Handler::removeRobot(const std::string& robotName)
 bool Handler::setSensor(gazebo::sensors::Sensor* _sensor)
 {
     bool ret = false;
+#if GAZEBO_MAJOR_VERSION >= 7
+    std::string scopedSensorName = _sensor->ScopedName();
+#else
     std::string scopedSensorName = _sensor->GetScopedName();
-
+#endif
     SensorsMap::iterator sensor = m_sensorsMap.find(scopedSensorName);
     if (sensor != m_sensorsMap.end()) {
         //sensor already exists. Increment reference counting

--- a/plugins/camera/src/Camera.cc
+++ b/plugins/camera/src/Camera.cc
@@ -57,7 +57,12 @@ void GazeboYarpCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
         return;
     }
 
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
     m_sensorName = _sensor->GetScopedName();
+#endif
+
     m_sensor = (gazebo::sensors::CameraSensor*)_sensor.get();
     if(m_sensor == NULL)
     {

--- a/plugins/camera/src/CameraDriver.cpp
+++ b/plugins/camera/src/CameraDriver.cpp
@@ -109,15 +109,26 @@ bool GazeboYarpCameraDriver::open(yarp::os::Searchable& config)
     if (config.check("display_timestamp")) m_display_timestamp =true;
     if (config.check("display_time_box")) m_display_time_box =true;
 
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_camera = m_parentSensor->Camera();
+#else
     m_camera = m_parentSensor->GetCamera();
+#endif
+
     if(m_camera == NULL)
     {
         std::cout << "GazeboYarpCameraDriver Error: camera pointer not valid" << std::endl;
         return false;
     }
 
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_width  = m_camera->ImageWidth();
+    m_height = m_camera->ImageHeight();
+#else
     m_width  = m_camera->GetImageWidth();
     m_height = m_camera->GetImageHeight();
+#endif
+
     m_bufferSize = 3*m_width*m_height;
 
     m_dataMutex.wait();
@@ -154,10 +165,18 @@ bool GazeboYarpCameraDriver::captureImage(const unsigned char *_image,
                           unsigned int _depth, const std::string &_format)
 {
     m_dataMutex.wait();
+
+#if GAZEBO_MAJOR_VERSION >= 7
+    if(m_parentSensor->IsActive())
+        memcpy(m_imageBuffer, m_parentSensor->ImageData(), m_bufferSize);
+
+    m_lastTimestamp.update(this->m_parentSensor->LastUpdateTime().Double());
+#else
     if(m_parentSensor->IsActive())
         memcpy(m_imageBuffer, m_parentSensor->GetImageData(), m_bufferSize);
 
     m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
+#endif
 
     if (m_display_timestamp)
     {

--- a/plugins/depthCamera/include/yarp/dev/DepthCameraDriver.h
+++ b/plugins/depthCamera/include/yarp/dev/DepthCameraDriver.h
@@ -267,9 +267,10 @@ private:
     unsigned char  *m_RGBPointCloud_Buffer;
     int counter;
 
+#if GAZEBO_MAJOR_VERSION < 7
     gazebo::sensors::CameraSensor*       m_imageCameraSensorPtr;
     gazebo::rendering::CameraPtr         m_imageCameraPtr;
-
+#endif
     gazebo::sensors::DepthCameraSensor*  m_depthCameraSensorPtr;
     gazebo::rendering::DepthCameraPtr    m_depthCameraPtr;
 

--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -60,7 +60,11 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
         return;
     }
 
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
     m_sensorName = _sensor->GetScopedName();
+#endif
     m_sensor = (gazebo::sensors::DepthCameraSensor*)_sensor.get();
     if(m_sensor == NULL)
     {

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -188,22 +188,21 @@ bool GazeboYarpDepthCameraDriver::OnNewImageFrame(const unsigned char *_image,
 //                     "\n\t_depth is " << _depth     <<
 //                     "\n\t_format is " << _format   << std::endl;
 
-
-#if GAZEBO_MAJOR_VERSION >= 7
     m_colorFrameMutex.wait();
+
+    #if GAZEBO_MAJOR_VERSION >= 7
     if(m_depthCameraSensorPtr->IsActive())
         memcpy(m_imageFrame_Buffer, m_depthCameraPtr->ImageData(), m_imageFrame_BufferSize);
 
     m_colorTimestamp.update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
-    m_colorFrameMutex.post();
 #else
-    m_colorFrameMutex.wait();
     if(m_imageCameraSensorPtr->IsActive())
         memcpy(m_imageFrame_Buffer, m_imageCameraSensorPtr->GetImageData(), m_imageFrame_BufferSize);
 
     m_colorTimestamp.update(this->m_imageCameraSensorPtr->GetLastUpdateTime().Double());
-    m_colorFrameMutex.post();
 #endif
+
+    m_colorFrameMutex.post();
     return true;
 }
 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -34,6 +34,15 @@ GazeboYarpDepthCameraDriver::GazeboYarpDepthCameraDriver()
     m_depthCameraSensorPtr = 0;
     m_depthCameraPtr       = 0;
 
+    m_depthFrame_Buffer     = 0;
+    m_depthFrame_BufferSize = 0;
+    m_imageFrame_Buffer     = 0;
+    m_imageFrame_BufferSize = 0;
+
+    // point cloud stuff is not used yet
+    m_RGBPointCloud_Buffer = 0;
+    m_RGBPointCloud_BufferSize = 0;
+
     m_updateDepthFrame_Connection = 0;
     m_updateRGBPointCloud_Connection = 0;
     m_updateImageFrame_Connection = 0;
@@ -148,15 +157,18 @@ bool GazeboYarpDepthCameraDriver::close()
 #endif
     m_depthCameraSensorPtr = NULL;
 
-    delete[] m_depthFrame_Buffer;
+    if(m_depthFrame_Buffer)
+        delete[] m_depthFrame_Buffer;
     m_depthFrame_Buffer = 0;
     m_depthFrame_BufferSize = 0;
 
-    delete[] m_imageFrame_Buffer;
+    if(m_imageFrame_Buffer)
+        delete[] m_imageFrame_Buffer;
     m_imageFrame_Buffer = 0;
     m_imageFrame_BufferSize = 0;
 
-    delete[] m_RGBPointCloud_Buffer;
+    if(m_RGBPointCloud_Buffer)
+        delete[] m_RGBPointCloud_Buffer;
     m_RGBPointCloud_Buffer = 0;
     m_RGBPointCloud_BufferSize = 0;
 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -55,7 +55,7 @@ bool GazeboYarpDepthCameraDriver::open(yarp::os::Searchable &config)
     std::cout << "GazeboYarpDepthCameraDriver::open() " << sensorScopedName << std::endl;
 
 #if GAZEBO_MAJOR_VERSION < 7
-    m_imageCameraSensorPtr = dynamic_cast<gazebo::sensors::CameraSensor*> (GazeboYarpPlugins::Handler::getHandler()->getSensor(sensorScopedName));
+    m_imageCameraSensorPtr = (gazebo::sensors::CameraSensor*) (GazeboYarpPlugins::Handler::getHandler()->getSensor(sensorScopedName));
     if (!m_imageCameraSensorPtr) {
         std::cout << "GazeboYarpDepthCameraDriver Error: camera sensor was not found" << std::endl;
         return false;
@@ -63,7 +63,7 @@ bool GazeboYarpDepthCameraDriver::open(yarp::os::Searchable &config)
     m_imageCameraPtr = m_imageCameraSensorPtr->GetCamera();
 #endif
 
-    m_depthCameraSensorPtr = (gazebo::sensors::DepthCameraSensor*)GazeboYarpPlugins::Handler::getHandler()->getSensor(sensorScopedName);
+    m_depthCameraSensorPtr = dynamic_cast<gazebo::sensors::DepthCameraSensor*> (GazeboYarpPlugins::Handler::getHandler()->getSensor(sensorScopedName));
     if (!m_depthCameraSensorPtr) {
         std::cout << "GazeboYarpDepthCameraDriver Error: camera sensor was not found" << std::endl;
         return false;

--- a/plugins/forcetorque/src/ForceTorque.cc
+++ b/plugins/forcetorque/src/ForceTorque.cc
@@ -71,8 +71,11 @@ void GazeboYarpForceTorque::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     {
         return;
     }
-
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
     m_sensorName = _sensor->GetScopedName();
+#endif
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 

--- a/plugins/forcetorque/src/ForceTorqueDriver.cpp
+++ b/plugins/forcetorque/src/ForceTorqueDriver.cpp
@@ -38,7 +38,11 @@ void GazeboYarpForceTorqueDriver::onUpdate(const gazebo::common::UpdateInfo& /*_
 
     /** \todo ensure that the timestamp is the right one */
     /** \todo TODO use GetLastMeasureTime, not GetLastUpdateTime */
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_lastTimestamp.update(this->m_parentSensor->LastUpdateTime().Double());
+#else
     m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
+#endif
 
     m_dataMutex.wait();
 

--- a/plugins/imu/src/IMU.cc
+++ b/plugins/imu/src/IMU.cc
@@ -55,8 +55,11 @@ void GazeboYarpIMU::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
     if (!configuration_loaded) {
         return;
     }
-
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
     m_sensorName = _sensor->GetScopedName();
+#endif
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 

--- a/plugins/imu/src/IMUDriver.cpp
+++ b/plugins/imu/src/IMUDriver.cpp
@@ -45,8 +45,11 @@ void GazeboYarpIMUDriver::onUpdate(const gazebo::common::UpdateInfo &/*_info*/)
 #endif
 
     /** \todo TODO ensure that the timestamp is the right one */
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_lastTimestamp.update(this->m_parentSensor->LastUpdateTime().Double());
+#else
     m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
-
+#endif
     m_dataMutex.wait();
 
     for (unsigned i = 0; i < 3; i++) {

--- a/plugins/lasersensor/src/LaserSensor.cc
+++ b/plugins/lasersensor/src/LaserSensor.cc
@@ -71,7 +71,11 @@ void GazeboYarpLaserSensor::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     ///< \todo TODO handle in a better way the parameters that are for the wrapper and the one that are for driver
     wrapper_properties = driver_properties;
 
+    #if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
     m_sensorName = _sensor->GetScopedName();
+#endif
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -29,12 +29,16 @@ GazeboYarpLaserSensorDriver::~GazeboYarpLaserSensorDriver() {}
 void GazeboYarpLaserSensorDriver::onUpdate(const gazebo::common::UpdateInfo& /*_info*/)
 {   
     yarp::os::LockGuard guard(m_mutex);
-    
+
     /** \todo ensure that the timestamp is the right one */
     /** \todo TODO use GetLastMeasureTime, not GetLastUpdateTime */
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_lastTimestamp.update(this->m_parentSensor->LastUpdateTime().Double());
+    this->m_parentSensor->Ranges(m_sensorData);
+#else
     m_lastTimestamp.update(this->m_parentSensor->GetLastUpdateTime().Double());
-
     this->m_parentSensor->GetRanges(m_sensorData);
+#endif
 
     return;
 }


### PR DESCRIPTION
Update plugins to Gazebo 7:

- Fix crash of depthCamera on Gazebo7.
- Substitute all deprecated functions with new version.