### PR TITLE
Depth camera no subdevice

### DIFF
--- a/libraries/singleton/src/ConfHelpers.cc
+++ b/libraries/singleton/src/ConfHelpers.cc
@@ -141,7 +141,7 @@ bool loadConfigSensorPlugin(sensors::SensorPtr _sensor,
     std::string sensorName = _sensor->GetName();
 #endif
             yError()  << "GazeboYarpPlugins error: failure in loading configuration for sensor " << sensorName << "\n"
-                      << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name 
+                      << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << "\n"
                       << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path ;
             return false;
         }

--- a/plugins/depthCamera/include/gazebo/DepthCamera.hh
+++ b/plugins/depthCamera/include/gazebo/DepthCamera.hh
@@ -8,11 +8,13 @@
 #ifndef GAZEBOYARP_DEPTHCAMERA_HH
 #define GAZEBOYARP_DEPTHCAMERA_HH
 
+#include <string>
+
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/plugins/DepthCameraPlugin.hh>
+
 #include <yarp/os/Network.h>
 #include <yarp/dev/PolyDriver.h>
-
 #include <yarp/dev/FrameGrabberInterfaces.h>
 
 
@@ -21,7 +23,6 @@ namespace yarp {
         class IMultipleWrapper;
     }
 }
-#include <string>
 
 namespace gazebo
 {

--- a/plugins/depthCamera/include/gazebo/DepthCamera.hh
+++ b/plugins/depthCamera/include/gazebo/DepthCamera.hh
@@ -15,6 +15,12 @@
 
 #include <yarp/dev/FrameGrabberInterfaces.h>
 
+
+namespace yarp {
+    namespace dev {
+        class IMultipleWrapper;
+    }
+}
 #include <string>
 
 namespace gazebo
@@ -51,10 +57,13 @@ namespace gazebo
 
     private:
         yarp::os::Network m_yarp;
-        yarp::os::Property m_parameters;
+        yarp::os::Property m_driverParameters;
         yarp::dev::PolyDriver m_cameraDriver;
         std::string m_sensorName;
         sensors::DepthCameraSensor *m_sensor;
+
+        yarp::dev::PolyDriver m_cameraWrapper;
+        yarp::dev::IMultipleWrapper* m_iWrap;
 
         yarp::dev::IFrameGrabberImage*      iFrameGrabberImage;
     };

--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -80,8 +80,6 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     // Add scoped name to list of params
     m_driverParameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
 
-    yarp::dev::IMultipleWrapper* m_iWrap;
-
     ///////////////////////////
     //Open the wrapper, forcing it to be a "RGBDSensorWrapper"
     wrapper_properties.put("device","RGBDSensorWrapper");

--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -34,7 +34,6 @@ GazeboYarpDepthCamera::~GazeboYarpDepthCamera()
 
 void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
 {
-    yTrace() << "depth camera LOAD";
     if (!m_yarp.checkNetwork(GazeboYarpPlugins::yarpNetworkInitializationTimeout)) {
         yError() << "GazeboYarpDepthCamera::Load error: yarp network does not seem to be available, is the yarpserver running?";
         return;
@@ -75,11 +74,6 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
         yDebug() << "m_sensor == NULL";
     }
 
-
-    // Don't forget to load the camera plugin!!!! ???
-//    DepthCameraPlugin::Load(_sensor, _sdf);
-
-    yDebug() << "GazeboYarpDepthCamera Plugin: sensor scoped name is " << m_sensorName.c_str() ;
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 

--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -14,6 +14,7 @@
 #include <yarp/os/LogStream.h>
 #include <gazebo/sensors/DepthCameraSensor.hh>
 #include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/Wrapper.h>
 
 
 GZ_REGISTER_SENSOR_PLUGIN(gazebo::GazeboYarpDepthCamera)
@@ -53,7 +54,9 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
 
     //Getting .ini configuration file from sdf
-    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor,_sdf,m_parameters);
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigSensorPlugin(_sensor,_sdf,m_driverParameters);
+    // wrapper params are in the same file along the driver params
+    ::yarp::os::Property wrapper_properties = m_driverParameters;
 
     if (!configuration_loaded)
     {
@@ -80,22 +83,53 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 
-    m_parameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
+    // Add scoped name to list of params
+    m_driverParameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
 
-    //Open the driver
-    if (m_cameraDriver.open(m_parameters)) {
-        yInfo() << "Loaded GazeboYarpDepthCamera Plugin correctly";
-    } else {
-        yError() << "GazeboYarpDepthCamera Plugin Load failed: error in opening yarp driver";
-    }
+    yarp::dev::IMultipleWrapper* m_iWrap;
 
-    m_cameraDriver.view(iFrameGrabberImage);
-    if(iFrameGrabberImage == NULL)
+    ///////////////////////////
+    //Open the wrapper, forcing it to be a "RGBDSensorWrapper"
+    wrapper_properties.put("device","RGBDSensorWrapper");
+    if(wrapper_properties.check("subdevice"))
     {
-        yError() << "Unable to get the iFrameGrabberImage interface from the device";
+        yError() << "RGBDSensorWrapper:  Do not use 'subdevice' keyword here since the only supported subdevice is <gazebo_depthCamera>. \
+                     Please remove the line 'subdevice " << wrapper_properties.find("subdevice").asString().c_str() << "' from your config file before proceeding";
         return;
     }
 
+    if(!m_cameraWrapper.open(wrapper_properties) )
+    {
+        yError()<<"GazeboYarpDepthCamera Plugin failed: error in opening yarp wrapper";
+        return;
+    }
+
+    //Open the driver
+    //Force the device to be of type "gazebo_forcetorque" (it make sense? probably yes)
+    m_driverParameters.put("device","gazebo_depthCamera");
+    yDebug() << "CC: m_driverParameters:\t" << m_driverParameters.toString();
+
+    if(!m_cameraDriver.open(m_driverParameters) )
+    {
+        yError()<<"GazeboYarpDepthCamera Plugin failed: error in opening yarp driver";
+        return;
+    }
+
+    //Attach the driver to the wrapper
+    ::yarp::dev::PolyDriverList driver_list;
+
+    if(!m_cameraWrapper.view(m_iWrap) )
+    {
+        yError() << "GazeboYarpDepthCamera : error in loading wrapper";
+        return;
+    }
+
+    driver_list.push(&m_cameraDriver,"dummy");
+
+    if(!m_iWrap->attachAll(driver_list) )
+    {
+        yError() << "GazeboYarpDepthCamera : error in connecting wrapper and device ";
+    }
 }
 
 }

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -83,7 +83,7 @@ bool GazeboYarpDepthCameraDriver::open(yarp::os::Searchable &config)
 
     if (!m_depthCameraSensorPtr)
     {
-        myError("camera sensor was not found");
+        yError("camera sensor was not found (sensor's scoped name %s!)", sensorScopedName.c_str());
         return false;
     }
 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -9,6 +9,7 @@
 #include <yarp/os/Value.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+#include <yarp/os/Time.h>
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
 
