### PR TITLE
Sensorplugin/contactpressuresensorsarray

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Marco Randazzo <marco.randazzo@iit.it>
 Miguel Aragao <miguelaragao91@gmail.com>
 Mirko Ferrati <mirko.ferrati@gmail.com>
 Silvio Traversaro <silvio.traversaro@iit.it>
+Prashanth Ramadoss <prashanth.ramadoss@iit.it>

--- a/doc/embed_plugins.md
+++ b/doc/embed_plugins.md
@@ -30,7 +30,7 @@ but are nevertheless useful for simulating complex scenarios.
 | Lidar Sensor        | `gazebo_yarp_lasersensor` | Sensor | gazebo::GazeboYarpLaserSensor | yarp::dev::GazeboYarpLaserSensorDriver |
 | Coupled Joint Encoders | `gazebo_yarp_maissensor` | Model |  gazebo::GazeboYarpMaisSensor | yarp::dev::GazeboYarpMaisSensorDriver |
 | Stereo Cameras         | `gazebo_yarp_multicamera` | Sensor | gazebo::GazeboYarpMultiCamera | yarp::dev::GazeboYarpMultiCameraDriver |
-| Contact Load Cell Array| `gazebo_contactloadcellarray` | Model (check documentation for this choice)| gazebo::GazeboYarpContactLoadCellArray| yarp::dev::GazeboYarpContactLoadCellArrayDriver|
+| Contact Load Cell Array| `gazebo_contactloadcellarray` | Model | gazebo::GazeboYarpContactLoadCellArray | yarp::dev::GazeboYarpContactLoadCellArrayDriver |
 
 ## Plugins exposing simulation-specific functionalities
 |  Functionality     | Plugin Name  | Plugin Type |  Gazebo Plugin class  |

--- a/doc/embed_plugins.md
+++ b/doc/embed_plugins.md
@@ -12,7 +12,7 @@ For additional information it is possible to access the official documentation f
 
 The `gazebo-yarp-plugins` consists of:
 * gazebo plugins that instantiate yarp device drivers and
-* yarp device drivers that wrap gazebo functionalities inside the yarp device interfaces . 
+* yarp device drivers that wrap gazebo functionalities inside the yarp device interfaces .
 
 Furthermore, in `gazebo-yarp-plugins` there are several plugins that do not mimic any interface or capability present in real robots,
 but are nevertheless useful for simulating complex scenarios.
@@ -30,6 +30,7 @@ but are nevertheless useful for simulating complex scenarios.
 | Lidar Sensor        | `gazebo_yarp_lasersensor` | Sensor | gazebo::GazeboYarpLaserSensor | yarp::dev::GazeboYarpLaserSensorDriver |
 | Coupled Joint Encoders | `gazebo_yarp_maissensor` | Model |  gazebo::GazeboYarpMaisSensor | yarp::dev::GazeboYarpMaisSensorDriver |
 | Stereo Cameras         | `gazebo_yarp_multicamera` | Sensor | gazebo::GazeboYarpMultiCamera | yarp::dev::GazeboYarpMultiCameraDriver |
+| Contact Load Cell Array| `gazebo_contactloadcellarray` | Model (check documentation for this choice)| gazebo::GazeboYarpContactLoadCellArray| yarp::dev::GazeboYarpContactLoadCellArrayDriver|
 
 ## Plugins exposing simulation-specific functionalities
 |  Functionality     | Plugin Name  | Plugin Type |  Gazebo Plugin class  |

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -44,3 +44,4 @@ else()
     message(STATUS "Gazebo version is lower than 7 or YARP version is lower than 2.3.67, disabling depthCamera  plugin.")
 endif()
 
+add_subdirectory(contactloadcellarray)

--- a/plugins/contactloadcellarray/CMakeLists.txt
+++ b/plugins/contactloadcellarray/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2018 Istituto Italiano di Tecnologia ADVR & iCub Facility & RBCS Department
+# Authors: see AUTHORS file.
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+cmake_minimum_required(VERSION 2.8.7)
+
+include(AddGazeboYarpPluginTarget)
+
+set(LIB_COMMON_NAME gazebo_yarp_lib_common)
+if(CMAKE_VERSION VERSION_LESS 3.0.0)
+  get_property(GAZEBO_YARP_COMMON_HEADERS GLOBAL PROPERTY GAZEBO_YARP_COMMON_HEADERS)
+  unset(LIB_COMMON_NAME)
+endif()
+
+add_gazebo_yarp_plugin_target(LIBRARY_NAME contactloadcellarray
+			      INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			      INCLUDE_DIRS include/gazebo include/yarp/dev
+			      SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS} ${YARP_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
+			      LINKED_LIBRARIES ${LIB_COMMON_NAME} gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} ${SDFORMAT_LIBRARIES}
+			      HEADERS include/gazebo/ContactLoadCellArray.hh
+				      include/yarp/dev/ContactLoadCellArrayDriver.h
+			      SOURCES src/ContactLoadCellArray.cc
+				      src/ContactLoadCellArrayDriver.cpp)

