### PR TITLE
[controlboard] Add three-parameters variant of setRefTorques

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -229,18 +229,21 @@ public:
     bool changeInteractionMode(int j, yarp::dev::InteractionModeEnum mode); //private function
 
     //TORQUE CONTROL
-    virtual bool setRefTorque(int j, double t); //NOT TESTED
-    virtual bool setRefTorques(const double *t); //NOT TESTED
-    virtual bool setTorqueMode(); //NOT TESTED
-    virtual bool getRefTorque(int j, double *t);    //NOT TESTED
-    virtual bool getRefTorques(double *t);//NOT TESTED
-    virtual bool getTorque(int j, double *t); //NOT TESTED
-    virtual bool getTorques(double *t); //NOT TESTED
+    virtual bool setRefTorque(int j, double t);
+    virtual bool setRefTorques(const double *t);
+    virtual bool setTorqueMode();
+    virtual bool getRefTorque(int j, double *t);
+    virtual bool getRefTorques(double *t);
+    virtual bool setRefTorques(const int n_joint, const int *joints, const double *t);
+    virtual bool getTorque(int j, double *t);
+    virtual bool getTorques(double *t);
 
-    virtual bool getBemfParam(int j, double *bemf); //NOT IMPLEMENTED
-    virtual bool setBemfParam(int j, double bemf); //NOT IMPLEMENTED
-    virtual bool getTorqueRange(int j, double *min, double *max); //NOT IMPLEMENTED
-    virtual bool getTorqueRanges(double *min, double *max); //NOT IMPLEMENTED
+    virtual bool getBemfParam(int j, double *bemf);
+    virtual bool setBemfParam(int j, double bemf);
+    virtual bool getTorqueRange(int j, double *min, double *max);
+    virtual bool getTorqueRanges(double *min, double *max);
+    virtual bool getMotorTorqueParams(int j,  yarp::dev::MotorTorqueParameters *params);
+    virtual bool setMotorTorqueParams(int j, const yarp::dev::MotorTorqueParameters params);
 
     //IMPEDANCE CTRL
     virtual bool getImpedance(int j, double *stiffness, double *damping); // [Nm/deg] & [Nm*sec/deg]

--- a/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
@@ -28,6 +28,16 @@ bool GazeboYarpControlBoardDriver::setRefTorques(const double* t)
     return true;
 }
 
+bool GazeboYarpControlBoardDriver::setRefTorques(const int n_joint, const int *joints, const double *t)
+{
+    if (!joints || !t) return false;
+    bool ret = true;
+    for (int i = 0; i < n_joint && ret; i++) {
+        m_jntReferenceTorques[joints[i]] = t[i];
+    }
+    return ret;
+}
+
 bool GazeboYarpControlBoardDriver::setTorqueMode()
 {
     bool ret = true;
@@ -73,7 +83,9 @@ bool GazeboYarpControlBoardDriver::getTorques(double* t)
     return true;
 }
 
-bool GazeboYarpControlBoardDriver::getTorqueRange(int, double*, double *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::getTorqueRanges(double *, double *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::getBemfParam(int , double *){return false;} //NOT IMPLEMENTED
-bool GazeboYarpControlBoardDriver::setBemfParam(int , double ){return false;} //NOT IMPLEMENTED
+bool GazeboYarpControlBoardDriver::getTorqueRange(int, double*, double *){return false;}
+bool GazeboYarpControlBoardDriver::getTorqueRanges(double *, double *){return false;}
+bool GazeboYarpControlBoardDriver::getBemfParam(int , double *){return false;}
+bool GazeboYarpControlBoardDriver::setBemfParam(int , double ){return false;}
+bool GazeboYarpControlBoardDriver::getMotorTorqueParams(int ,  yarp::dev::MotorTorqueParameters *){return false;}
+bool GazeboYarpControlBoardDriver::setMotorTorqueParams(int , const yarp::dev::MotorTorqueParameters ){return false;}


### PR DESCRIPTION
This method was implemented in YARP (and in the ControlBoardWrapper)
in https://github.com/robotology/yarp/pull/349 , but it was never
implemented in Gazebo. Unfortunatly, as the setRefTorques result
in message sent only on the streaming port, the call to setRefTorques
was correctly returning true, and the only error was a print in the
ControlBoardWrapper running inside Gazebo, so the failure was quite silent.

I also cleanup the rest of methods of the ITorqueControl interface. 