### PR TITLE
Fix plugin worldinterface

### DIFF
--- a/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
+++ b/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
@@ -22,8 +22,7 @@ WorldInterfaceServerImpl::~WorldInterfaceServerImpl()
 
 std::string WorldInterfaceServerImpl::makeSphere(const double radius, const GazeboYarpPlugins::Pose& pose, const GazeboYarpPlugins::Color& color,const std::string& frame_name , const std::string& object_name,const bool gravity_enable , const bool collision_enable )
 {
-  return proxy->makeSphere(radius, pose, color,frame_name,object_name,gravity_enable, collision_enable);
-  
+  return proxy->makeSphere(radius, pose, color,frame_name,object_name,gravity_enable, collision_enable);  
 }
 
 std::string WorldInterfaceServerImpl::makeBox(const double width, const double height, const double thickness, const GazeboYarpPlugins::Pose& pose, const GazeboYarpPlugins::Color& color,const std::string& frame_name , const std::string& object_name,const bool gravity_enable , const bool collision_enable )

--- a/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
+++ b/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
@@ -6,7 +6,7 @@
  *
  */
  
- #include "worldinterfaceserverimpl.h"
+#include "worldinterfaceserverimpl.h"
 #include <string>
 #include <list>
 

--- a/plugins/worldinterface/src/worldproxy.cpp
+++ b/plugins/worldinterface/src/worldproxy.cpp
@@ -668,13 +668,13 @@ bool WorldProxy::enableCollision(const std::string& id, const bool enable)
 
 gazebo::physics::LinkPtr WorldProxy::HELPER_getLink(std::string full_scoped_link_name)
 {
-    size_t lastcolon = full_scoped_link_name.rfind(":");
-    if (lastcolon == std::string::npos)
+    size_t firstcolon = full_scoped_link_name.find(":");
+    if (firstcolon == std::string::npos)
     {
       yError () << "Unable to parse model name: " << full_scoped_link_name;
       return gazebo::physics::LinkPtr();
     }
-    std::string model_name = full_scoped_link_name.substr(0,lastcolon-1);
+    std::string model_name = full_scoped_link_name.substr(0,firstcolon);
 #if GAZEBO_MAJOR_VERSION >= 8
     physics::ModelPtr p_model=world->ModelByName(model_name);
 #else


### PR DESCRIPTION
In the previous version, it was not possible to get a link if its path was deeper than 2 levels. So it was possible to retrieve a link of the form `A::link`, but **NOT** one like `A::B::link`. This issue has been fixed here.