--- a/plugins/contactloadcellarray/include/gazebo/ContactLoadCellArray.hh
+++ b/plugins/contactloadcellarray/include/gazebo/ContactLoadCellArray.hh
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_CONTACTLOADCELLARRAY_HH
+#define GAZEBOYARP_CONTACTLOADCELLARRAY_HH
+
+#include <gazebo/common/Plugin.hh>
+#include <string>
+#include <yarp/dev/PolyDriverList.h>
+
+#include <sdf/sdf_config.h>
+#include <sdf/Element.hh>
+#include <sdf/Param.hh>
+
+
+namespace yarp 
+{
+    namespace dev
+    {
+        class IMultipleWrapper;
+    }
+}
+
+namespace gazebo
+{
+    class GazeboYarpContactLoadCellArray : public ModelPlugin
+    {
+        public:
+        GazeboYarpContactLoadCellArray();
+        virtual ~GazeboYarpContactLoadCellArray();
+    
+       /**
+        * Saves the gazebo pointer, creates the device driver
+        */
+        void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+    
+        private:
+       
+       /**
+        * Polydriver instance to connect to analog sensor server
+        */
+        yarp::dev::PolyDriver m_devWrapper;
+        
+       /**
+        * Wrapper to attach all necessary devices
+        */
+        yarp::dev::IMultipleWrapper *m_imultwrapper;
+        
+       /**
+        * Polydriver instance to instantiate the device driver
+        */
+        yarp::dev::PolyDriver m_devDriver;
+    
+       /**
+        * YARP property to store information from config file
+        */
+        yarp::os::Property m_parameters;    
+        
+       /**
+        * Network interface to connect to
+        */
+        std::string m_wrapperName;
+        
+       /**
+        * Device driver name to be instantiated
+        */
+        std::string m_sensorDriverName;
+ 
+       /**
+        * Name of the robot model loaded by model plugin 
+        */
+        std::string m_gazeboRobotName;
+   
+    };
+}
+
+
+#endif 

