### PR TITLE
Model Pose Publisher model plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,5 +16,6 @@ Lorenzo Natale <lorenzo.natale@iit.it>
 Marco Randazzo <marco.randazzo@iit.it>
 Miguel Aragao <miguelaragao91@gmail.com>
 Mirko Ferrati <mirko.ferrati@gmail.com>
+Nicola Piga <nicolapiga@gmail.com>
 Silvio Traversaro <silvio.traversaro@iit.it>
 Prashanth Ramadoss <prashanth.ramadoss@iit.it>

--- a/doc/embed_plugins.md
+++ b/doc/embed_plugins.md
@@ -40,7 +40,7 @@ but are nevertheless useful for simulating complex scenarios.
 | Display the Center of Mass of a model | `gazebo_yarp_showmodelcom` | Model | gazebo::ShowModelCoM |
 | Project an image stream on a simulated surface | `gazebo_yarp_videotexture` | Visual  | gazebo::VideoTexture |
 | Expose a YARP RPC interface to create/manipulate objects programatically. | `gazebo_yarp_worldinterface` | Model |  gazebo::WorldInterface |
-| Publish the absolute pose of the root link of a model. | `gazebo_yarp_modelPosePublisher` | Model | gazebo::GazeboYarpModelPosePublisher |
+| Publish the absolute pose of the root link of a model. | `gazebo_yarp_modelposepublisher` | Model | gazebo::GazeboYarpModelPosePublisher |
 
 
 ## Using the plugins in Gazebo Models

--- a/doc/embed_plugins.md
+++ b/doc/embed_plugins.md
@@ -40,6 +40,7 @@ but are nevertheless useful for simulating complex scenarios.
 | Display the Center of Mass of a model | `gazebo_yarp_showmodelcom` | Model | gazebo::ShowModelCoM |
 | Project an image stream on a simulated surface | `gazebo_yarp_videotexture` | Visual  | gazebo::VideoTexture |
 | Expose a YARP RPC interface to create/manipulate objects programatically. | `gazebo_yarp_worldinterface` | Model |  gazebo::WorldInterface |
+| Publish the absolute pose of the root link of a model. | `gazebo_yarp_modelPosePublisher` | Model | gazebo::GazeboYarpModelPosePublisher |
 
 
 ## Using the plugins in Gazebo Models

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -33,3 +33,4 @@ add_subdirectory(depthCamera)
 
 
 add_subdirectory(contactloadcellarray)
+add_subdirectory(modelposepublisher)

--- a/plugins/modelposepublisher/CMakeLists.txt
+++ b/plugins/modelposepublisher/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (C) 2018 Istituto Italiano di Tecnologia 
+# Authors: see AUTHORS file.
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+cmake_minimum_required(VERSION 2.8.7)
+
+PROJECT(Plugin_ModelPosePublisher)
+
+include(AddGazeboYarpPluginTarget)
+
+set(LIB_COMMON_NAME gazebo_yarp_lib_common)
+if(CMAKE_VERSION VERSION_LESS 3.0.0)
+    get_property(GAZEBO_YARP_COMMON_HEADERS GLOBAL PROPERTY GAZEBO_YARP_COMMON_HEADERS)
+    unset(LIB_COMMON_NAME)
+endif()
+
+add_gazebo_yarp_plugin_target(LIBRARY_NAME modelPosePublisher
+                              INCLUDE_DIRS include/gazebo
+                              SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS} ${YARP_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS}  ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS}
+                              LINKED_LIBRARIES ${LIB_COMMON_NAME} ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}
+                              HEADERS include/gazebo/ModelPosePublisher.hh
+                              SOURCES src/ModelPosePublisher.cc
+                              )

--- a/plugins/modelposepublisher/CMakeLists.txt
+++ b/plugins/modelposepublisher/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_VERSION VERSION_LESS 3.0.0)
     unset(LIB_COMMON_NAME)
 endif()
 
