### PR TITLE
[controlboard] missing methods implementation in GazeboYarpControlBoardDriver

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -403,6 +403,7 @@ private:
 
     yarp::sig::Vector m_positions; /**< joint positions [Degrees] */
     yarp::sig::Vector m_velocities; /**< joint velocities [Degrees/Seconds] */
+    yarp::sig::Vector m_accelerations; /**< joint accelerations [Degrees/Seconds/Seconds]> */
     yarp::sig::Vector m_torques; /**< joint torques [Netwon Meters] */
     yarp::sig::Vector m_maxTorques; /**< joint torques [Netwon Meters] */
 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -403,7 +403,7 @@ private:
 
     yarp::sig::Vector m_positions; /**< joint positions [Degrees] */
     yarp::sig::Vector m_velocities; /**< joint velocities [Degrees/Seconds] */
-    yarp::sig::Vector m_accelerations; /**< joint accelerations [Degrees/Seconds/Seconds]> */
+    yarp::sig::Vector m_accelerations; /**< joint accelerations [Degrees/Seconds^2]> */
     yarp::sig::Vector m_torques; /**< joint torques [Netwon Meters] */
     yarp::sig::Vector m_maxTorques; /**< joint torques [Netwon Meters] */
 

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -63,6 +63,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_zeroPosition.resize(m_numberOfJoints);
     m_jntReferenceVelocities.resize(m_numberOfJoints);
     m_velocities.resize(m_numberOfJoints);
+    m_accelerations.resize(m_numberOfJoints);
     amp.resize(m_numberOfJoints);
     m_torques.resize(m_numberOfJoints); m_torques.zero();
     m_maxTorques.resize(m_numberOfJoints, 2000.0);
@@ -98,6 +99,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_positions.zero();
     m_zeroPosition.zero();
     m_velocities.zero();
+    m_accelerations.zero();
     m_motReferencePositions.zero();
     m_motReferenceVelocities.zero();
     m_motReferenceTorques.zero();
@@ -419,6 +421,7 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _i
         //TODO: consider multi-dof joint ?
         m_positions[jnt_cnt] = convertGazeboToUser(jnt_cnt, m_jointPointers[jnt_cnt]->GetAngle(0));
         m_velocities[jnt_cnt] = convertGazeboToUser(jnt_cnt, m_jointPointers[jnt_cnt]->GetVelocity(0));
+        //TODO Acceleration measurements - Not yet implemented in gazebo
         m_torques[jnt_cnt] = m_jointPointers[jnt_cnt]->GetForce(0u);
     }
     

--- a/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
@@ -112,20 +112,20 @@ bool GazeboYarpControlBoardDriver::getEncoderSpeeds(double *spds) //NOT TESTED
     return true;
 }
 
-bool GazeboYarpControlBoardDriver::getEncoderAcceleration(int j, double *spds) //NOT IMPLEMENTED
+bool GazeboYarpControlBoardDriver::getEncoderAcceleration(int j, double *spds) //NOT TESTED
 {
     if (spds && j >= 0 && j < (int)m_numberOfJoints) {
-        *spds = 0.0;
+        *spds = m_accelerations[j];
         return true;
     }
     return false;
 }
 
-bool GazeboYarpControlBoardDriver::getEncoderAccelerations(double *accs) //NOT IMPLEMENTED
+bool GazeboYarpControlBoardDriver::getEncoderAccelerations(double *accs) //NOT TESTED
 {
     if (!accs) return false;
     for (unsigned int i=0; i<m_numberOfJoints; ++i) {
-        accs[i] = 0.0;
+        getEncoderAcceleration(i,&accs[i]);
     }
     return true;
 }

--- a/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
@@ -116,7 +116,7 @@ bool GazeboYarpControlBoardDriver::getEncoderAcceleration(int j, double *spds) /
 {
     if (spds && j >= 0 && j < (int)m_numberOfJoints) {
         *spds = m_accelerations[j];
-        return true;
+        return false;
     }
     return false;
 }

--- a/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverEncoders.cpp
@@ -127,5 +127,5 @@ bool GazeboYarpControlBoardDriver::getEncoderAccelerations(double *accs) //NOT T
     for (unsigned int i=0; i<m_numberOfJoints; ++i) {
         getEncoderAcceleration(i,&accs[i]);
     }
-    return true;
+    return false;
 }

--- a/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
@@ -97,8 +97,22 @@ namespace yarp {
             return true;
         }
 
-        bool GazeboYarpControlBoardDriver::getErrorLimit (int /*j*/, double */*limit*/) { return false; }
-        bool GazeboYarpControlBoardDriver::getErrorLimits (double */*limits*/) { return false; }
+        bool GazeboYarpControlBoardDriver::getErrorLimit (int j, double *limit) {
+            return false;
+            if(limit && j >= 0 && j < (int)m_numberOfJoints){
+                // Not yet implemented 
+                *limit = 0.0;
+                return false;
+            }
+        }
+        
+        bool GazeboYarpControlBoardDriver::getErrorLimits (double *limits) {
+            if(!limits) return false;
+            for (unsigned int i=0; i<m_numberOfJoints; i++){
+                getErrorLimit(i,&limits[i]);
+            }
+        }
+        
         bool GazeboYarpControlBoardDriver::resetPid (int /*j*/) { return false; }
         bool GazeboYarpControlBoardDriver::disablePid (int /*j*/) { return false; }
         bool GazeboYarpControlBoardDriver::enablePid (int /*j*/) { return false; }

--- a/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
@@ -111,6 +111,7 @@ namespace yarp {
             for (unsigned int i=0; i<m_numberOfJoints; i++){
                 getErrorLimit(i,&limits[i]);
             }
+            return false;
         }
         
         bool GazeboYarpControlBoardDriver::resetPid (int /*j*/) { return false; }


### PR DESCRIPTION
See https://github.com/robotology/gazebo-yarp-plugins/issues/154
@traversaro Thank you
In ControlBoardDriverPidControl.cpp, the following methods are not implemented. The semantics of this methods are not defined in the YARP interfaces, and they are not implemented in any known implementation of the YARP Controlboards
1) getErrorLimit
2)getErrorLimits
3)resetPid
4)disablePid
5)enablePid
6)setOffset