### PR TITLE
Remove unnecessary m_robotRefreshPeriod

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -391,7 +391,6 @@ private:
 
     yarp::os::Property m_pluginParameters; /**< Contains the parameters of the device contained in the yarpConfigurationFile .ini file */
 
-    unsigned int m_robotRefreshPeriod; //ms
     unsigned int m_numberOfJoints; /**< number of joints controlled by the control board */
     std::vector<Range> m_jointPosLimits;
     std::vector<Range> m_jointVelLimits;

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -55,7 +55,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     assert(m_robot);
     if (!m_robot) return false;
 
-    this->m_robotRefreshPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
     if (!setJointNames()) return false;      // this function also fills in the m_jointPointers vector
 
     m_numberOfJoints = m_jointNames.size();

--- a/plugins/maissensor/include/yarp/dev/MaisSensorDriver.h
+++ b/plugins/maissensor/include/yarp/dev/MaisSensorDriver.h
@@ -103,8 +103,7 @@ private:
     yarp::os::Property m_pluginParameters; /**< Contains the parameters of the device contained in the yarpConfigurationFile .ini file */
 
     yarp::sig::Vector m_positions; /**< joint positions [Degrees] */
-    unsigned int m_robotRefreshPeriod; //ms
-    unsigned int m_numberOfJoints; /**< number of joints controlled by the control board */;
+    unsigned int m_numberOfJoints; /**< number of joints controlled by the control board */
 
 
     yarp::os::Stamp m_lastTimestamp; /**< timestamp, updated with simulation time at each onUpdate call */

--- a/plugins/maissensor/src/MaisSensorDriver.cpp
+++ b/plugins/maissensor/src/MaisSensorDriver.cpp
@@ -53,7 +53,6 @@ bool GazeboYarpMaisSensorDriver::gazebo_init()
     assert(m_robot);
     if (!m_robot) return false;
 
-    this->m_robotRefreshPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
     if (!setJointNames()) return false;      // this function also fills in the m_jointPointers vector
 
     m_channels_num = 16;


### PR DESCRIPTION
This lead to a segfault in some cases as `GetPhysicsEngine()` pointed to `NULL` and there was no check against this.