--- a/plugins/contactloadcellarray/include/yarp/dev/ContactLoadCellArrayDriver.h
+++ b/plugins/contactloadcellarray/include/yarp/dev/ContactLoadCellArrayDriver.h
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_CONTACTLOADCELLARRAYDRIVER_H
+#define GAZEBOYARP_CONTACTLOADCELLARRAYDRIVER_H
+
+#include <yarp/dev/DeviceDriver.h>
+#include <yarp/dev/IAnalogSensor.h>
+#include <yarp/dev/PreciselyTimed.h>
+#include <yarp/os/Stamp.h>
+#include <yarp/os/Semaphore.h>
+
+#include <yarp/sig/Matrix.h>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/common.hh>
+
+
+#include <gazebo/sensors/Sensor.hh>
+#include <gazebo/sensors/ContactSensor.hh>
+#include <gazebo/sensors/SensorManager.hh>
+
+#include <gazebo/physics/Contact.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Inertial.hh>
+#include <gazebo/physics/physics.hh>
+
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math.hh>
+
+namespace yarp
+{
+    namespace dev
+    {
+        class GazeboYarpContactLoadCellArrayDriver;
+    }
+}
+
+/**
+ * YARP Device Driver for an array of contact load cells giving 1-axis force at different locations
+ * 
+ * This device is used to simulate the contact normal forces that might be 
+ * measured by an arbitrary number of load cells at specific locations with respect
+ * to a given link's origin frame. It uses the instance of a Gazebo Contact Sensor which
+ * provides contact information of the link (specifically providing wrenches - 
+ * 6 axis force torque components,  acting at different position with respect to the link).
+ * The equivalent wrench acts on the Center of Gravity(CG) of the link expressed in link origin frame.
+ * The CG of thee link is defined by the <inertial > in the sdf as a child of <link> tag.
+ * This information is transformed and mapped to the desired contact normal forces.
+ * 
+ * MAJOR ASSUMPTION: The load cells are distributed over a plane perpendicular to the z-axis of the link frame
+ * and the load cells are measuring the force over the z-direction
+ * 
+ * In its current version, this device reads the location of the load cells (to be copied manually from the urdf or sdf onto the configuration file)
+ * from a configuration file. Reads the contact forces and torques acting at the gazebo collision level through a 
+ * gazebo ContactSensor instance. Finds an equivalent wrench acting at the CG of the specified link(location CG, rotation same as link origin). Transforms this
+ * equivalent wrench to the origin of the specified link. This transformation is necessary since the load cell locations are
+ * with respect to the link origin. Finally, the transformed equivalent wrench is mapped to an array of contact normal forces acting
+ * at the load cell locations. 
+ * 
+ * This mapping problem is an infinite solution problem and is solved by obtaining a pseudo inverse, 
+ * which gives the results with a minimized norm.
+ * 
+ * The configuation file must be specified in the sdf within the plugin element within the yarpConfigurationFile tags
+ * The configuration file must contain two groups [WRAPPER] and [DRIVER]
+ * 
+ * Parameters accepted in the config argument of the open method for [WRAPPER]:
+ * 
+ * | Parameter name| Type |Units|Default Value|Required |                 Description                |              Notes             |
+ * |:-------------:|:----:|:---:|:-----------:|:-------:|:------------------------------------------:|:------------------------------:|
+ * | name          |string|  -  |    -        |   Yes   | full name of the port opened by the device | MUST start with a '/' character|
+ * | period        |double|  ms |    20       |   No    | refresh period of broadcast value in ms    |    optional, default 20ms      |   
+ * | device        |string|  -  |    -        |   Yes   | name of the network wrapper to connect to  | MUST be set to analogServer    |    
+ *
+ * Parameters accepted in the config argument of the open method for [DRIVER]:
+ * 
+ * | Parameter name|      Type     |Units|Default Value|Required |                       Description                      |                        Notes                     |
+ * |:-------------:|:-------------:|:---:|:-----------:|:-------:|:------------------------------------------------------:|:------------------------------------------------:|
+ * | device        |    string     |  -  |    -        |   Yes   | name of the device driver to instantiate               | MUST be set to gazebo_contactloadcellarray|
+ * | loadCellNames |list of strings|  -  |    -        |   Yes   | list of load cell names, eg. (lr rr lf rf)             | locations MUST be obtained manually from urdf/sdf|
+ * | loadCellX     |list of doubles|  m  |    -        |   Yes   | list of load cell location X coordinate wrt link origin| MUST be the same size and order as loadCellName  |
+ * | loadCellY     |list of doubles|  m  |    -        |   Yes   | list of load cell location Y coordinate wrt link origin| MUST be the same size and order as loadCellName  |
+ * | loadCellZ     |list of doubles|  m  |    -        |   Yes   | list of load cell location Z coordinate wrt link origin| MUST be the same size and order as loadCellName  |
+ * | linkName      |     string    |  -  |    -        |   Yes   | name of the link associated to the contact sensor      |                            -                     |
+ *
+ * NOTE: Although being sensor-related, this plugin is implemented as a model plugin instead of a sensor plugin. This design choice is due to the fact that transformations related
+ * to the link were required for computations in this device; which could not be achieved through a sensor plugin, since Gazebo inherently divides its
+ * physics engine and sensor engine in its software architecture. As a model plugin, the link information can be directly accessed,
+ * however the sensor name and collision name related to the link are obtained by parsing through the SDF directly. Again, this design decision
+ * of parsing through the sdf is made due to the fact that the Link information does not give the type of sensors but only sensor counts.
+ * 
+ * This plugin in its current version assumes a only single collision element is associated to the specified link
+ * This sensor plugin in its current version handles only one link with a plugin instance 
+ * (i.e., multiple links cannot be specified per plugin, but multiple plugins can be instantiated through the sdf)
+ * The collision element in the contact sensor added to the specific link in the sdf should be set to {link_name}_collision
+ * The name of the collision element associated to the link should be set to default (i.e. "name" parameter should not be set so that it can take
+ * the default name {link_name}_collision. Otherwise, things become worse).
+ * 
+ * WARNING: Please note that the current version of this plugin is not tested on (heavily) nested models and also rather does not support the models
+ * having links with non-default collision element names.
+ * Refer discussion in \url https://github.com/robotology/gazebo-yarp-plugins/pull/338/files/e757d8a40d21eebf8c55db9e1c47bf397a134c43#r161473858
+ * for further information.
+ */
+class yarp::dev::GazeboYarpContactLoadCellArrayDriver : public yarp::dev::IAnalogSensor,
+                                                               public yarp::dev::DeviceDriver,
+                                                               public yarp::dev::IPreciselyTimed
+    {
+        public:
+        GazeboYarpContactLoadCellArrayDriver();
+        virtual ~GazeboYarpContactLoadCellArrayDriver();
+
+        /**
+         * Update callback from Gazebo
+         * Gets the contact information from the link contact sensor
+         * Computes equivalent wrench at the link CG (location CG, rotation link origin)
+         * Transforms this wrench to the link origin (same force, moment is transformed)
+         * Maps the transformed wrench to contact normal forces at load cell locations
+         */
+        void onUpdate(const gazebo::common::UpdateInfo& /*_info*/);
+    
+        // Device Driver
+        virtual bool open(yarp::os::Searchable& config);
+        virtual bool close();
+    
+        // Analog sensor
+        virtual int read(yarp::sig::Vector &out);
+        
+        // Analog sensor unimplemented - not required in simulation
+        virtual int getState(int ch);
+        virtual int getChannels();
+        virtual int calibrateChannel(int ch);
+        virtual int calibrateChannel(int ch, double v);
+        virtual int calibrateSensor();
+        virtual int calibrateSensor(const yarp::sig::Vector& value);
+    
+        // Precisely Timed
+        virtual yarp::os::Stamp getLastInputStamp(); 
+    
+        private:
+       /**
+        * Gets the link specified in the config file from the model
+        * instance loaded by Gazebo and stores it as a gazebo::physics::LinkPtr 
+        * \return true if specified link is found successfully 
+        */
+        bool initLinkAssociatedToContactSensor(yarp::os::Property &pluginParameters);
+        
+       /**
+        * Parses the sdf for link associated to the contact sensor
+        * to obtain the sensor name and the collision name of the link
+        * Uses the Gazebo Sensor Manager to get the pointer to the sensor 
+        * \return true if pointer to the contact sensor is set successfully
+        */
+        bool initContactSensor();
+        
+       /**
+        * Reads the configuration file for load cell locations
+        * \return true if successful
+        */
+        bool configure(yarp::os::Property &pluginParameters);
+        
+       /**
+        * Prepares a matrix as a function of loadcell locations
+        * which then maps an equivalent wrench to contact normal forces
+        * at the load cell locations
+        * \return true if successful
+        */
+        bool prepareMappingMatrix();
+        
+       /**
+        * Gets position of frame associated to the link CG
+        * with respect to the frame associated to the link origin
+        */
+        bool prepareLinkInformation();
+                
+        
+        /**
+         * Computes difference between measured CoP from equivalent wrench
+         * and estimated CoP from the contact normal forces, assuming
+         * a flat contact parallel to ground plane is made 
+         * and the loadcell locations lie in the same XY plane
+         */
+        void checkCoP(const yarp::sig::Vector &threeAxisContactForceTorque);
+        
+        // Pointer to the contact sensor
+        gazebo::sensors::ContactSensor* m_sensor;
+        
+        // Pointer to the robot model
+        gazebo::physics::Model* m_robot;
+        
+        // Pointer to the link associated to the sensor
+        gazebo::physics::Link* m_sensorLink;
+        
+        // Name of the link associated to the sensor
+        std::string m_linkAssociateToSensor;
+        
+        // Name of the link collision associated to the sensor
+        std::string m_linkCollisionName;
+        
+        // Position of link CG wrt link origin
+        ignition::math::Vector3d m_linkOrigin_Pos_linkCG;
+   
+        // Timestamp
+        yarp::os::Stamp m_stamp;
+    
+        // Mutex
+        yarp::os::Mutex m_dataMutex;
+        
+        // Vector of magnitudes of contact normal forces acting at load cell locations
+        yarp::sig::Vector m_contactNormalForces;
+        
+        // Vector of load cell locations with respect to the link origin
+        std::vector<yarp::sig::Vector> m_loadCellLocations;
+        
+        // Matrix to map an equivalent wrench acting at link origin to contact normal forces at load cell locations
+        yarp::sig::Matrix m_mapWrenchtoNormalForce;
+        
+        // Pointer to a connection signal to be tiggered when the model/sensor is updated
+        gazebo::event::ConnectionPtr m_updateConnection;
+    
+        // Flag to indicate availability of the sensor output after first computation
+        bool m_dataAvailable = false;
+  };
+
+
+#endif 

