### PR TITLE
lasersensor plugin requires yarp version 2.3.68

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -24,10 +24,10 @@ else()
     message(WARNING "Gazebo version is lower than 4.0, disabling worldinterface plugin.")
 endif()
 
-if( NOT (GAZEBO_VERSION VERSION_LESS 6) )
+if( (NOT (GAZEBO_VERSION VERSION_LESS 6)) AND (NOT (YARP_VERSION VERSION_LESS 2.3.68)) )
     add_subdirectory(lasersensor)
 else()
-    message(STATUS "Gazebo version is lower than 6, disabling  lasersensor plugin.")
+    message(STATUS "Gazebo version is lower than 6 or YARP version is lower than 2.3.68, disabling  lasersensor plugin.")
 endif()
 
 # disabling depthCamera plugin until it is updated to latest changes in yarp


### PR DESCRIPTION
Fixes compilation for users with `YARP < 2.3.68`