### PR TITLE
Clean up robot in destructor of GazeboYarpMaisSensor

### DIFF
--- a/plugins/maissensor/src/MaisSensor.cc
+++ b/plugins/maissensor/src/MaisSensor.cc
@@ -38,6 +38,7 @@ GazeboYarpMaisSensor::~GazeboYarpMaisSensor()
         m_wrapper.close();
 
     GazeboYarpPlugins::Handler::getHandler()->removeDevice(m_sensorName);
+    GazeboYarpPlugins::Handler::getHandler()->removeRobot(m_robotName);
 
     yarp::os::Network::fini();
 }


### PR DESCRIPTION
This lead to issues if the iCub is removed and added again, as the robot was still present.