--- a/plugins/contactloadcellarray/src/ContactLoadCellArray.cc
+++ b/plugins/contactloadcellarray/src/ContactLoadCellArray.cc
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#include "ContactLoadCellArrayDriver.h"
+#include "ContactLoadCellArray.hh"
+
+#include <GazeboYarpPlugins/Handler.hh>
+#include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
+
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/dev/Wrapper.h>
+
+#include <string>
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+
+GZ_REGISTER_MODEL_PLUGIN(gazebo::GazeboYarpContactLoadCellArray)
+
+namespace gazebo 
+{
+    GazeboYarpContactLoadCellArray::GazeboYarpContactLoadCellArray() : ModelPlugin(), m_imultwrapper(0)
+    {
+
+    }
+  
+
+    GazeboYarpContactLoadCellArray::~GazeboYarpContactLoadCellArray()
+    {
+        if (m_imultwrapper)
+        {
+            m_imultwrapper->detachAll();
+            m_imultwrapper = 0;
+        }
+    
+        if (m_devWrapper.isValid())
+        {
+            m_devWrapper.close();
+        }
+    
+        if (m_devDriver.isValid())
+        {
+            m_devDriver.close();
+        }
+    
+        GazeboYarpPlugins::Handler::getHandler()->removeRobot(m_gazeboRobotName);
+        yarp::os::Network::fini();
+    }
+
+
+    void GazeboYarpContactLoadCellArray::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
+    {
+        yarp::os::Network::init();
+        if (!yarp::os::Network::checkNetwork(GazeboYarpPlugins::yarpNetworkInitializationTimeout))
+        {
+            yError() << "GazeboYarpContactLoadCellArray::Load error: yarp network does not seem to be available, is the yarp server running?";
+            return;
+        }
+    
+        if (!_parent)
+        {
+            gzerr << "GazeboYarpContactLoadCellArray plugin requires a parent \n";
+            return;
+        }
+
+        // Insert the pointer in the singleton handler for retrieving it in the yarp driver
+        GazeboYarpPlugins::Handler::getHandler()->setRobot(boost::get_pointer(_parent));
+
+        m_gazeboRobotName = _parent->GetScopedName();
+   
+        // Add the gazebo device driver to the factory
+        ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpContactLoadCellArrayDriver>
+                                           ("gazebo_contactloadcellarray", "analogServer", "GazeboYarpContactLoadCellArray"));
+           
+        // Getting .ini config file from _sdf
+        yarp::os::Bottle wrapper_properties;
+        yarp::os::Bottle driver_properties;
+    
+        bool configuration_loaded = false;
+        if (_sdf->HasElement("yarpConfigurationFile"))
+        {
+            std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
+            std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+      
+            GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_parent, _sdf, m_parameters);
+      
+            bool wipe = false;
+            if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str(), wipe))
+            {
+                wrapper_properties = m_parameters.findGroup("WRAPPER");
+                if (wrapper_properties.isNull())
+                {
+                    yError() << "GazeboYarpContactLoadCellArray Plugin failed: [WRAPPER] group not found in config file";
+                    return;  
+                }
+
+                driver_properties = m_parameters.findGroup("DRIVER");
+                if (driver_properties.isNull())
+                {
+                    yError() << "GazeboYarpContactLoadCellArray Plugin failed: [DRIVER] group not found in config file";
+                    return;
+                }
+
+                configuration_loaded = true;
+            }
+        }
+    
+        if (!configuration_loaded)
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: File .ini not found, load failed";
+            return;
+        }
+    
+        // Check on Required Parameter for Analog Sensor Wrapper
+        if (wrapper_properties.find("device").isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: Missing parameter \"device\"  under [WRAPPER] in config";
+            return;
+        }
+        m_wrapperName = wrapper_properties.find("device").asString();
+        if (m_wrapperName != "analogServer")
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: \"device\" should be set to \"analogSensor\" network wrapper.";
+            return;
+        }
+    
+        // Check on Required Parameter for Device driver
+        if (driver_properties.find("device").isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: Missing parameter \"device\"  under [DRIVER] in config";
+            return;
+        }
+        m_sensorDriverName = driver_properties.find("device").asString();
+        if (m_sensorDriverName != "gazebo_contactloadcellarray")
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: \"device\" should be set to \"gazebo_contactloadcellarray\".";
+            return;
+        }
+    
+        if (driver_properties.find("linkName").isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: Missing parameter \"linkName\"  under [DRIVER] in config";
+            return;
+        }
+
+        // Adding robot name so that it can be used in the driver
+        yarp::os::Bottle& driver_robot_config = driver_properties.addList();
+        driver_robot_config.addString("robotName");
+        driver_robot_config.addString(m_gazeboRobotName.data());
+   
+        // Check if robot name is added to the pluginParameters
+        if (driver_properties.find("robotName").isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: Sensor name not passed to the driver";
+            return;
+        }
+    
+        // Open the wrapper
+        if (!m_devWrapper.open(wrapper_properties))
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: error in opening wrapper for yarp driver";
+            return;
+        }
+    
+        // Open the driver
+        if (!m_devDriver.open(driver_properties))
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: error in opening yarp driver";
+            return;
+        }
+    
+        // Attach the driver to the wrapper
+        yarp::dev::PolyDriverList driver_list;
+    
+        if (!m_devWrapper.view(m_imultwrapper))
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: Error in loading wrapper";
+            return;
+        }
+    
+        driver_list.push(&m_devDriver, "dummy");
+    
+        if (!m_imultwrapper->attachAll(driver_list))
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: Error in connecting the wrapper and device";
+        }
+     
+    } 
+} 

