### PR TITLE
Add handling of remote variable 'kinematic_mj' in ControlBoard device driver

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -447,6 +447,7 @@ private:
     yarp::sig::Vector m_maxStiffness;
     yarp::sig::Vector m_maxDamping;
     yarp::sig::Vector m_kPWM;
+    yarp::os::Bottle m_kinematic_mj;
 
     double m_robotPositionToleranceRevolute {0.9};      // Degrees
     double m_robotPositionToleranceLinear   {0.004};    // Meters
@@ -473,6 +474,8 @@ private:
     bool setPIDsForGroup_IMPEDANCE( std::vector<std::string>& control_law, std::vector<gazebo::common::PID>&);
     bool setMinMaxImpedance();
     bool setPIDs(); //WORKS
+    bool setKinematic_mj(yarp::os::Bottle* srcCouplingMat);
+    void getKinematic_mj(yarp::os::Bottle& expCouplingMat);
     bool setMaxTorques();
     bool setPositionsToleranceRevolute();
     bool setPositionsToleranceLinear();

--- a/plugins/controlboard/src/ControlBoardDriverRemoteVariables.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverRemoteVariables.cpp
@@ -31,6 +31,8 @@ bool GazeboYarpControlBoardDriver::getRemoteVariablesList(yarp::os::Bottle* list
     listOfKeys->addString("SHORTCUT_all_pos_ki");
 
     listOfKeys->addString("VelocityTimeout");
+
+    listOfKeys->addString("kinematic_mj");
     return true;
 }
 
@@ -124,6 +126,11 @@ bool GazeboYarpControlBoardDriver::getRemoteVariable(std::string key, yarp::os::
     if (key == "VelocityTimeout")
     {
         yarp::os::Bottle& r = val.addList(); for (size_t i = 0; i< m_numberOfJoints; i++) { r.addFloat64(m_velocity_watchdog[i]->getDuration()); }
+        return true;
+    }
+    if (key == "kinematic_mj")
+    {
+        this->getKinematic_mj(val);
         return true;
     }
     yWarning("getRemoteVariable(): Unknown variable %s", key.c_str());


### PR DESCRIPTION
This change allows to extract the joint coupling matrices from the `gazebo-yarp-plugin` configuration files (refer to https://github.com/robotology-playground/icub-model-generator/pull/87), populate the remote debug variable `kinematic_mj` and expose it through the interface `yarp::dev::IRemoteVariables`.