### PR TITLE
m_controllerPeriod is now tied to GetPhysicsEngine()->GetMaxStepSize()

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
@@ -59,7 +59,7 @@ protected:
     double m_xf;
     double m_speed;
     double m_computed_reference;
-    unsigned int m_controllerPeriod;
+    double m_controllerPeriod;
     double m_joint_min;
     double m_joint_max;
     TrajectoryGenerator(gazebo::physics::Model* model);

--- a/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
@@ -206,7 +206,7 @@ bool MinJerkTrajectoryGenerator::abortTrajectory (double limit)
 bool MinJerkTrajectoryGenerator::initTrajectory (double current_pos, double final_pos, double speed)
 {
     m_mutex.wait();
-    m_controllerPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
+    m_controllerPeriod = this->m_robot->GetWorld()->GetPhysicsEngine()->GetMaxStepSize() * 1000.0;
     double speedf = fabs(speed);
     double dx0 =0;
     m_computed_reference = current_pos;
@@ -227,7 +227,7 @@ bool MinJerkTrajectoryGenerator::initTrajectory (double current_pos, double fina
 
     //double step = (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod * _T_controller;
 
-    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / double (m_controllerPeriod);
+    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / m_controllerPeriod;
     m_dx0 = m_dx0 * m_tf;
 
     dx0  = m_dx0;
@@ -382,7 +382,7 @@ ConstSpeedTrajectoryGenerator::~ConstSpeedTrajectoryGenerator() {}
 bool ConstSpeedTrajectoryGenerator::initTrajectory (double current_pos, double final_pos, double speed)
 {
     m_mutex.wait();
-    m_controllerPeriod = (unsigned)(this->m_robot->GetWorld()->GetPhysicsEngine()->GetUpdatePeriod() * 1000.0);
+    m_controllerPeriod = this->m_robot->GetWorld()->GetPhysicsEngine()->GetMaxStepSize() * 1000.0;
     m_x0 = current_pos;
     m_xf = final_pos;
     if (m_xf > m_joint_max) m_xf = m_joint_max;


### PR DESCRIPTION
See discussion in #300 
This fix enables the iCub to be run on Gazebo with `real_time_update_rate` and `max_step_size` values different from the standard values (1000, 0.001) achieving faster than real time simulations.