### PR TITLE
Fixes issue 325 (mismatch between inertial sensors scoped names from the ini config files and sensor plugins)

### DIFF
--- a/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
@@ -91,6 +91,11 @@ public:
      */
     gazebo::sensors::Sensor* getSensor(const std::string& sensorScopedName) const;
 
+    /** Returns the vector of all sensor names
+     * \return vector of all sensor names
+     */
+    std::vector<std::string> getSensors() const;
+    
     /** \brief Removes a sensor from the internal database
      *  \param sensorName the name of the sensor to be removed
      */

--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -141,6 +141,23 @@ gazebo::sensors::Sensor* Handler::getSensor(const std::string& sensorScopedName)
     return tmp;
 }
 
+std::vector<std::string> Handler::getSensors() const
+{
+    // define the output vector of sensor names
+    std::vector<std::string> sensorsV(m_sensorsMap.size());
+    
+    // iterate over the sensor map and get all the names
+    SensorsMap::const_iterator sensor; int idx;
+    for (sensor=m_sensorsMap.begin(), idx=0;
+         sensor!=m_sensorsMap.end();
+         sensor++,idx++)
+    {
+        sensorsV[idx] = sensor->first;
+    }
+    
+    return sensorsV;
+}
+
 void Handler::removeSensor(const std::string& sensorName)
 {
     SensorsMap::iterator sensor = m_sensorsMap.find(sensorName);

--- a/plugins/inertialmtbPart/include/yarp/dev/inertialMTBPartDriver.h
+++ b/plugins/inertialmtbPart/include/yarp/dev/inertialMTBPartDriver.h
@@ -91,6 +91,18 @@ private:
 
     /**
      *
+     * @brief search the list of strings for a string matching the given end string.
+     *
+     * @param [in]  stringList   pick list of strings
+     * @param [in]  endingString end string
+     * @param [out] fullString   completed string if there is a match
+     * @return                   'true' if a match was found
+     */
+    inline bool getNameCompletionFromList(std::vector<std::string> &stringList,
+                                          std::string const &endingString,
+                                          std::string &fullString);
+    /**
+     *
      * Fill the output buffer with the inertial sensors fixed metadata as per
      * EMS data format specified further below: n, VER, ai, bi.
      */


### PR DESCRIPTION
Fix the mismatch between the inertial sensors scoped names set from the ini config files and those registered by the sensor plugins. 
Fixes issue https://github.com/robotology/gazebo-yarp-plugins/issues/325