### PR TITLE
Add multicamera plugin

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(forcetorque)
 add_subdirectory(imu)
 add_subdirectory(jointsensors)
 add_subdirectory(showmodelcom)
+add_subdirectory(multicamera)
 
 find_package(OpenCV QUIET)
 option(GAZEBO_YARP_PLUGINS_HAS_OPENCV "Compile plugins that depend on OpenCV" ${OpenCV_FOUND})

--- a/plugins/multicamera/CMakeLists.txt
+++ b/plugins/multicamera/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (C) 2007-2015 Istituto Italiano di Tecnologia ADVR & iCub Facility & RBCS Department
+# Authors: Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro, Alessandro Settimi and Francesco Romano
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+cmake_minimum_required(VERSION 2.8.7)
+
+project(Plugin_MultiCamera)
+
+include(AddGazeboYarpPluginTarget)
+
+set(LIB_COMMON_NAME gazebo_yarp_lib_common)
+if(CMAKE_VERSION VERSION_LESS 3.0.0)
+    get_property(GAZEBO_YARP_COMMON_HEADERS GLOBAL PROPERTY GAZEBO_YARP_COMMON_HEADERS)
+    unset(LIB_COMMON_NAME)
+endif()
+
+include_directories(/usr/local/src/robot/gazebo-yarp-plugins/libraries/singleton/include)
+
+add_gazebo_yarp_plugin_target(LIBRARY_NAME MultiCameraPlugin
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                              INCLUDE_DIRS include
+                              SYSTEM_INCLUDE_DIRS ${GAZEBO_INCLUDE_DIRS}
+                                                  ${Boost_INCLUDE_DIRS}
+                              LINKED_LIBRARIES ${GAZEBO_LIBRARIES}
+                                               ${Boost_LIBRARIES}
+                              HEADERS include/gazebo/plugins/MultiCameraPlugin.hh
+                              SOURCES src/MultiCameraPlugin.cpp)
+
+add_gazebo_yarp_plugin_target(LIBRARY_NAME multicamera
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                              INCLUDE_DIRS include
+                              SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS}
+                                                  ${YARP_INCLUDE_DIRS}
+                                                  ${Boost_INCLUDE_DIRS}
+                                                  ${GAZEBO_INCLUDE_DIRS}
+                                                  ${SDFORMAT_INCLUDE_DIRS}
+                                                  ${PROTOBUF_INCLUDE_DIRS}
+                                                  ${OGRE_INCLUDE_DIRS}
+                              LINKED_LIBRARIES ${LIB_COMMON_NAME}
+                                               gazebo_yarp_singleton
+                                               gazebo_yarp_MultiCameraPlugin
+                                               ${YARP_LIBRARIES}
+                                               ${GAZEBO_LIBRARIES}
+                                               ${Boost_LIBRARIES}
+                              HEADERS include/gazebo/MultiCamera.hh
+                                      include/yarp/dev/MultiCameraDriver.h
+                              SOURCES src/MultiCamera.cc
+                                      src/MultiCameraDriver.cpp)

