### PR TITLE
Catch them all headers cleanup

### DIFF
--- a/plugins/clock/src/Clock.cc
+++ b/plugins/clock/src/Clock.cc
@@ -9,7 +9,10 @@
 #include "ClockServerImpl.h"
 
 #include <gazebo/gazebo_config.h>
-#include <gazebo/physics/physics.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/PhysicsIface.hh>
 #include <yarp/os/Network.h>
 #include <yarp/os/Property.h>
 #include <yarp/os/BufferedPort.h>

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -7,7 +7,7 @@
 #ifndef GAZEBOYARP_COUPLING_H
 #define GAZEBOYARP_COUPLING_H
 
-#include <gazebo/physics/physics.hh>
+#include <gazebo/physics/Model.hh>
 
 namespace yarp {
     namespace dev {

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
@@ -7,7 +7,7 @@
 #ifndef GAZEBOYARP_TRAJECTORY_H
 #define GAZEBOYARP_TRAJECTORY_H
 
-#include <gazebo/physics/physics.hh>
+#include <gazebo/physics/Model.hh>
 
 namespace yarp {
     namespace dev {

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -9,7 +9,9 @@
 #include <GazeboYarpPlugins/common.h>
 
 #include <cstdio>
-#include <gazebo/physics/physics.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/Joint.hh>
 #include <gazebo/transport/transport.hh>
 #include <gazebo/math/Angle.hh>
 

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -10,8 +10,7 @@
 
 #include <ControlBoardDriverCoupling.h>
 #include <cstdio>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Model.hh>
 #include <gazebo/math/Angle.hh>
 
 #include <yarp/os/LogStream.h>

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "ControlBoardDriver.h"
-#include <gazebo/physics/physics.hh>
 
 using namespace yarp::dev;
 

--- a/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPidControl.cpp
@@ -8,8 +8,8 @@
 
 #include "ControlBoardDriver.h"
 #include <GazeboYarpPlugins/common.h>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Joint.hh>
+#include <gazebo/transport/Publisher.hh>
 
 namespace yarp {
     namespace dev {

--- a/plugins/controlboard/src/ControlBoardDriverRemoteVariables.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverRemoteVariables.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "ControlBoardDriver.h"
-#include <gazebo/physics/physics.hh>
+#include <gazebo/physics/Joint.hh>
 
 using namespace yarp::dev;
 

--- a/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
@@ -10,8 +10,8 @@
 
 #include <ControlBoardDriverTrajectory.h>
 #include <cstdio>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
 #include <gazebo/math/Angle.hh>
 
 #include <yarp/os/LogStream.h>

--- a/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
@@ -4,8 +4,10 @@
 #include <iostream>
 #include <string>
 #include <gazebo/common/Plugin.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/transport/Node.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/Model.hh>
 
 #include <yarp/os/Network.h>
 #include <yarp/os/RpcServer.h>

--- a/plugins/jointsensors/include/yarp/dev/JointSensorsDriver.h
+++ b/plugins/jointsensors/include/yarp/dev/JointSensorsDriver.h
@@ -14,8 +14,8 @@
 #include <yarp/os/Semaphore.h>
 
 #include <gazebo/common/Plugin.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/Joint.hh>
 
 namespace yarp {
     namespace dev {

--- a/plugins/maissensor/src/MaisSensorDriver.cpp
+++ b/plugins/maissensor/src/MaisSensorDriver.cpp
@@ -9,8 +9,10 @@
 #include <GazeboYarpPlugins/common.h>
 
 #include <cstdio>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/Joint.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/transport/Node.hh>
 #include <gazebo/math/Angle.hh>
 
 #include <yarp/os/LogStream.h>

--- a/plugins/multicamera/include/gazebo/plugins/MultiCameraPlugin.hh
+++ b/plugins/multicamera/include/gazebo/plugins/MultiCameraPlugin.hh
@@ -23,7 +23,6 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/sensors/MultiCameraSensor.hh>
 #include <gazebo/rendering/Camera.hh>
-#include <gazebo/gazebo.hh>
 
 namespace gazebo
 {

--- a/plugins/showmodelcom/src/ShowModelCoM.cc
+++ b/plugins/showmodelcom/src/ShowModelCoM.cc
@@ -9,8 +9,11 @@
 #include <iostream>
 #include <string>
 #include <gazebo/common/Plugin.hh>
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/transport/Node.hh>
 
 #include <yarp/os/Network.h>
 #include <yarp/os/Bottle.h>

--- a/plugins/worldinterface/src/worldinterface.h
+++ b/plugins/worldinterface/src/worldinterface.h
@@ -9,9 +9,6 @@
  #ifndef YARPGAZEBO_WORLD_INTERFACE
 #define YARPGAZEBO_WORLD_INTERFACE
 
-
-#include "gazebo/physics/physics.hh"
-#include "gazebo/common/common.hh"
 #include "gazebo/gazebo.hh"
 
 #include "worldinterfaceserverimpl.h"

--- a/plugins/worldinterface/src/worldinterfaceserverimpl.h
+++ b/plugins/worldinterface/src/worldinterfaceserverimpl.h
@@ -10,11 +10,6 @@
 #define YARPGAZEBO_WORLD_INTERFACESERVERIMPL
 
 #include <WorldInterfaceServer.h>
-
-#include "gazebo/physics/physics.hh"
-#include "gazebo/common/common.hh"
-#include "gazebo/gazebo.hh"
-
 #include "worldproxy.h"
 
 class WorldInterfaceServerImpl: public GazeboYarpPlugins::WorldInterfaceServer

--- a/plugins/worldinterface/src/worldproxy.h
+++ b/plugins/worldinterface/src/worldproxy.h
@@ -9,9 +9,11 @@
 #ifndef GAZEBOYARP_WORLDPROXY_H
 #define GAZEBOYARP_WORLDPROXY_H
 
-#include "gazebo/physics/physics.hh"
-#include "gazebo/common/common.hh"
-#include "gazebo/gazebo.hh"
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/Joint.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
+#include <gazebo/physics/Link.hh>
 
 #include "WorldInterfaceServer.h"
 #include <yarp/os/Mutex.h>


### PR DESCRIPTION
See https://github.com/robotology/gazebo-yarp-plugins/issues/221
headers cleaned up from the all the plugins modules
@traversaro please check if this helps to reduce the compilation time