--- a/plugins/contactloadcellarray/src/ContactLoadCellArrayDriver.cpp
+++ b/plugins/contactloadcellarray/src/ContactLoadCellArrayDriver.cpp
@@ -1,0 +1,468 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#include "ContactLoadCellArrayDriver.h"
+#include <GazeboYarpPlugins/Handler.hh>
+#include <GazeboYarpPlugins/common.h>
+
+#include <yarp/os/LockGuard.h>
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/math/Math.h>
+#include <yarp/math/SVD.h>
+
+#include <sdf/Param.hh>
+
+#define DEBUG 0
+
+using namespace yarp::dev;
+
+GazeboYarpContactLoadCellArrayDriver::GazeboYarpContactLoadCellArrayDriver()
+{
+
+}
+
+GazeboYarpContactLoadCellArrayDriver::~GazeboYarpContactLoadCellArrayDriver()
+{
+
+}
+
+void GazeboYarpContactLoadCellArrayDriver::onUpdate(const gazebo::common::UpdateInfo& _info)
+{ 
+    const gazebo::msgs::Contacts& contacts = this->m_sensor->Contacts();
+    
+    ignition::math::Vector3d resultantForceonCG(0.0, 0.0, 0.0);
+    ignition::math::Vector3d resultantMomentonCG(0.0, 0.0, 0.0);
+        
+    const double TIME_CONVERSION_NS = 1.0e-9;
+    double timestamp = -1;
+    for (size_t i = 0; i < contacts.contact_size(); i++)
+    {
+        for (int j = 0; j < contacts.contact(i).position_size(); j++)
+        {
+            double t = contacts.contact(i).time().sec() + TIME_CONVERSION_NS*contacts.contact(i).time().nsec();
+            if (timestamp < 0)
+            {
+                timestamp = t;
+            }
+
+            // This block allows addition of wrench components only if they arrive in same timestamp
+            if (!ignition::math::equal(t, timestamp))
+                continue;
+
+            const gazebo::msgs::JointWrench& wrench = contacts.contact(i).wrench(j);
+
+            // we are interested only in the link specific contact wrenches and not the contact surface
+            if (wrench.body_1_name() == this->m_linkCollisionName)
+            {
+                resultantForceonCG += ignition::math::Vector3d(wrench.body_1_wrench().force().x(),
+                                                            wrench.body_1_wrench().force().y(),
+                                                            wrench.body_1_wrench().force().z());
+                resultantMomentonCG += ignition::math::Vector3d(wrench.body_1_wrench().torque().x(),
+                                                             wrench.body_1_wrench().torque().y(),
+                                                             wrench.body_1_wrench().torque().z());
+            }
+            else if (wrench.body_2_name() == this->m_linkCollisionName)
+            {
+                resultantForceonCG += ignition::math::Vector3d(wrench.body_2_wrench().force().x(),
+                                                            wrench.body_2_wrench().force().y(),
+                                                            wrench.body_2_wrench().force().z());
+                resultantMomentonCG += ignition::math::Vector3d(wrench.body_2_wrench().torque().x(),
+                                                             wrench.body_2_wrench().torque().y(),
+                                                             wrench.body_2_wrench().torque().z());
+            }
+        }
+    }
+
+#if DEBUG 
+     std::cout << "Wrench at CG [ " << resultantForceonCG.X() << " " <<  resultantForceonCG.Y() << " " << resultantForceonCG.Z() << " " << resultantMomentonCG.X() << " " <<  resultantMomentonCG.Y() << " " << resultantMomentonCG.Z() << " ]" << std::endl;
+#endif
+     
+    // The wrench is applied at the CG and with the rotation same as link origin 
+    // consider L: Link Origin Frame, C: Link CG Frame, ^: cross product operator givng a skew symmetric matrix
+    // L_f = C_f
+    // L_m = [L_o_c]^L_f
+    ignition::math::Vector3d resultantForceonLinkOrigin = resultantForceonCG;
+    
+    ignition::math::Matrix3d L_o_C_cross = ignition::math::Matrix3d(0, -m_linkOrigin_Pos_linkCG.Z(), m_linkOrigin_Pos_linkCG.Y(),
+                                                                    m_linkOrigin_Pos_linkCG.Z(), 0, -m_linkOrigin_Pos_linkCG.X(),
+                                                                    -m_linkOrigin_Pos_linkCG.Y(), m_linkOrigin_Pos_linkCG.X(), 0);
+    ignition::math::Vector3d resultantMomentonLinkOrigin = resultantMomentonCG + L_o_C_cross*resultantForceonLinkOrigin;
+   
+#if DEBUG     
+    std::cout << "Wrench at Link Origin [ " << resultantForceonLinkOrigin.X() << " " <<  resultantForceonLinkOrigin.Y() << " " << resultantForceonLinkOrigin.Z() << " " << resultantMomentonLinkOrigin.X() << " " <<  resultantMomentonLinkOrigin.Y() << " " << resultantMomentonLinkOrigin.Z() << " ]" << std::endl;
+#endif    
+    
+    // build a reduced wrench only with normal force f_{z}, and tangential moments tau_{x}, tau_{y} 
+    yarp::sig::Vector reducedWrench;
+    reducedWrench.clear();
+    reducedWrench.push_back(resultantForceonLinkOrigin.Z());
+    reducedWrench.push_back(resultantMomentonLinkOrigin.X());
+    reducedWrench.push_back(resultantMomentonLinkOrigin.Y()); 
+    
+    // map this reduced wrench to the load cell normal forces at the respective load cell locations
+    if (reducedWrench.size() != m_mapWrenchtoNormalForce.cols())
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver Error: Improper contact wrench dimensions. cannot map to load cell normal forces";
+    }
+    m_contactNormalForces.resize(m_mapWrenchtoNormalForce.rows());
+    using namespace yarp::math;
+    m_contactNormalForces = m_mapWrenchtoNormalForce*reducedWrench; 
+    
+    // This flag is important. If its not set to true, the analog sensor ouput will be zero
+    m_dataAvailable = true;
+    m_stamp.update(m_sensor->LastMeasurementTime().Double());
+    
+#if DEBUG    
+    checkCoP(reducedWrench);
+#endif
+}
+
+void GazeboYarpContactLoadCellArrayDriver::checkCoP(const yarp::sig::Vector& threeAxisContactForceTorque)
+{
+    yarp::sig::Vector copFromEquivalentContactWrench(2);
+    copFromEquivalentContactWrench[0] = -threeAxisContactForceTorque[2]/threeAxisContactForceTorque[0]; // -tau_{y]/f_{z}
+    copFromEquivalentContactWrench[1] = threeAxisContactForceTorque[1]/threeAxisContactForceTorque[0];  // tau_{x}/f_{z}
+
+    
+    // Computing COP from contact normal forces, assumption load cell locations are on the same XY plane
+    double sumOfNormalForcesInN = 0.0;
+    yarp::sig::Vector weightedSumOfLocations(3);
+    weightedSumOfLocations.zero();
+    
+    using namespace yarp::math;
+    using namespace yarp::sig;
+    for (size_t i = 0; i < m_contactNormalForces.size(); i++)
+    {
+        sumOfNormalForcesInN += m_contactNormalForces[i];
+        weightedSumOfLocations += m_contactNormalForces[i]*m_loadCellLocations[i];
+    }
+    
+    yarp::sig::Vector copFromContactNormalForces(2);
+    copFromContactNormalForces[0] = weightedSumOfLocations[0]/sumOfNormalForcesInN;
+    copFromContactNormalForces[1] = weightedSumOfLocations[1]/sumOfNormalForcesInN;
+    
+    yarp::sig::Vector differenceInCoP(2);
+    differenceInCoP = copFromEquivalentContactWrench - copFromContactNormalForces;
+
+#if DEBUG     
+    //yInfo() << "GazeboYarpContactLoadCellArrayDriver: Measured Wrench: [" << threeAxisContactForceTorque[0] <<", " << threeAxisContactForceTorque[1] << ", " << threeAxisContactForceTorque[2] << "]";
+    //yInfo() << "GazeboYarpContactLoadCellArrayDriver: Measured CoP: [" << copFromEquivalentContactWrench[0] <<", " << copFromEquivalentContactWrench[1] <<"]";
+    //yInfo() << "GazeboYarpContactLoadCellArrayDriver: Estimated CoP: [" << copFromContactNormalForces[0] <<", " << copFromContactNormalForces[1] <<"]";
+    yInfo() << "GazeboYarpContactLoadCellArrayDriver: Difference in measured CoP and estimated CoP: [" << differenceInCoP[0] <<", " << differenceInCoP[1] <<"]";
+#endif
+    
+    if (std::abs(copFromContactNormalForces[0] - copFromEquivalentContactWrench[0])/copFromEquivalentContactWrench[0] > 1e-09)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Measured CoP and Estiamted CoP X intercept do not match";
+    }
+    
+    if (std::abs(copFromContactNormalForces[1] - copFromEquivalentContactWrench[1])/copFromEquivalentContactWrench[1] > 1e-09)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Measured CoP and Estiamted CoP Y intercept do not match";
+    }
+}
+
+
+bool GazeboYarpContactLoadCellArrayDriver::open(yarp::os::Searchable& config)
+{
+    yarp::os::Property pluginParams;
+    pluginParams.fromString(config.toString().c_str());
+  
+    std::string robotName(pluginParams.find("robotName").asString().c_str());
+  
+    this->m_robot = GazeboYarpPlugins::Handler::getHandler()->getRobot(robotName);
+    if (this->m_robot == NULL)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Robot Model was not found";
+        return false;
+    }
+  
+    if (!this->initLinkAssociatedToContactSensor(pluginParams))
+    {
+        return false;
+    }
+   
+    if (!this->initContactSensor())
+    {
+        return false;
+    }
+
+    if (!this->configure(pluginParams))
+    {
+        return false;
+    }
+  
+    if (!this->prepareLinkInformation())
+    {
+        return false;
+    }
+  
+    yarp::os::LockGuard guard(m_dataMutex);
+  
+    this->m_updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpContactLoadCellArrayDriver::onUpdate, this, _1));
+    this->m_sensor->SetActive(true);
+  
+    return true;
+}
+
+bool GazeboYarpContactLoadCellArrayDriver::close()
+{
+    yarp::os::LockGuard guard(m_dataMutex);
+    this->m_updateConnection.reset();
+    return true;
+}
+
+bool GazeboYarpContactLoadCellArrayDriver::initLinkAssociatedToContactSensor(yarp::os::Property &pluginParameters)
+{
+    m_linkAssociateToSensor = pluginParameters.find("linkName").asString();
+  
+    const gazebo::physics::Link_V &gazeboModelLinks = m_robot->GetLinks();
+    std::string linkNameScopedEnding = "::" + m_linkAssociateToSensor;
+    bool linkFound = false;
+    for (size_t gazeboLink = 0; gazeboLink < gazeboModelLinks.size(); gazeboLink++)
+    {  
+        std::string gazeboLinkName = gazeboModelLinks[gazeboLink]->GetScopedName();
+        if (GazeboYarpPlugins::hasEnding(gazeboLinkName, linkNameScopedEnding))
+        {
+            linkFound = true;
+            m_sensorLink = boost::get_pointer(gazeboModelLinks[gazeboLink]);
+            break;
+        }
+    }
+  
+    if (!linkFound)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: initContactSensor(): Link associated to sensor not found";
+        return false;
+    }
+    
+    return true;
+}
+
+bool GazeboYarpContactLoadCellArrayDriver::initContactSensor()
+{
+    // Choosing to get the sensor information from the sdf::Element of the link rather than gazebo::LinkPtr
+    // because Gazebo has a division between physics engine and sensors engine handled in
+    // separate threads. To avoid any runtime discrepancy, the decision to get info from sdf is made.
+    // Also the Link Element might have multiple sensors, we need specifically the contact type sensor
+    // Assumes there is only one contact collision element per link
+    size_t linkSensorCount = m_sensorLink->GetSensorCount();
+    sdf::ElementPtr sensorsdf;
+    bool contactSensorFound = false;
+    for (size_t sensor = 0; sensor < linkSensorCount; sensor++)
+    {
+        sensorsdf = (m_sensorLink->GetSDF()).get()->GetElement("sensor");
+        if (sensorsdf.get()->GetAttribute("type")->GetAsString() == "contact")
+        {
+            break;
+        }
+    }
+  
+    std::string sensorName = sensorsdf.get()->GetAttribute("name")->GetAsString();
+    // For some reason scoped name is not necessary force
+    // instantiating the contact sensor, uncomment the block if necessary
+    // Get collision name 
+    sdf::ElementPtr collision = (sensorsdf.get()->GetElement("contact")).get()->GetElement("collision"); 
+    std::string collisionName = collision.get()->GetValue()->GetAsString();
+    /* std::string tmp = m_sensorLink->GetName() + "::" + collisionName + "::" + sensorName;
+     * sensorName.clear();
+     * sensorName = tmp;
+     */
+  
+  
+    this->m_linkCollisionName = m_robot->GetName() + "::" + m_sensorLink->GetName() + "::" + collisionName;
+  
+    yarp::os::LockGuard guard(m_dataMutex);
+    gazebo::sensors::SensorManager *mgr = gazebo::sensors::SensorManager::Instance();
+  
+    // If sensors are not initialized, fail.
+    if (!mgr->SensorsInitialized())
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Sensors not initialized";
+        return false;
+    }
+     
+  
+    gazebo::sensors::SensorPtr contact = mgr->GetSensor(sensorName); 
+    this->m_sensor = dynamic_cast<gazebo::sensors::ContactSensor*>(contact.get());
+    if (this->m_sensor == nullptr)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Could not get pointer to the sensor";
+        return false;      
+    }
+    this->m_sensor->SetActive(true);
+    return true;
+}
+
+
+bool GazeboYarpContactLoadCellArrayDriver::configure(yarp::os::Property& pluginParams)
+{
+    // Get load cell locations with respect to the CG of the link (body1)
+    yarp::os::Bottle *loadCellNames = pluginParams.find("loadCellNames").asList();
+    if (loadCellNames->size() == 0)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Error parsing parameters: \"loadCellNames\" should be followed by  list";
+        return false;
+    }
+  
+    yarp::os::Bottle *loadCellX = pluginParams.find("loadCellX").asList();
+    yarp::os::Bottle *loadCellY = pluginParams.find("loadCellY").asList();
+    yarp::os::Bottle *loadCellZ = pluginParams.find("loadCellZ").asList();
+  
+    if (loadCellX->size() == 0 || loadCellY->size() == 0 || loadCellZ->size() == 0)
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Error parsing parameters: \"loadCellX , ..Y, ..Z\" should be followed by  list";
+        return false;    
+    }
+  
+    if (loadCellX->size() != loadCellNames->size() || loadCellY->size() != loadCellNames->size() || loadCellZ->size() != loadCellNames->size())
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver: Error parsing parameters: \"loadCellX , ..Y, ..Z\" should be the same size as \"loadCellNames\"";
+        return false;
+    }
+  
+    for (size_t i = 0; i < loadCellNames->size(); i++)
+    {
+        yarp::sig::Vector loadCellLoc(3);
+        loadCellLoc.clear();
+        loadCellLoc.push_back(loadCellX->get(i).asDouble());
+        loadCellLoc.push_back(loadCellY->get(i).asDouble());
+        loadCellLoc.push_back(loadCellZ->get(i).asDouble());
+        this->m_loadCellLocations.push_back(loadCellLoc);
+     }
+  
+     m_contactNormalForces.resize(m_loadCellLocations.size());  
+     if (!this->prepareMappingMatrix())
+     {
+         return false;
+     }
+    
+    return true;
+}
+
+bool GazeboYarpContactLoadCellArrayDriver::prepareMappingMatrix()
+{
+    // get the size of the load cell locations
+    int n_cells = this->m_loadCellLocations.size();
+    const int N_AXIS = 3;
+  
+    // Consider w = Af ; where w is the wrench of size 3x1 containing normal force, tangential and radial torques
+    // A is the matrix that maps the array of load cell normal forces f to an resultant wrench w acting 
+    // at the contact. However, we ae solving the inverse problem of mapping a wrench acting at the contact link
+    // to the presure sensor array normal forces, hence we need to obtain the pseudo inverse through
+    // f = (A+)w ; where (A+) is the pseudo inverse. Mapping an equivalent wrench to a number of load cell 
+    // normal forces has infinite solutions, but considering the pseudo inverse gives us the solution with minimized norm.
+    // Hence it is not necessary that the array of load cell simulate the same forces at corresponding locations
+    // similar to the real robot. However, the resultant wrench from the load cell array of normal forces should be valid.
+    // The matrix A is the function of loadCell locations (x, y) with respect to the link coordinate frame
+    
+    // ASSUMPTION: The load cells are distributed over a plane perpendicular to the z-axis of the link frame
+    // and the load cells are measuring the force over the z-direction
+    yarp::sig::Matrix A; 
+    A.resize(N_AXIS ,n_cells);
+  
+    // Add the respective columns to the mapping matrix
+    for (int i = 0; i < n_cells; i++)
+    {
+        yarp::sig::Vector columnMap;
+        columnMap.clear();
+        columnMap.push_back(1);
+        columnMap.push_back(this->m_loadCellLocations[i][1]); // r_y : y-intercept of the contact point with respect to link origin
+        columnMap.push_back(-this->m_loadCellLocations[i][0]); // -r_x : x-intercept of the contact point with respect to link origin
+        
+        if (!A.setCol(i, columnMap))
+        {
+            yError() << "GazeboYarpContactLoadCellArrayDriver Failed: Failed to form mapping matrix";
+            return false;
+        }
+    }
+  
+    if (A.rows() != N_AXIS || A.cols() != m_loadCellLocations.size())
+    {
+        yError() << "GazeboYarpContactLoadCellArrayDriver Failed: Mismatched dimensions in the mapping matrix";
+        return false;
+    }
+ 
+    // Compute the pseudo-inverse to determine the mapping matrix
+    this->m_mapWrenchtoNormalForce = yarp::math::pinv(A);
+
+    return true;
+}
+
+bool GazeboYarpContactLoadCellArrayDriver::prepareLinkInformation()
+{
+    // \url https://bitbucket.org/osrf/gazebo/issues/545/request-change-contact-reference-frame
+    // \url https://bitbucket.org/osrf/gazebo/pull-requests/355/bullet-contact-sensor/diff
+    // According to the above issue and PR, the force torque feedback values are acting at the 
+    // CG with respect to the link origin frame.
+     
+#if GAZEBO_MAJOR_VERSION >= 8
+    // Just get information about location of link CG with respect to the link origin frame
+    this->m_linkOrigin_Pos_linkCG = m_sensorLink->GetInertial().get()->Pose().Pos();
+#else
+    gazebo::math::Pose tmp = m_sensorLink->GetInertial().get()->GetPose();
+    this->m_linkOrigin_Pos_linkCG = ignition::math::Vector3d(tmp.pos.x, tmp.pos.y, tmp.pos.z);
+#endif
+    
+#if DEBUG   
+     std::cout << "L_o_C: \n [ " << m_linkOrigin_Pos_linkCG[0] << " " <<  m_linkOrigin_Pos_linkCG[1] << " " << m_linkOrigin_Pos_linkCG[2] << " ]"<< std::endl;
+#endif  
+   
+    return true;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::read(yarp::sig::Vector& out)
+{
+    yarp::os::LockGuard guard(m_dataMutex);
+  
+    if (!m_dataAvailable)
+    {
+        return AS_TIMEOUT;
+    }
+  
+    out.resize(m_contactNormalForces.size());
+    out = m_contactNormalForces;
+  
+    return AS_OK;
+}
+
+
+yarp::os::Stamp GazeboYarpContactLoadCellArrayDriver::getLastInputStamp()
+{
+    return this->m_stamp;
+}
+
+
+int GazeboYarpContactLoadCellArrayDriver::getState(int ch)
+{
+    return AS_OK;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::calibrateChannel(int ch)
+{
+    return AS_OK;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::calibrateChannel(int ch, double v)
+{
+    return AS_OK;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::calibrateSensor(const yarp::sig::Vector& value)
+{
+    return AS_OK;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::calibrateSensor()
+{
+    return AS_OK;
+}
+
+int GazeboYarpContactLoadCellArrayDriver::getChannels()
+{
+    return AS_OK;
+}


### PR DESCRIPTION
This device is used to simulate the contact normal forces that might be observed by an arbitrary number of load cells at specific locations with respect to a given link's origin frame. 
It uses the instance of a Gazebo Contact Sensor which provides contact information of the link (specifically providing wrenches acting at the CG). This information is transformed and mapped to the desired contact normal forces. In its current version, this device reads the location of the load cells (to be mentioned manually from the urdf or sdf) from a configuration file. 

- Reads the contact forces and torques acting at the gazebo collision level through a  gazebo ContactSensor instance. 
- Finds an equivalent wrench acting at the CG of the specified link.
- Transforms this equivalent wrench to the origin of the specified link. This transformation is necessary since the load cell locations are usually designed as fixed joints  with respect to the link origin in the model. 
- Finally, the transformed equivalent wrench is mapped to an array of contact normal forces acting at the load cell locations.  This mapping problem is an infinite solution problem and is solved by obtaining a pseudo inverse,  which gives the results with a minimized norm.