--- a/plugins/multicamera/include/gazebo/MultiCamera.hh
+++ b/plugins/multicamera/include/gazebo/MultiCamera.hh
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+
+#ifndef GAZEBOYARP_MULTICAMERA_HH
+#define GAZEBOYARP_MULTICAMERA_HH
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/plugins/MultiCameraPlugin.hh>
+#include <yarp/dev/PolyDriver.h>
+
+#include <yarp/dev/FrameGrabberInterfaces.h>
+
+#include <string>
+
+namespace gazebo
+{
+    namespace sensors {
+        class MultiMultiCameraSensor;
+    }
+
+    /// \class GazeboYarpMultiCamera
+    /// Gazebo Plugin reading from the Gazebo MultiCamera plugin.
+    ///
+    /// This plugin instantiate a yarp camera driver for the Gazebo simulator
+    /// and instantiate a network wrapper (provided by yarp::dev::ServerFrameGrabbers)
+    /// to expose the sensor on the yarp network.
+    ///
+    /// It can be configurated using the yarpConfigurationFile sdf tag,
+    /// that contains a Gazebo URI pointing at a yarp .ini configuration file
+    ///
+    /// The parameter that the yarpConfigurationFile must contain are:
+    ///  <TABLE>
+    ///  <TR><TD> name </TD><TD> Port name to assign to the wrapper to this device. </TD></TR>
+    ///  <TR><TD> period </TD><TD> Update period (in s) of yarp port that publish the measure. </TD></TR>
+    ///  </TABLE>
+    /// If the required parameters are not specified, their value will be the
+    /// default one assigned by the yarp::dev::ServerFrameGrabbers wrapper.
+    ///
+    class GazeboYarpMultiCamera : public MultiCameraPlugin
+    {
+    public:
+        GazeboYarpMultiCamera();
+        virtual ~GazeboYarpMultiCamera();
+        virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
+
+    private:
+        yarp::os::Property m_parameters; 
+        yarp::dev::PolyDriver m_cameraDriver;
+        std::string m_sensorName;
+        sensors::MultiCameraSensor *m_sensor;
+
+        yarp::dev::IFrameGrabberImage*      iFrameGrabberImage;
+    };
+}
+
+
+
+#endif  // GAZEBOYARP_MULTICAMERA_HH

--- a/plugins/multicamera/include/gazebo/MultiCamera.hh
+++ b/plugins/multicamera/include/gazebo/MultiCamera.hh
@@ -18,10 +18,6 @@
 
 namespace gazebo
 {
-    namespace sensors {
-        class MultiMultiCameraSensor;
-    }
-
     /// \class GazeboYarpMultiCamera
     /// Gazebo Plugin reading from the Gazebo MultiCamera plugin.
     ///

--- a/plugins/multicamera/include/gazebo/plugins/MultiCameraPlugin.hh
+++ b/plugins/multicamera/include/gazebo/plugins/MultiCameraPlugin.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _GAZEBO_MULTI_CAMERA_PLUGIN_HH_
+#define _GAZEBO_MULTI_CAMERA_PLUGIN_HH_
+
+#include <string>
+#include <vector>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/sensors/MultiCameraSensor.hh>
+#include <gazebo/rendering/Camera.hh>
+#include <gazebo/gazebo.hh>
+
+namespace gazebo
+{
+  class MultiCameraPlugin : public SensorPlugin
+  {
+    public: MultiCameraPlugin();
+
+    /// \brief Destructor
+    public: virtual ~MultiCameraPlugin();
+
+    public: virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
+
+    public: virtual void OnNewFrameLeft(const unsigned char *_image,
+                              unsigned int _width, unsigned int _height,
+                              unsigned int _depth, const std::string &_format);
+    public: virtual void OnNewFrameRight(const unsigned char *_image,
+                              unsigned int _width, unsigned int _height,
+                              unsigned int _depth, const std::string &_format);
+
+    protected: sensors::MultiCameraSensorPtr parentSensor;
+
+    protected: std::vector<unsigned int> width, height, depth;
+    protected: std::vector<std::string> format;
+
+    protected: std::vector<rendering::CameraPtr> camera;
+
+    private: std::vector<event::ConnectionPtr> newFrameConnection;
+  };
+}
+#endif

--- a/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
+++ b/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro, Alessandro Settimi, Marco Randazzo, and Daniele E. Domenichelli
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_MULTICAMERADRIVER_H
+#define GAZEBOYARP_MULTICAMERADRIVER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/os/Semaphore.h>
+#include <yarp/os/Time.h>
+
+#include <boost/shared_ptr.hpp>
+#include <gazebo/rendering/Camera.hh>
+#include <gazebo/sensors/MultiCameraSensor.hh>
+
+
+//Forward declarations
+namespace yarp {
+    namespace dev {
+        class GazeboYarpMultiCameraDriver;
+    }
+}
+
+namespace gazebo {
+    namespace common {
+        class UpdateInfo;
+    }
+    namespace sensors {
+        class MultiCameraSensor;
+    }
+    namespace event {
+        class Connection;
+        typedef boost::shared_ptr<Connection> ConnectionPtr;
+    }
+}
+
+extern const std::string YarpScopedName;
+
+class yarp::dev::GazeboYarpMultiCameraDriver:
+    virtual public yarp::dev::DeviceDriver,
+    virtual public yarp::dev::IFrameGrabberImage,
+    virtual public yarp::dev::IPreciselyTimed
+{
+public:
+    GazeboYarpMultiCameraDriver();
+
+    virtual ~GazeboYarpMultiCameraDriver();
+
+    /**
+     * Yarp interfaces start here
+     */
+
+    // yarp::dev::DeviceDriver
+    virtual bool open(yarp::os::Searchable& config);
+    virtual bool close();
+
+    // yarp::dev::IPreciselyTimed
+    virtual yarp::os::Stamp getLastInputStamp();
+
+    // yarp::dev::IFrameGrabberImage
+    virtual bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image);
+    virtual int height() const;
+    virtual int width() const;
+
+
+    /*
+     * Get the image from the simulator and store it internally
+     */
+    virtual bool captureImage(unsigned int _camera,
+                              const unsigned char *_image,
+                              unsigned int _width,
+                              unsigned int _height,
+                              unsigned int _depth,
+                              const std::string &_format);
+
+private:
+    static double start_time;
+
+    unsigned int m_camera_count;
+
+    std::vector<int> m_width;
+    std::vector<int> m_height;
+    std::vector<int> m_bufferSize;
+
+    int m_max_width;
+    int m_max_height;
+
+    bool m_vertical_flip;
+    bool m_horizontal_flip;
+    bool m_display_time_box;
+    bool m_display_timestamp;
+    bool m_vertical;
+
+    std::vector<yarp::os::Stamp> m_lastTimestamp; // buffer for last timestamp data
+    std::vector<yarp::os::Semaphore*> m_dataMutex; // mutex for accessing the data
+
+    std::vector<unsigned char*> m_imageBuffer;
+    int m_counter;
+
+    gazebo::sensors::MultiCameraSensor* m_parentSensor;
+    std::vector<gazebo::rendering::CameraPtr> m_camera;
+    std::vector<gazebo::event::ConnectionPtr> m_updateConnection;
+};
+
+#endif // GAZEBOYARP_MULTICAMERADRIVER_H