@@ -292,7 +293,11 @@ bool GazeboYarpDepthCameraDriver::getRgbImage(FlexImage& rgbImage, Stamp* timeSt
     rgbImage.setPixelCode(m_imageFormat);
     rgbImage.resize(m_width, m_height);
     memcpy(rgbImage.getRawImage(), m_imageFrame_Buffer, m_imageFrame_BufferSize);
-    timeStamp->getTime();
+#if GAZEBO_MAJOR_VERSION >= 7
+    timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
+#else
+    timeStamp->update(this->m_depthCameraSensorPtr->GetLastUpdateTime().Double());
+#endif
 
     m_colorFrameMutex.post();
     return true;
@@ -397,7 +402,12 @@ bool GazeboYarpDepthCameraDriver::getDepthImage(depthImageType& depthImage, Stam
     depthImage.resize(m_width, m_height);
     //depthImage.setPixelCode(m_depthFormat);
     memcpy(depthImage.getRawImage(), m_depthFrame_Buffer, m_width * m_height * sizeof(float));
-    timeStamp->getTime();
+
+#if GAZEBO_MAJOR_VERSION >= 7
+    timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
+#else
+    timeStamp->update(this->m_depthCameraSensorPtr->GetLastUpdateTime().Double());
+#endif
 
     m_depthFrameMutex.post();
     return true;
@@ -420,13 +430,13 @@ IRGBDSensor::RGBDSensor_status GazeboYarpDepthCameraDriver::getSensorStatus()
 }
 yarp::os::ConstString GazeboYarpDepthCameraDriver::getLastErrorMsg(Stamp* timeStamp)
 {
-    if(!timeStamp)
+    if(timeStamp)
     {
-        myError("timeStamp pointer invalid");
-    }
-    else
-    {
-        timeStamp->update();
+#if GAZEBO_MAJOR_VERSION >= 7
+	timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
+#else
+	timeStamp->update(this->m_depthCameraSensorPtr->GetLastUpdateTime().Double());
+#endif
     }
     return m_error;
 }

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -288,6 +288,7 @@ bool GazeboYarpDepthCameraDriver::getRgbImage(FlexImage& rgbImage, Stamp* timeSt
     if(m_width == 0 || m_height == 0)
     {
         myError("gazebo returned an invalid image size");
+        m_colorFrameMutex.post();
         return false;
     }
     rgbImage.setPixelCode(m_imageFormat);
@@ -396,6 +397,7 @@ bool GazeboYarpDepthCameraDriver::getDepthImage(depthImageType& depthImage, Stam
     if(m_width == 0 || m_height == 0)
     {
         myError("gazebo returned an invalid image size");
+        m_depthFrameMutex.post();
         return false;
     }
 

--- a/tutorial/model/depthcamera/depthcamera.ini
+++ b/tutorial/model/depthcamera/depthcamera.ini
@@ -1,5 +1,4 @@
 device RGBDSensorWrapper
-subdevice  gazebo_depthCamera
 period 30
 imagePort /camera
 depthPort /depthcamera


### PR DESCRIPTION
Change depth Camera plugin in such a way that 'subdevice' keyword in '.ini' config file is not allowed.
Subdevice is always added in the singleton as a loaded plugin and reachable by all other plugins upon request.

CER config file has to be updated accordingly to keep working