-add_gazebo_yarp_plugin_target(LIBRARY_NAME modelPosePublisher
+add_gazebo_yarp_plugin_target(LIBRARY_NAME modelposepublisher
                               INCLUDE_DIRS include/gazebo
                               SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS} ${YARP_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS}  ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS} ${OGRE_INCLUDE_DIRS}
                               LINKED_LIBRARIES ${LIB_COMMON_NAME} ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES}

--- a/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
+++ b/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
@@ -56,7 +56,7 @@ namespace gazebo
     ///     ...
     ///     </link>
     ///
-    ///    <plugin name='...' filename='libgazebo_yarp_modelPosePublisher.so'>
+    ///    <plugin name='...' filename='libgazebo_yarp_modelposepublisher.so'>
     ///      <period>1.0</period>
     ///    </plugin>
     ///

--- a/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
+++ b/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
@@ -105,9 +105,9 @@ namespace gazebo
     /// SDF tag in seconds. If the parameter is not provided a default value of 10 ms
     /// is used.
     ///
-    /// This plugin __does not__ support <a href="http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot">Gazebo nested models</a>
+    /// This plugin __does not__ support [Gazebo nested models](http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot)
     /// since the method `gazebo::physics::WorldPose()` does not work properly
-    /// with nested models (see <a href="https://bitbucket.org/osrf/gazebo/issues/2410/wrong-gazebo-physics-model-worldpose-for">issue</a>).
+    /// with nested models (see [issue](https://bitbucket.org/osrf/gazebo/issues/2410/wrong-gazebo-physics-model-worldpose-for")).
     ///
     class GazeboYarpModelPosePublisher : public ModelPlugin
     {

--- a/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
+++ b/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
@@ -107,7 +107,7 @@ namespace gazebo
     ///
     /// This plugin __does not__ support <a href="http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot">Gazebo nested models</a>
     /// since the method `gazebo::physics::WorldPose()` does not work properly
-    /// with nested models.
+    /// with nested models (see <a href="https://bitbucket.org/osrf/gazebo/issues/2410/wrong-gazebo-physics-model-worldpose-for">issue</a>).
     ///
     class GazeboYarpModelPosePublisher : public ModelPlugin
     {

--- a/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
+++ b/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia iCub Facility
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_MODELPOSEPUBLISHER_HH
+#define GAZEBOYARP_MODELPOSEPUBLISHER_HH
+
+// gazebo
+#include <gazebo/common/Plugin.hh>
+
+// yarp
+#include <yarp/os/Network.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IFrameTransform.h>
+#include <yarp/dev/PolyDriver.h>
+
+namespace gazebo
+{
+    /// \class GazeboYarpModelPosePublisher
+    /// Gazebo Plugin that publishes the pose of the root link
+    /// of a model with respect to the Gazebo world frame.
+    ///
+    /// This plugin instantiates a `yarp::dev::FrameTransformClient`
+    /// in order to publish the transform between the Gazebo world frame
+    /// and the root link of the model.
+    /// This requires a `yarp::dev::FrameTransformServer` to be actived and
+    /// running before the model is inserted in Gazebo. It is not required to
+    /// write code in order to have a working `FrameTransfomServer`. Instead `yarpdev`
+    /// can be used from the command line, e.g.
+    /// \code
+    /// yarpdev --device transformServer --ROS::enable_ros_publisher false --ROS::enable_ros_subscriber false
+    /// \endcode
+    /// In the example above support to ROS is disabled.
+    ///
+    /// Each transform published by the plugin contains as `source` frame the string
+    /// "/inertial" and as `target` frame a string that depends on the `name` option
+    /// of the `model` tag within the SDF. If such a name is `<name>` the string describing
+    /// the `target` will be "/<name>/frame". In case the model `<name>` is inserted in the
+    /// Gazebo environment more than once than the its name becomes `<name>_x` where
+    /// `x` assumes the values `0, 1, 2...`. This beavior depends on the internal behavior of
+    /// Gazebo.
+    ///
+    /// The pose published by the plugin is that of the __root link__ of the model with respect
+    /// to the Gazebo world frame. If the SDF of the model is the following
+    /// \code
+    /// <sdf>
+    ///   <model name="object">
+    ///   <!-- pose of model frame w.r.t Gazebo world -->
+    ///   <pose> x_m y_m z_m roll_m pich_m yaw_m </pose>
+    ///
+    ///     <link name="object_root_link">
+    ///     <!-- pose of the root link w.r.t the model frame -->
+    ///     <pose> x_l y_l z_l roll_l pich_l yaw_l </pose>    
+    ///     ...
+    ///     </link>
+    ///
+    ///    <plugin name='...' filename='libgazebo_yarp_modelPosePublisher.so'>
+    ///      <period>1.0</period>
+    ///    </plugin>
+    ///
+    ///	  </model>
+    /// <\sdf>
+    /// \endcode
+    /// then the pose of the root link depends on both the transformation between
+    /// the Gazebo world frame and the model frame and the transformation between
+    /// the model frame and the root link.
+    ///
+    /// In order to retrieve the published transform an istance of
+    /// `yarp::dev::FrameTransformClient` can be used. An example is provided below
+    /// \code
+    /// ...
+    /// // Instantiate the driver
+    ///	yarp::dev::PolyDriver m_drvTransformClient;
+    /// yarp::dev::IFrameTransform* m_tfClient;
+    /// yarp::os::Property propTfClient;
+    /// propTfClient.put("device", "transformClient");
+    /// propTfClient.put("local", "/transformClientLocal");
+    /// propTfClient.put("remote", "/transformServer");
+    ///
+    /// // Check if the driver opened correctly
+    /// bool ok_open = m_drvTransformClient.open(propTfClient);
+    /// if (!ok) {
+    ///     // Error...
+    /// }
+    ///
+    /// // Check if the view was obtained succesfully
+    /// bool ok_view = m_drvTransformClient.view(m_tfClient);
+    /// if (!ok_view || m_tfClient == nullptr) {
+    ///     // Error...
+    /// }
+    ///
+    /// // Retrieve the transform
+    /// yarp::sig::Matrix transform(4, 4);
+    /// std::string source = "/inertial";
+    /// std::string target = "/<name>/frame";
+    /// bool ok_transform = m_tfClient->getTransform(target, source, transform);
+    /// if (!ok_transform) {
+    ///     // Transform not ready...
+    /// }
+    /// \endcode
+    ///
+    /// The update rate of the plugin can be configured using the `period`
+    /// SDF tag in seconds. If the parameter is not provided a default value of 10 ms
+    /// is used.
+    ///
+    /// This plugin __does not__ support <a href="http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot">Gazebo nested models</a>
+    /// since the method `gazebo::physics::WorldPose()` does not work properly
+    /// with nested models.
+    ///
+    class GazeboYarpModelPosePublisher : public ModelPlugin
+    {
+    public:
+	~GazeboYarpModelPosePublisher();
+	
+	/**
+	 * Store pointer to the model, load parameters from the SDF,
+	 * configure the frame transform client, reset the time of the last update and
+	 * connect to the World update event of Gazebo.
+	 */	
+	void Load(gazebo::physics::ModelPtr, sdf::ElementPtr);
+	
+    private:
+	/**
+	 * Instance of yarp::os::Network
+	 */
+	yarp::os::Network m_yarp;
+
+	/**
+	 * Pointer to the model where the plugin is inserted
+	 */
+	gazebo::physics::ModelPtr m_model;
+
+	/**
+	 * Connection to the World update event of Gazebo
+	 */
+	gazebo::event::ConnectionPtr m_worldUpdateConnection;
+
+	/**
+	 * Time of the last update of the plugin
+	 */
+	gazebo::common::Time m_lastUpdateTime;
+		
+	/**
+	 * Update period of the plugin
+	 */
+	double m_period;
+
+	/**
+	 * PolyDriver required to access a yarp::dev::IFrameTransform
+	 */
+	yarp::dev::PolyDriver m_drvTransformClient;
+
+	/**
+	 * Pointer to yarp::dev::IFrameTransform view of the PolyDriver
+	 */
+	yarp::dev::IFrameTransform* m_tfClient;
+
+	/**
+	 * Publish the transform from the inertial frame to the model root link frame.
+	 */	
+	void PublishTransform();
+
+	/**
+	 * Check if a period is elapsed since last update 
+	 * and in case calls the method `PublishTransform`.
+	 */	
+	void OnWorldUpdate();
+    };
+}
+#endif

--- a/plugins/modelposepublisher/src/ModelPosePublisher.cc
+++ b/plugins/modelposepublisher/src/ModelPosePublisher.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia iCub Facility
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+// gazebo
+#include <gazebo/physics/Model.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/World.hh>
+
+// ignition
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Quaternion.hh>
+
+// GazeboYarpPlugins
+#include <GazeboYarpPlugins/common.h>
+
+// yarp
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/math/FrameTransform.h>
+
+// boost
+#include <boost/bind.hpp>
+
+#include "ModelPosePublisher.hh"
+
+GZ_REGISTER_MODEL_PLUGIN(gazebo::GazeboYarpModelPosePublisher)
+
+namespace gazebo {
+
+GazeboYarpModelPosePublisher::~GazeboYarpModelPosePublisher()
+{
+    // Close the driver
+    m_drvTransformClient.close();
+}
+
+void GazeboYarpModelPosePublisher::Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf)
+{
+    // Check yarp network availability
+    if (!m_yarp.checkNetwork(GazeboYarpPlugins::yarpNetworkInitializationTimeout)) {
+        yError() << "GazeboYarpModelPosePublisher::Load error:"
+		 << "yarp network does not seem to be available, is the yarpserver running?";
+        return;
+    }
+
+    // Store pointer to the model
+    m_model = _parent;
+
+    // Load update period
+    if (_sdf->HasElement("period")) {
+	// Get the parameter
+	sdf::ParamPtr periodPtr = _sdf->GetElement("period")->GetValue();
+
+	// Check if it is a strictly positive double
+	if (!periodPtr->Get<double>(m_period) || m_period <= 0) {
+		yError() << "GazeboYarpModelPosePublisher::Load error:"
+			 << "parameter 'period' for model"
+			 << m_model->GetName() << "should be a strictly positive number";
+		return;
+	}
+    } else {
+	// Default to 10 ms
+	m_period = 0.01;
+    }
+
+    // Prepare properties for the PolyDriver
+    yarp::os::Property propTfClient;    
+    propTfClient.put("device", "transformClient");
+    // The local port depends on the model name that is unique
+    // also in the case of multiple insertions of the same model
+    // in Gazebo
+    propTfClient.put("local", "/" + m_model->GetName() + "/transformClient");
+    propTfClient.put("remote", "/transformServer");
+    // This is the update period of the transformClient in ms
+    propTfClient.put("period", m_period * 1000);
+
+    // Open the driver and obtain a a IFrameTransform view
+    m_tfClient = nullptr;    
+    bool ok = m_drvTransformClient.open(propTfClient);
+    ok = ok && m_drvTransformClient.view(m_tfClient) && m_tfClient != nullptr;
+    
+    // Return if the driver open failed
+    // or the view retrieval failed
+    // or the IFrameTransform pointer is not valid
+    if (!ok) {
+	yError() << "GazeboYarpModelPosePublisher::Load error:"
+	         << "failure in opening iFrameTransform interface for model"
+		 << m_model->GetName();
+	return;
+    }
+    
+    // Clear last update time
+    m_lastUpdateTime = gazebo::common::Time(0.0);
+
+    // Listen to the update event
+    auto worldUpdateBind = boost::bind(&GazeboYarpModelPosePublisher::OnWorldUpdate, this);
+    m_worldUpdateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(worldUpdateBind);
+}
+
+void GazeboYarpModelPosePublisher::PublishTransform()
+{
+    // Get the current pose of the model    
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Pose3d curPose = m_model->WorldPose();
+#else
+    gazebo::math::Pose curPoseGazebo = m_model->GetWorldPose();
+    // Convert to Ignition so that the same interface
+    // can be used in the rest of the function
+    ignition::math::Pose3d curPose = curPoseGazebo.Ign();
+#endif
+
+    // Get the positional and rotational parts
+    ignition::math::Vector3d pos = curPose.Pos();
+    ignition::math::Quaterniond rot = curPose.Rot();
+ 
+    // Convert the pose to a homogeneous transformation matrix
+    // (the first two arguments can be blank)
+    yarp::math::FrameTransform  inertialToModel("", "",
+						pos.X(),
+						pos.Y(),
+						pos.Z(),
+						rot.X(),						
+						rot.Y(),
+						rot.Z(),
+						rot.W());
+
+    // Set a new transform using
+    // /inertial for source frame name and
+    // /<model_name>/frame for the target frame name
+    m_tfClient->setTransform("/" + m_model->GetName() + "/frame",
+			     "/inertial",
+			     inertialToModel.toMatrix());
+}
+
+void GazeboYarpModelPosePublisher::OnWorldUpdate()
+{    
+    // Get current time
+#if GAZEBO_MAJOR_VERSION >= 8
+    gazebo::common::Time currentTime = m_model->GetWorld()->SimTime();
+#else
+    gazebo::common::Time currentTime = m_model->GetWorld()->GetSimTime();
+#endif
+    
+    // Check if an update period is elapsed
+    if(currentTime - m_lastUpdateTime >= m_period) {
+	
+	// Store current time for next update
+	m_lastUpdateTime = currentTime;
+
+	// Publish the transform with the current pose
+	PublishTransform();
+    }
+}
+
+}

--- a/plugins/modelposepublisher/src/ModelPosePublisher.cc
+++ b/plugins/modelposepublisher/src/ModelPosePublisher.cc
@@ -6,6 +6,7 @@
 
 // gazebo
 #include <gazebo/physics/Model.hh>
+#include <gazebo/physics/Link.hh>
 #include <gazebo/common/Events.hh>
 #include <gazebo/physics/World.hh>
 
@@ -102,11 +103,11 @@ void GazeboYarpModelPosePublisher::Load(gazebo::physics::ModelPtr _parent, sdf::
 
 void GazeboYarpModelPosePublisher::PublishTransform()
 {
-    // Get the current pose of the model    
+    // Get the current pose of the canonical link of the model    
 #if GAZEBO_MAJOR_VERSION >= 8
-    ignition::math::Pose3d curPose = m_model->WorldPose();
+    ignition::math::Pose3d curPose = m_model->GetLink()->WorldPose();
 #else
-    gazebo::math::Pose curPoseGazebo = m_model->GetWorldPose();
+    gazebo::math::Pose curPoseGazebo = m_model->GetLink()->GetWorldPose();
     // Convert to Ignition so that the same interface
     // can be used in the rest of the function
     ignition::math::Pose3d curPose = curPoseGazebo.Ign();

--- a/tutorial/model/model_pose_publisher/CMakeLists.txt
+++ b/tutorial/model/model_pose_publisher/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (C) 2018 Istituto Italiano di Tecnologia ADVR & iCub Facility & RBCS Department
+# Authors: see AUTHORS file.
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+cmake_minimum_required(VERSION 2.8.7)
+
+project(gazebo_yarp_model_pose_publisher_example)
+
+find_package(YARP REQUIRED)
+find_package(ICUBcontrib REQUIRED)
+LIST(APPEND CMAKE_MODULE_PATH ${YARP_MODULE_PATH})
+list(APPEND CMAKE_MODULE_PATH ${ICUBCONTRIB_MODULE_PATH})
+include(ICUBcontribHelpers)
+include(ICUBcontribOptions)
+icubcontrib_set_default_prefix()
+icubcontrib_add_uninstall_target()
+
+set(TARGET_NAME example)
+
+add_executable(${TARGET_NAME} example.cpp)
+target_include_directories(${TARGET_NAME} PRIVATE ${YARP_INCLUDE_DIRS})
+target_link_libraries(${TARGET_NAME} ${YARP_LIBRARIES})
+
+install(TARGETS ${TARGET_NAME} DESTINATION bin)

--- a/tutorial/model/model_pose_publisher/README.md
+++ b/tutorial/model/model_pose_publisher/README.md
@@ -1,0 +1,89 @@
+# Tutorial for plugin GazeboYarpModelPosePublisher
+
+This tutorial shows how to retrieve the global pose of a model loaded in the Gazebo
+environment using the plugin GazeboYarpModelPosePublisher.
+
+## Setup the environment
+Hereafter it is supposed that the repository `gazebo-yarp-plugins` is located at
+`$GAZEBO_YARP_PLUGINS`.
+
+In order to use the `SDF model` provided for this tutorial it is required to
+add the path `$GAZEBO_YARP_PLUGINS/tutorial/model/model_pose_publisher` to the
+environment variable `GAZEBO_MODEL_PATH`:
+```
+export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:$GAZEBO_YARP_PLUGINS/tutorial/model/model_pose_publisher
+```
+
+After this when launching `Gazebo` a new model `Gazebo Yarp Model Pose Publisher` should be available.
+
+## SDF model
+The [model](scenario/model.sdf) provided consists in a box equipped with the plugin:
+```
+<?xml version="1.0" ?>
+<sdf version="1.5">
+
+  <!-- Box -->
+  <model name="box">
+    <pose>1 1 0.5 0 0 0.7</pose>	
+    <link name="box_root">
+      <pose>0 0 0 0 0 0</pose>
+      <collision name="box_collison">
+	<geometry>
+          <box>
+            <size>1.0 1.0 1.0</size>
+          </box>
+	</geometry>
+      </collision>
+      <visual name="box_visual">
+	<geometry>
+          <box>
+            <size>1.0 1.0 1.0</size>
+          </box>
+	</geometry>
+      </visual>
+    </link>
+
+    <!-- Gazebo Yarp Model Pose Publisher plugin -->
+    <plugin name='pose publisher' filename='libgazebo_yarp_modelPosePublisher.so'></plugin>
+    
+  </model>      
+</sdf>
+```
+
+## How to run the tutorial
+- Compile the example code provided
+```
+cd $GAZEBO_YARP_PLUGINS/tutorial/model/model_pose_publisher
+mkdir build
+cd build
+cmake ../
+make install
+```
+The executable is available in `$GAZEBO_YARP_PLUGINS/tutorial/model/model_pose_publisher/build/bin/example`.
+
+- Run `yarpserver`
+```
+yarpserver 
+```
+
+- Run the Frame Transfom Server via `yarpdev`
+```
+yarpdev --device transformServer --ROS::enable_ros_publisher false --ROS::enable_ros_subscriber false
+```
+
+- Run gazebo from a terminal in which the variable `$GAZEBO_MODEL_PATH` was updated as shown above
+- Insert the model `Gazebo Yarp Model Pose Publisher` in the environment
+- Run the executable provided
+```
+cd `$GAZEBO_YARP_PLUGINS/tutorial/model/model_pose_publisher/build/bin/
+./example
+```
+
+Then, a part from some information printed by the Frame Transform Client, you should see
+the current pose of the model
+```
+[INFO]Transform from /inertial to /box/frame : 
+[INFO]Position:   0.425452	-1.087350	 0.500001 
+[INFO]Rotation (Euler ZYX):  -1.570796	-0.000001	 2.270795
+```
+updated every second.

--- a/tutorial/model/model_pose_publisher/README.md
+++ b/tutorial/model/model_pose_publisher/README.md
@@ -44,7 +44,7 @@ The [model](scenario/model.sdf) provided consists in a box equipped with the plu
     </link>
 
     <!-- Gazebo Yarp Model Pose Publisher plugin -->
-    <plugin name='pose publisher' filename='libgazebo_yarp_modelPosePublisher.so'></plugin>
+    <plugin name='pose publisher' filename='libgazebo_yarp_modelposepublisher.so'></plugin>
     
   </model>      
 </sdf>

--- a/tutorial/model/model_pose_publisher/example.cpp
+++ b/tutorial/model/model_pose_publisher/example.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2018 Fondazione Istituto Italiano di Tecnologia iCub Facility
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+// yarp
+#include <yarp/os/ResourceFinder.h>
+#include <yarp/os/RFModule.h>
+#include <yarp/os/Network.h>
+#include <yarp/dev/ControlBoardInterfaces.h>
+#include <yarp/dev/IFrameTransform.h>
+#include <yarp/dev/PolyDriver.h>
+#include <yarp/math/FrameTransform.h>
+#include <yarp/sig/Vector.h>
+#include <yarp/sig/Matrix.h>
+
+// std
+#include <string>
+
+class GazeboYarpModelPosePublisherExample : public yarp::os::RFModule
+{   
+private:
+    /**
+     * PolyDriver required to access a yarp::dev::IFrameTransform
+     */
+    yarp::dev::PolyDriver m_drvTransformClient;
+
+    /**
+     * Pointer to yarp::dev::IFrameTransform view of the PolyDriver
+     */
+    yarp::dev::IFrameTransform* m_tfClient;
+    
+public:
+    /*
+     * Configures the module.
+     */
+    bool configure(yarp::os::ResourceFinder &rf)
+    {
+	// Prepare properties for the FrameTransformClient
+	yarp::os::Property propTfClient;
+	propTfClient.put("device", "transformClient");
+	propTfClient.put("local", "/transformClientExample");
+	propTfClient.put("remote", "/transformServer");
+	
+	// Try to open the driver
+	bool ok_open = m_drvTransformClient.open(propTfClient);
+	if (!ok_open) {
+	    yError() << "Unable to open the FrameTransformClient driver.";
+	    return false;
+	}
+
+	// Try to retrieve the view
+	bool ok_view = m_drvTransformClient.view(m_tfClient);
+	if (!ok_view || m_tfClient == 0) {
+	    yError() << "Unable to retrieve the FrameTransformClient view.";
+	    return false;
+	}
+
+        return true;
+    }
+    
+    /*
+     * Defines the cleanup behavior.
+     */
+    bool close()
+    {
+	// Close the driver
+	return m_drvTransformClient.close();
+    }
+
+    /*
+     * Defines the period of the module.
+     */
+    double getPeriod()
+    {
+	// Update every second
+        return 1.0;
+    }
+
+    /*
+     * Defines the behavior of the module.
+     */
+    bool updateModule()
+    {
+	// Check if the module should stop
+	if (isStopping())
+	    return false;
+
+	// Get the current pose of the model box
+	yarp::sig::Matrix matrixTransform(4, 4);
+	std::string source = "/inertial";
+	std::string target = "/box/frame";
+	bool ok_transform = m_tfClient->getTransform(target, source, matrixTransform);
+	if (!ok_transform) {
+	    // Transform not ready
+	    // Wait for the next module update
+	    return true;
+	}
+
+	// Extract the translational and rotational part
+	yarp::math::FrameTransform frameTransform;
+	frameTransform.fromMatrix(matrixTransform);
+	yarp::sig::Vector pos(3, 0.0);
+	pos[0] = frameTransform.translation.tX;
+	pos[1] = frameTransform.translation.tY;
+	pos[2] = frameTransform.translation.tZ;	
+	yarp::sig::Vector rot = frameTransform.getRPYRot();
+
+	// Print transform
+	yInfo() << "Transform from" << source
+		<< "to" << target << ":";
+	yInfo()	<< "Position: " << pos.toString();
+	yInfo()	<< "Rotation (Euler ZYX): " << rot.toString();
+	yInfo() << "";
+	
+        return true;
+    }
+};
+
+int main(int argc, char **argv)
+{
+    // Check for availability of yarp
+    yarp::os::Network yarp;
+    if (!yarp.checkNetwork()) {
+        yError() << "YARP doesn't seem to be available";
+        return 1;
+    }
+
+    // Instantiate the example
+    GazeboYarpModelPosePublisherExample example;
+
+    // Run the module
+    yarp::os::ResourceFinder rf;    
+    bool outcome = example.runModule(rf);
+
+    return outcome;
+}
+

--- a/tutorial/model/model_pose_publisher/scenario/model.config
+++ b/tutorial/model/model_pose_publisher/scenario/model.config
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Gazebo Yarp Model Pose Publisher plugin</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+  
+  <description>
+    Scenario with a box. Its global pose can be obtained
+    using the Gazebo Yarp Model Pose Publisher plugin.
+  </description>
+</model>

--- a/tutorial/model/model_pose_publisher/scenario/model.sdf
+++ b/tutorial/model/model_pose_publisher/scenario/model.sdf
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+
+  <!-- Box -->
+  <model name="box">
+    <pose>1 1 0.5 0 0 0.7</pose>	
+    <link name="box_root">
+      <pose>0 0 0 0 0 0</pose>
+      <collision name="box_collison">
+	<geometry>
+          <box>
+            <size>1.0 1.0 1.0</size>
+          </box>
+	</geometry>
+      </collision>
+      <visual name="box_visual">
+	<geometry>
+          <box>
+            <size>1.0 1.0 1.0</size>
+          </box>
+	</geometry>
+      </visual>
+    </link>
+
+    <!-- Gazebo Yarp Model Pose Publisher plugin -->
+    <plugin name='pose publisher' filename='libgazebo_yarp_modelPosePublisher.so'></plugin>
+    
+  </model>      
+</sdf>

--- a/tutorial/model/model_pose_publisher/scenario/model.sdf
+++ b/tutorial/model/model_pose_publisher/scenario/model.sdf
@@ -23,7 +23,7 @@
     </link>
 
     <!-- Gazebo Yarp Model Pose Publisher plugin -->
-    <plugin name='pose publisher' filename='libgazebo_yarp_modelPosePublisher.so'></plugin>
+    <plugin name='pose publisher' filename='libgazebo_yarp_modelposepublisher.so'></plugin>
     
   </model>      
 </sdf>


### PR DESCRIPTION
This is a possible implementation of a Model plugin that allows to retrieve the absolute pose of a model inserted within the Gazebo environment, as discussed in #337.

It uses the base class `gazebo::ModelPlugin`  to access the model and obtain its pose defined as the absolute pose, with respect to the Gazebo world frame, of the root link of the model 
```
<sdf>
  <model name="object">
    <!-- pose of model frame w.r.t Gazebo world -->
    <pose> x_m y_m z_m roll_m pich_m yaw_m </pose>

    <link name="object_root_link">
      <!-- pose of the root link w.r.t the model frame -->
      <pose> x_l y_l z_l roll_l pich_l yaw_l </pose>    
      ...
    </link>
    
    <plugin name='...' filename='libgazebo_yarp_modelPosePublisher.so'>
      <period>1.0</period>
    </plugin>
  </model>
<\sdf>
```
This pose depends on both the transformation between the Gazebo world frame and the model frame and the transformation between the model frame and the root link of the model.

The pose is published within the plugin using a `yarp::dev::FrameTransformClient` that connects to a `yarp::dev::FrameTransformServer`. The server can be activated from the command line using `yarpdev` as explained in the documentation. The user can access to the pose of the model using a `yarp::dev::FrameTransformClient`.
__Documentation__ of the plugin and __example code__ for the final user is provided in the documentation string of the main class `GazeboYarpModelPosePublisher` available through Doxygen. Also a __tutorial__ is available in `gazebo-yarp-plugins/tutorial/model/model_state_publisher`. 

The plugin does not support Gazebo [nested models](http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot) since the method `gazebo::physics::Model::WorldPose`, required to obtain the absolute pose of a model, is not working properly with nested models.

The plugin was tested with Gazebo 7 and deprecated methods in Gazebo 8 are handled in the code.