--- a/plugins/multicamera/src/MultiCamera.cc
+++ b/plugins/multicamera/src/MultiCamera.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+
+#include "gazebo/MultiCamera.hh"
+#include "yarp/dev/MultiCameraDriver.h"
+
+#include <GazeboYarpPlugins/Handler.hh>
+#include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
+
+#include <gazebo/sensors/MultiCameraSensor.hh>
+#include <gazebo/sensors/DepthCameraSensor.hh>
+#include <gazebo/sensors/CameraSensor.hh>
+
+#include <yarp/os/Network.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/dev/PolyDriver.h>
+
+
+GZ_REGISTER_SENSOR_PLUGIN(gazebo::GazeboYarpMultiCamera)
+
+
+namespace gazebo {
+
+GazeboYarpMultiCamera::GazeboYarpMultiCamera() :
+        MultiCameraPlugin()
+{
+}
+
+GazeboYarpMultiCamera::~GazeboYarpMultiCamera()
+{
+    this->m_cameraDriver.close();
+    GazeboYarpPlugins::Handler::getHandler()->removeSensor(this->m_sensorName);
+}
+
+void GazeboYarpMultiCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
+{
+    if (!yarp::os::NetworkBase::checkNetwork(GazeboYarpPlugins::yarpNetworkInitializationTimeout)) {
+        yError() << "GazeboYarpMultiCamera::Load error: yarp network does not seem to be available, is the yarpserver running?";
+        return;
+    }
+
+    MultiCameraPlugin::Load(_sensor, _sdf);
+
+    m_sensor = parentSensor.get();
+    yAssert(m_sensor != NULL);
+
+    // Add my gazebo device driver to the factory.
+    yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpMultiCameraDriver>
+                                      ("gazebo_multicamera", "grabber", "GazeboYarpMultiCameraDriver"));
+
+    //Getting .ini configuration file from sdf
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor, _sdf, m_parameters);
+
+    if (!configuration_loaded) {
+        yWarning() << "MultiCameraPlugin could not load configuration";
+        return;
+    }
+
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_sensorName = _sensor->ScopedName();
+#else
+    m_sensorName = _sensor->GetScopedName();
+#endif
+
+    yDebug() << "GazeboYarpMultiCamera Plugin: sensor scoped name is" << m_sensorName.c_str();
+    //Insert the pointer in the singleton handler for retriving it in the yarp driver
+    GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
+
+    m_parameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
+
+    //Open the driver
+    if (m_cameraDriver.open(m_parameters)) {
+        yInfo() << "Loaded GazeboYarpMultiCamera Plugin correctly";
+    } else {
+        yWarning() << "GazeboYarpMultiCamera Plugin Load failed: error in opening yarp driver";
+    }
+
+    m_cameraDriver.view(iFrameGrabberImage);
+    if(iFrameGrabberImage == NULL) {
+        yError() << "Unable to get the iFrameGrabberImage interface from the device";
+        return;
+    }
+}
+
+} // namespace gazebo

--- a/plugins/multicamera/src/MultiCameraDriver.cpp
+++ b/plugins/multicamera/src/MultiCameraDriver.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro, Alessandro Settimi, Marco Randazzo, and Daniele E. Domenichelli
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+
+#include "yarp/dev/MultiCameraDriver.h"
+
+#include <GazeboYarpPlugins/Handler.hh>
+#include <GazeboYarpPlugins/common.h>
+
+#include <gazebo/math/Vector3.hh>
+#include <gazebo/sensors/MultiCameraSensor.hh>
+
+#include <yarp/os/Value.h>
+#include <yarp/os/LogStream.h>
+
+#include <algorithm>
+
+const std::string YarpScopedName = "sensorScopedName";
+double yarp::dev::GazeboYarpMultiCameraDriver::start_time = 0;
+
+
+
+static void print(unsigned char* pixbuf, int pixbuf_w, int pixbuf_h, int x, int y, char* s, int size)
+{
+    int pixelsize = 5;
+    for (int i=0;i<size;i++) {
+        const char* num_p=0;
+        switch(s[i]) {
+            case '0' : num_p = "**** ** ** ****"; break;
+            case '1' : num_p = " *  *  *  *  * "; break;
+            case '2' : num_p = "***  *****  ***"; break;
+            case '3' : num_p = "***  ****  ****"; break;
+            case '4' : num_p = "* ** ****  *  *"; break;
+            case '5' : num_p = "****  ***  ****"; break;
+            case '6' : num_p = "****  **** ****"; break;
+            case '7' : num_p = "***  *  *  *  *"; break;
+            case '8' : num_p = "**** ***** ****"; break;
+            case '9' : num_p = "**** ****  ****"; break;
+            case ' ' : num_p = "               "; break;
+            case '.' : num_p = "          ** **"; break;
+            default: break;
+        }
+
+        for (int yi = 0; yi < 5; yi++) {
+            for (int xi = 0; xi < 3; xi++) {
+                int ii = yi * 3 + xi;
+                if (num_p[ii]=='*') {
+                    for (int r = yi * pixelsize; r < yi * pixelsize + pixelsize; r++) {
+                        int off = i * (pixelsize + 20);
+                        for (int c = xi * pixelsize + off; c < xi * pixelsize + pixelsize + off; c++) {
+                            unsigned char *pixel = pixbuf + c * 3 + r * (pixbuf_w * 3);
+                            pixel[0] = 0;
+                            pixel[1] = 0;
+                            pixel[2] = 255;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+yarp::dev::GazeboYarpMultiCameraDriver::GazeboYarpMultiCameraDriver() :
+            m_max_height(0),
+            m_max_width(0),
+            m_vertical_flip(false),
+            m_horizontal_flip(false),
+            m_display_time_box(false),
+            m_display_timestamp(false),
+            m_counter(0)
+{
+    start_time = yarp::os::Time::now();
+}
+
+
+yarp::dev::GazeboYarpMultiCameraDriver::~GazeboYarpMultiCameraDriver()
+{
+    yTrace();
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::open(yarp::os::Searchable& config)
+{
+    //Get gazebo pointers
+    std::string sensorScopedName(config.find(YarpScopedName.c_str()).asString().c_str());
+
+    m_parentSensor = (gazebo::sensors::MultiCameraSensor*)GazeboYarpPlugins::Handler::getHandler()->getSensor(sensorScopedName);
+    if (!m_parentSensor) {
+        std::cout << "GazeboYarpMultiCameraDriver Error: camera sensor was not found" << std::endl;
+        return false;
+    }
+
+    m_vertical_flip     = config.check("vertical_flip");
+    m_horizontal_flip   = config.check("horizontal_flip");
+    m_display_timestamp = config.check("display_timestamp");
+    m_display_time_box  = config.check("display_time_box");
+    m_vertical          = config.check("vertical");
+
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_camera_count = this->m_parentSensor->CameraCount();
+#else
+    m_camera_count = this->m_parentSensor->GetCameraCount();
+#endif
+
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+#if GAZEBO_MAJOR_VERSION >= 7
+        m_camera.push_back(m_parentSensor->Camera(i));
+#else
+        m_camera.push_back(m_parentSensor->GetCamera(i));
+#endif
+        if(m_camera[i] == NULL) {
+            yError() << "GazeboYarpMultiCameraDriver: camera" << i <<  "pointer is not valid";
+            return false;
+       }
+#if GAZEBO_MAJOR_VERSION >= 7
+        m_width.push_back(m_camera[i]->ImageWidth());
+        m_height.push_back(m_camera[i]->ImageHeight());
+#else
+        m_width.push_back(m_camera[i]->GetImageWidth());
+        m_height.push_back(m_camera[i]->GetImageHeight());
+#endif
+        m_max_width = std::max(m_max_width, m_width[i]);
+        m_max_height = std::max(m_max_height, m_height[i]);
+
+        m_bufferSize.push_back(3 * m_width[i] * m_height[i]);
+        m_dataMutex.push_back(new yarp::os::Semaphore());
+        m_dataMutex[i]->wait();
+        m_imageBuffer.push_back(new unsigned char[m_bufferSize[i]]);
+        memset(m_imageBuffer[i], 0x00, m_bufferSize[i]);
+        m_dataMutex[i]->post();
+
+        m_lastTimestamp.push_back(yarp::os::Stamp());
+    }
+
+    // Connect all the cameras only when everything is set up
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+        this->m_updateConnection.push_back(this->m_camera[i]->ConnectNewImageFrame(boost::bind(&yarp::dev::GazeboYarpMultiCameraDriver::captureImage, this, i, _1, _2, _3, _4, _5)));
+    }
+
+    return true;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::close()
+{
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+        if (this->m_updateConnection[i].get())
+        {
+            m_camera[i]->DisconnectNewImageFrame(this->m_updateConnection[i]);
+            this->m_updateConnection[i] = gazebo::event::ConnectionPtr();
+            m_parentSensor = NULL;
+        }
+        delete[] m_imageBuffer[i];
+        m_imageBuffer[i] = 0;
+        delete m_dataMutex[i];
+    }
+
+    return true;
+}
+
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::captureImage(unsigned int _camera,
+                                                          const unsigned char *_image,
+                                                          unsigned int _width,
+                                                          unsigned int _height,
+                                                          unsigned int _depth,
+                                                          const std::string &_format)
+{
+    m_dataMutex[_camera]->wait();
+
+    yAssert(_width  == m_width[_camera]);
+    yAssert(_height == m_height[_camera]);
+    // FIXME For now assume depth = 3 and format = "R8G8B8"
+    yAssert(_depth  == 3);
+    yAssert(_format == "R8G8B8");
+
+    int rowsize = _depth * _width;
+
+    if(m_parentSensor->IsActive()) {
+        if (m_vertical_flip == false && m_horizontal_flip == false) {
+            memcpy(m_imageBuffer[_camera], _image, m_bufferSize[_camera]);
+        } else if (m_vertical_flip == true && m_horizontal_flip == false) {
+           for (int r = 0; r < _height; r++) {
+               memcpy(m_imageBuffer[_camera] + (rowsize*r), _image + rowsize * (_height-r), rowsize);
+           }
+        } else if (m_vertical_flip == false && m_horizontal_flip == true) {
+            for (int r = 0; r < _height; r++) {
+                for (int c = 0; c < _width; c++) {
+                    memcpy(m_imageBuffer[_camera] + (rowsize*r) + (c*_depth), _image + rowsize * r + (_width-c-1) * _depth, _depth);
+                }
+            }
+        } else { // (m_vertical_flip == true && m_horizontal_flip == true)
+            for (int r = 0; r < _height; r++) {
+                for (int c = 0; c < _width; c++) {
+                    memcpy(m_imageBuffer[_camera] + (rowsize*r) + (c*_depth), _image + rowsize * (_height-r-1) + (_width-c-1) * _depth, _depth);
+                }
+            }
+        }
+    }
+
+#if GAZEBO_MAJOR_VERSION >= 7
+    m_lastTimestamp[_camera].update(this->m_parentSensor->LastUpdateTime().Double());
+#else
+    m_lastTimestamp[_camera].update(this->m_parentSensor->GetLastUpdateTime().Double());
+#endif
+
+    if (m_display_timestamp) {
+        char txtbuf[1000];
+        double time=yarp::os::Time::now()-start_time;
+        sprintf(txtbuf,"%.3f",time);
+        int len = strlen(txtbuf);
+        if (len < 20)
+            print(m_imageBuffer[_camera], _width, _height, 0, 0, txtbuf, len);
+    }
+
+    m_dataMutex[_camera]->post();
+    return true;
+}
+
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& _image)
+{
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+        m_dataMutex[i]->wait();
+    }
+
+    if (m_vertical) {
+        _image.resize(m_max_width, m_max_height * m_camera_count);
+    } else {
+        _image.resize(m_max_width * m_camera_count, m_max_height);
+    }
+
+    unsigned char *pBuffer = _image.getRawImage();
+    memset(pBuffer, 0, _image.getRawImageSize());
+
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+
+        int rowsize = 3 * m_width[i];
+        int rowoffset = i * 3 * m_max_width;
+        if (m_vertical) {
+            if (m_max_width == m_width[i] && m_max_height == m_height[i]) {
+                memcpy(pBuffer + (3 * m_max_width * m_max_height * i), m_imageBuffer[i], m_bufferSize[i]);
+            } else {
+                for (int r = 0; r < m_height[i]; r++) {
+                    memcpy(pBuffer + (3 * m_max_width) * (m_max_height * i + r), m_imageBuffer[i] + rowsize * r, rowsize);
+                }
+            }
+        } else {
+            for (int r = 0; r < m_height[i]; r++) {
+                memcpy(pBuffer + (3 * m_max_width * m_camera_count * r) + rowoffset, m_imageBuffer[i] + rowsize * r, rowsize);
+            }
+        }
+    }
+
+    if (m_display_time_box) {
+        m_counter = (++m_counter % 10);
+        for (int c = m_counter*30; c < 30 + m_counter*30; c++) {
+            for (int r=0; r<30; r++) {
+                for (unsigned int i = 0; i < m_camera_count; ++i) {
+                    unsigned char *pixel;
+                    if (m_vertical) {
+                        pixel = _image.getPixelAddress(m_width[i]-c-1, m_max_height * i + m_height[i]-r-1);
+                    } else {
+                        pixel = _image.getPixelAddress(m_max_width * i + m_width[i]-c-1, m_height[i]-r-1);
+                    }
+                    pixel[0] = (m_counter % 2 == 0) ? 255 : 0;
+                    pixel[1] = (m_counter % 2 == 0) ? 0 : 255;
+                    pixel[2] = 0;
+                }
+            }
+        }
+    }
+
+    for (unsigned int i = 0; i < m_camera_count; ++i) {
+        m_dataMutex[i]->post();
+    }
+
+    return true;
+}
+
+int yarp::dev::GazeboYarpMultiCameraDriver::height() const
+{
+    return (m_vertical ? m_max_height * m_camera_count : m_max_height);
+}
+
+int yarp::dev::GazeboYarpMultiCameraDriver::width() const
+{
+    return (m_vertical ? m_max_width * m_camera_count : m_max_width * m_camera_count);
+}
+
+
+yarp::os::Stamp yarp::dev::GazeboYarpMultiCameraDriver::getLastInputStamp()
+{
+    // FIXME Ensure that the images are syncronous
+    for (unsigned int i = 1; i < m_camera_count; ++i) {
+        if (m_lastTimestamp[i].getTime() != m_lastTimestamp[0].getTime()) {
+            yWarning() << "Timestamp is different!" <<  m_lastTimestamp[0].getTime() << m_lastTimestamp[i].getTime();
+        }
+    }
+    return m_lastTimestamp[0];
+}

--- a/plugins/multicamera/src/MultiCameraPlugin.cpp
+++ b/plugins/multicamera/src/MultiCameraPlugin.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gazebo/sensors/DepthCameraSensor.hh>
+#include <gazebo/sensors/CameraSensor.hh>
+#include <gazebo/plugins/MultiCameraPlugin.hh>
+//#include <gazebo_plugins/gazebo_ros_utils.h>
+
+#ifndef GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST
+# if GAZEBO_MAJOR_VERSION >= 7
+#define GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST using std::dynamic_pointer_cast
+# else
+#define GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST using boost::dynamic_pointer_cast
+# endif
+#endif
+
+using namespace gazebo;
+GZ_REGISTER_SENSOR_PLUGIN(MultiCameraPlugin)
+
+/////////////////////////////////////////////////
+MultiCameraPlugin::MultiCameraPlugin() : SensorPlugin()
+{
+}
+
+/////////////////////////////////////////////////
+MultiCameraPlugin::~MultiCameraPlugin()
+{
+  this->parentSensor.reset();
+  this->camera.clear();
+}
+
+/////////////////////////////////////////////////
+void MultiCameraPlugin::Load(sensors::SensorPtr _sensor,
+  sdf::ElementPtr /*_sdf*/)
+{
+  if (!_sensor)
+    gzerr << "Invalid sensor pointer.\n";
+
+  GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST;
+  this->parentSensor =
+    dynamic_pointer_cast<sensors::MultiCameraSensor>(_sensor);
+
+  if (!this->parentSensor)
+  {
+    gzerr << "MultiCameraPlugin requires a CameraSensor.\n";
+    if (dynamic_pointer_cast<sensors::DepthCameraSensor>(_sensor))
+      gzmsg << "It is a depth camera sensor\n";
+    if (dynamic_pointer_cast<sensors::CameraSensor>(_sensor))
+      gzmsg << "It is a camera sensor\n";
+  }
+
+  if (!this->parentSensor)
+  {
+    gzerr << "MultiCameraPlugin not attached to a camera sensor\n";
+    return;
+  }
+
+# if GAZEBO_MAJOR_VERSION >= 7
+  for (unsigned int i = 0; i < this->parentSensor->CameraCount(); ++i)
+  {
+    this->camera.push_back(this->parentSensor->Camera(i));
+
+    // save camera attributes
+    this->width.push_back(this->camera[i]->ImageWidth());
+    this->height.push_back(this->camera[i]->ImageHeight());
+    this->depth.push_back(this->camera[i]->ImageDepth());
+    this->format.push_back(this->camera[i]->ImageFormat());
+
+    std::string cameraName = this->parentSensor->Camera(i)->Name();
+#else
+  for (unsigned int i = 0; i < this->parentSensor->GetCameraCount(); ++i)
+  {
+    this->camera.push_back(this->parentSensor->GetCamera(i));
+
+    // save camera attributes
+    this->width.push_back(this->camera[i]->GetImageWidth());
+    this->height.push_back(this->camera[i]->GetImageHeight());
+    this->depth.push_back(this->camera[i]->GetImageDepth());
+    this->format.push_back(this->camera[i]->GetImageFormat());
+
+    std::string cameraName = this->parentSensor->GetCamera(i)->GetName();
+#endif
+    // gzdbg << "camera(" << i << ") name [" << cameraName << "]\n";
+
+    // FIXME: hardcoded 2 camera support only
+    if (cameraName.find("left") != std::string::npos)
+    {
+      this->newFrameConnection.push_back(this->camera[i]->ConnectNewImageFrame(
+        boost::bind(&MultiCameraPlugin::OnNewFrameLeft,
+        this, _1, _2, _3, _4, _5)));
+    }
+    else if (cameraName.find("right") != std::string::npos)
+    {
+      this->newFrameConnection.push_back(this->camera[i]->ConnectNewImageFrame(
+        boost::bind(&MultiCameraPlugin::OnNewFrameRight,
+        this, _1, _2, _3, _4, _5)));
+    }
+  }
+
+  this->parentSensor->SetActive(true);
+}
+
+/////////////////////////////////////////////////
+void MultiCameraPlugin::OnNewFrameLeft(const unsigned char * /*_image*/,
+                              unsigned int /*_width*/,
+                              unsigned int /*_height*/,
+                              unsigned int /*_depth*/,
+                              const std::string &/*_format*/)
+{
+  /*rendering::Camera::SaveFrame(_image, this->width,
+    this->height, this->depth, this->format,
+    "/tmp/camera/me.jpg");
+    */
+}
+
+/////////////////////////////////////////////////
+void MultiCameraPlugin::OnNewFrameRight(const unsigned char * /*_image*/,
+                              unsigned int /*_width*/,
+                              unsigned int /*_height*/,
+                              unsigned int /*_depth*/,
+                              const std::string &/*_format*/)
+{
+  /*rendering::Camera::SaveFrame(_image, this->width,
+    this->height, this->depth, this->format,
+    "/tmp/camera/me.jpg");
+    */
+}

--- a/tutorial/model/database.config
+++ b/tutorial/model/database.config
@@ -10,5 +10,6 @@
 <uri>file://camera</uri>
 <uri>file://depthcamera</uri>
 <uri>file://laser</uri>
+<uri>file://multicamera</uri>
 </models>
 </database>

--- a/tutorial/model/multicamera/model.config
+++ b/tutorial/model/multicamera/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>MultiCamera</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Daniele E. Domenichelli</name>
+    <email>daniele.domenichelli@iit.it</email>
+  </author>
+
+  <description>
+    A simple multicamera using YARP plugins.
+  </description>
+</model>

--- a/tutorial/model/multicamera/model.sdf
+++ b/tutorial/model/multicamera/model.sdf
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="multicamera_model">
+    <static>true</static>
+    <pose>0 0 0.1 0 0 0</pose>
+    <link name="link">
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="multicamera_sensor" type="multicamera">
+        <camera name="left">
+          <pose>0 +0.07 0 0 0 0</pose>
+          <horizontal_fov>1.047</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <camera name="right">
+          <pose>0 -0.07 0 0 0 0</pose>
+          <horizontal_fov>1.047</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>true</visualize>
+        <plugin name="multicamera_plugin" filename="libgazebo_yarp_multicamera.so">
+          <yarpConfigurationFile>model://multicamera/multicamera.ini</yarpConfigurationFile>
+        </plugin>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/tutorial/model/multicamera/multicamera.ini
+++ b/tutorial/model/multicamera/multicamera.ini
@@ -1,0 +1,5 @@
+device grabber
+subdevice gazebo_multicamera
+name /multicamera
+framerate 30
+stamp 1


### PR DESCRIPTION
Allows to add multicameras containing any number of cameras.
The cameras are supposed to be sync, but there is still some race condition that sometimes (on my pc ~1 or 2 frames each second) outputs 2 images with a different timestamp. Anyway it works good enought to be used.