### PR TITLE
ICurrentControl Interfaces implementation completed and moved to ControlBoardDriverCurrent.cpp

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -80,7 +80,6 @@ class yarp::dev::GazeboYarpControlBoardDriver:
     public DeviceDriver,
     public IPositionControl2,
     public IVelocityControl2,
-    public IAmplifierControl,
     public IEncodersTimed,
     public IControlCalibration2,
     public IControlLimits2,
@@ -255,8 +254,8 @@ public:
 
     // Current interface
     //virtual bool getAxes(int *ax);
-    //virtual bool getCurrent(int j, double *t);
-    //virtual bool getCurrents(double *t);
+    virtual bool getCurrent(int j, double *t); //TODO
+    virtual bool getCurrents(double *t); //TODO
     virtual bool getCurrentRange(int j, double *min, double *max);
     virtual bool getCurrentRanges(double *min, double *max);
     virtual bool setRefCurrents(const double *t);
@@ -293,16 +292,7 @@ public:
     /*
      * Probably useless stuff here
      */
-    //AMPLIFIER CONTROL (inside comanOthers.cpp)
-    virtual bool enableAmp(int j); //NOT IMPLEMENTED
-    virtual bool disableAmp(int j); //NOT IMPLEMENTED
-    virtual bool getCurrent(int j, double *val); //NOT IMPLEMENTED
-    virtual bool getCurrents(double *vals); //NOT IMPLEMENTED
-    virtual bool setMaxCurrent(int j, double v); //NOT IMPLEMENTED
-    virtual bool getMaxCurrent(int j, double *v);  //NOT IMPLEMENTED
-    virtual bool getAmpStatus(int *st); //NOT IMPLEMENTED
-    virtual bool getAmpStatus(int k, int *v); //NOT IMPLEMENTED
-
+    
     //CONTROL CALIBRATION (inside comanOthers.cpp)
     virtual bool calibrate2(int j, unsigned int iv, double v1, double v2, double v3); //NOT IMPLEMENTED
     virtual bool done(int j); // NOT IMPLEMENTED
@@ -397,7 +387,6 @@ private:
 
     yarp::os::Stamp m_lastTimestamp;        /**< timestamp, updated with simulation time at each onUpdate call */
 
-    yarp::sig::Vector m_amp;
     yarp::sig::VectorOf<JointType> m_jointTypes;
 
     //Desired Control variables

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -80,6 +80,7 @@ class yarp::dev::GazeboYarpControlBoardDriver:
     public DeviceDriver,
     public IPositionControl2,
     public IVelocityControl2,
+    public IAmplifierControl,
     public IEncodersTimed,
     public IControlCalibration2,
     public IControlLimits2,
@@ -293,6 +294,14 @@ public:
      * Probably useless stuff here
      */
     
+    //AMPLIFIER CONTROL (inside comanOthers.cpp)
+    virtual bool enableAmp(int j); //NOT IMPLEMENTED
+    virtual bool disableAmp(int j); //NOT IMPLEMENTED
+    virtual bool setMaxCurrent(int j, double v); //NOT IMPLEMENTED
+    virtual bool getMaxCurrent(int j, double *v);  //NOT IMPLEMENTED
+    virtual bool getAmpStatus(int *st); //NOT IMPLEMENTED
+    virtual bool getAmpStatus(int k, int *v); //NOT IMPLEMENTED
+
     //CONTROL CALIBRATION (inside comanOthers.cpp)
     virtual bool calibrate2(int j, unsigned int iv, double v1, double v2, double v3); //NOT IMPLEMENTED
     virtual bool done(int j); // NOT IMPLEMENTED
@@ -388,7 +397,8 @@ private:
     yarp::os::Stamp m_lastTimestamp;        /**< timestamp, updated with simulation time at each onUpdate call */
 
     yarp::sig::VectorOf<JointType> m_jointTypes;
-
+    yarp::sig::Vector m_amp;
+    
     //Desired Control variables
     yarp::sig::Vector m_jntReferencePositions; /**< desired reference positions.
                                                  Depending on the position mode,

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -254,8 +254,8 @@ public:
 
     // Current interface
     //virtual bool getAxes(int *ax);
-    virtual bool getCurrent(int j, double *t); //TODO
-    virtual bool getCurrents(double *t); //TODO
+    virtual bool getCurrent(int j, double *t);
+    virtual bool getCurrents(double *t);
     virtual bool getCurrentRange(int j, double *min, double *max);
     virtual bool getCurrentRanges(double *min, double *max);
     virtual bool setRefCurrents(const double *t);

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -62,7 +62,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_zeroPosition.resize(m_numberOfJoints);
     m_jntReferenceVelocities.resize(m_numberOfJoints);
     m_velocities.resize(m_numberOfJoints);
-    m_amp.resize(m_numberOfJoints);
     m_torques.resize(m_numberOfJoints); m_torques.zero();
     m_maxTorques.resize(m_numberOfJoints, 2000.0);
     m_trajectoryGenerationReferenceSpeed.resize(m_numberOfJoints);
@@ -110,7 +109,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_trajectoryGenerationReferencePosition.zero();
     // m_trajectoryGenerationReferenceAcceleration.zero();
     m_trajectoryGenerationReferenceAcceleration=10.0; //default value in deg/s^2
-    m_amp = 1; // initially on - ok for simulator
     m_controlMode = new int[m_numberOfJoints];
     m_interactionMode = new int[m_numberOfJoints];
     m_isMotionDone = new bool[m_numberOfJoints];

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -62,6 +62,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_zeroPosition.resize(m_numberOfJoints);
     m_jntReferenceVelocities.resize(m_numberOfJoints);
     m_velocities.resize(m_numberOfJoints);
+    m_amp.resize(m_numberOfJoints);
     m_torques.resize(m_numberOfJoints); m_torques.zero();
     m_maxTorques.resize(m_numberOfJoints, 2000.0);
     m_trajectoryGenerationReferenceSpeed.resize(m_numberOfJoints);
@@ -109,6 +110,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_trajectoryGenerationReferencePosition.zero();
     // m_trajectoryGenerationReferenceAcceleration.zero();
     m_trajectoryGenerationReferenceAcceleration=10.0; //default value in deg/s^2
+    m_amp = 1;
     m_controlMode = new int[m_numberOfJoints];
     m_interactionMode = new int[m_numberOfJoints];
     m_isMotionDone = new bool[m_numberOfJoints];

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -53,7 +53,7 @@ namespace yarp {
         {          
             if (!joints || !t) return false;
             bool ret = true;
-            for (int i = 0; i < n_joint && ret; i++){
+            for (int i = 0; i < n_joint && ret; i++) {
                 ret = setRefCurrent(joints[i], t[i]);
             }
             return ret;

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -30,7 +30,7 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getCurrentRanges(double *min, double *max)
         {
-            if (!min || !max)) return false;
+            if (!min || !max) return false;
             for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 min[j] = -m_maxTorques[j] / m_kPWM[j];
                 max[j] = m_maxTorques[j] / m_kPWM[j];
@@ -50,7 +50,7 @@ namespace yarp {
         }
 
         bool GazeboYarpControlBoardDriver::setRefCurrents(const int n_joint, const int *joints, const double *t)
-        {          
+        {
             if (!joints || !t) return false;
             bool ret = true;
             for (int i = 0; i < n_joint && ret; i++) {

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -21,8 +21,8 @@ namespace yarp {
         {
             std::cout << "max torque " << m_maxTorques[j] << std::endl;
             if (min && max && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-                *min = -m_maxTorques[j]/m_kPWM[j];
-                *max = m_maxTorques[j]/m_kPWM[j];
+                *min = -m_maxTorques[j] / m_kPWM[j];
+                *max = m_maxTorques[j] / m_kPWM[j];
                 return true;
             }
             return false;
@@ -32,23 +32,25 @@ namespace yarp {
         {
             if (!min || !max)) return false;
             for (size_t j = 0; j < m_numberOfJoints; ++j) {
-                min[j] = -m_maxTorques[j]/m_kPWM[j];
-                max[j] = m_maxTorques[j]/m_kPWM[j];
+                min[j] = -m_maxTorques[j] / m_kPWM[j];
+                max[j] = m_maxTorques[j] / m_kPWM[j];
             }
             return true;
         }
 
         bool GazeboYarpControlBoardDriver::setRefCurrent(int j, double v)
         {
+            if (!checkIfTorqueIsValid(v * m_kPWM[j]))
+                return false;
             if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-                m_jntReferenceTorques[j] = v*m_kPWM[j];
+                m_jntReferenceTorques[j] = v * m_kPWM[j];
                 return true;
             }
             return false;
         }
 
         bool GazeboYarpControlBoardDriver::setRefCurrents(const int n_joint, const int *joints, const double *t)
-        {
+        {          
             if (!joints || !t) return false;
             bool ret = true;
             for (int i = 0; i < n_joint && ret; i++){
@@ -61,7 +63,7 @@ namespace yarp {
         {
             if (!v) return false;
             for (size_t j = 0; j < m_numberOfJoints; ++j) {
-                m_jntReferenceTorques[j] = v[j]*m_kPWM[j];
+                m_jntReferenceTorques[j] = v[j] * m_kPWM[j];
             }
             return true;
         }
@@ -69,7 +71,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getCurrent(int j, double* val)
         {
             if (val && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-                *val = m_torques[j]/m_kPWM[j];
+                *val = m_torques[j] / m_kPWM[j];
                 return true;
             }
             return false;
@@ -86,8 +88,8 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getRefCurrent(int j, double *v)
         {
-            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-                *v = m_jntReferenceTorques[j]/m_kPWM[j];
+            if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
+                *v = m_jntReferenceTorques[j] / m_kPWM[j];
                 return true;
             }
             return false;
@@ -97,7 +99,7 @@ namespace yarp {
         {
             if (!v) return false;
             for (size_t j = 0; j < m_numberOfJoints; ++j) {
-                v[j] = m_jntReferenceTorques[j]/m_kPWM[j];
+                v[j] = m_jntReferenceTorques[j] / m_kPWM[j];
             }
             return true;
         }

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -30,7 +30,7 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getCurrentRanges(double *min, double *max)
         {
-            if (!min || !(max)) return false;
+            if (!min || !max)) return false;
             for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 min[j] = -m_maxTorques[j]/m_kPWM[j];
                 max[j] = m_maxTorques[j]/m_kPWM[j];

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -24,7 +24,6 @@ namespace yarp {
             {
                 *min = -m_maxTorques[j]/m_kPWM[j];
                 *max = m_maxTorques[j]/m_kPWM[j];
-                std::cout << "min: " << *min << " max: " << *max << std::endl;
                 return true;
             }
             return false;

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -20,8 +20,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getCurrentRange(int j, double *min, double *max)
         {
             std::cout << "max torque " << m_maxTorques[j] << std::endl;
-            if (min && max && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
-            {
+            if (min && max && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
                 *min = -m_maxTorques[j]/m_kPWM[j];
                 *max = m_maxTorques[j]/m_kPWM[j];
                 return true;
@@ -32,8 +31,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getCurrentRanges(double *min, double *max)
         {
             if (!min || !(max)) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) 
-            {
+            for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 min[j] = -m_maxTorques[j]/m_kPWM[j];
                 max[j] = m_maxTorques[j]/m_kPWM[j];
             }
@@ -42,8 +40,7 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::setRefCurrent(int j, double v)
         {
-            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
-            {
+            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
                 m_jntReferenceTorques[j] = v*m_kPWM[j];
                 return true;
             }
@@ -54,8 +51,7 @@ namespace yarp {
         {
             if (!joints || !t) return false;
             bool ret = true;
-            for (int i = 0; i < n_joint && ret; i++)
-            {
+            for (int i = 0; i < n_joint && ret; i++){
                 ret = setRefCurrent(joints[i], t[i]);
             }
             return ret;
@@ -64,8 +60,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::setRefCurrents(const double* v)
         {
             if (!v) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) 
-            {
+            for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 m_jntReferenceTorques[j] = v[j]*m_kPWM[j];
             }
             return true;
@@ -73,8 +68,7 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getCurrent(int j, double* val)
         {
-            if (val && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
-            {
+            if (val && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
                 *val = m_torques[j]/m_kPWM[j];
                 return true;
             }
@@ -84,8 +78,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getCurrents(double *vals)
         {
             if (!vals) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) 
-            {
+            for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 this->getCurrent(j,&vals[j]);
             }
             return true;
@@ -93,8 +86,7 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getRefCurrent(int j, double *v)
         {
-            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
-            {
+            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
                 *v = m_jntReferenceTorques[j]/m_kPWM[j];
                 return true;
             }
@@ -104,8 +96,7 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getRefCurrents(double *v)
         {
             if (!v) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) 
-            {
+            for (size_t j = 0; j < m_numberOfJoints; ++j) {
                 v[j] = m_jntReferenceTorques[j]/m_kPWM[j];
             }
             return true;

--- a/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCurrent.cpp
@@ -19,17 +19,32 @@ namespace yarp {
 
         bool GazeboYarpControlBoardDriver::getCurrentRange(int j, double *min, double *max)
         {
-            return NOT_YET_IMPLEMENTED("getCurrentRange");
+            std::cout << "max torque " << m_maxTorques[j] << std::endl;
+            if (min && max && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
+            {
+                *min = -m_maxTorques[j]/m_kPWM[j];
+                *max = m_maxTorques[j]/m_kPWM[j];
+                std::cout << "min: " << *min << " max: " << *max << std::endl;
+                return true;
+            }
+            return false;
         }
 
         bool GazeboYarpControlBoardDriver::getCurrentRanges(double *min, double *max)
         {
-            return NOT_YET_IMPLEMENTED("getCurrentRanges");
+            if (!min || !(max)) return false;
+            for (size_t j = 0; j < m_numberOfJoints; ++j) 
+            {
+                min[j] = -m_maxTorques[j]/m_kPWM[j];
+                max[j] = m_maxTorques[j]/m_kPWM[j];
+            }
+            return true;
         }
 
         bool GazeboYarpControlBoardDriver::setRefCurrent(int j, double v)
         {
-            if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
+            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
+            {
                 m_jntReferenceTorques[j] = v*m_kPWM[j];
                 return true;
             }
@@ -50,40 +65,38 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::setRefCurrents(const double* v)
         {
             if (!v) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) {
+            for (size_t j = 0; j < m_numberOfJoints; ++j) 
+            {
                 m_jntReferenceTorques[j] = v[j]*m_kPWM[j];
             }
             return true;
         }
 
-        /*
-         //Already implemented by another interface
-         bool GazeboYarpControlBoardDriver::getCurrent(int j, double *v)
-         {
-         if (val && j >= 0 && j < (int)m_numberOfJoints) {
-         *val = amp[j];
-         return true;
-         }
-         return false;
-         }
-         */
+        bool GazeboYarpControlBoardDriver::getCurrent(int j, double* val)
+        {
+            if (val && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
+            {
+                *val = m_torques[j]/m_kPWM[j];
+                return true;
+            }
+            return false;
+        }
 
-        /*
-         //Already implemented by another interface
-         bool GazeboYarpControlBoardDriver::getCurrents(double *v)
-         {
-         if (!vals) return false;
-         for (unsigned int i=0; i<m_numberOfJoints; i++) {
-         vals[i] = amp[i];
-         }
-         return true;
-         }
-         */
+        bool GazeboYarpControlBoardDriver::getCurrents(double *vals)
+        {
+            if (!vals) return false;
+            for (size_t j = 0; j < m_numberOfJoints; ++j) 
+            {
+                this->getCurrent(j,&vals[j]);
+            }
+            return true;
+        }
 
         bool GazeboYarpControlBoardDriver::getRefCurrent(int j, double *v)
         {
-            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-                *v = m_jntReferenceTorques[j];
+            if (v && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
+            {
+                *v = m_jntReferenceTorques[j]/m_kPWM[j];
                 return true;
             }
             return false;
@@ -92,8 +105,9 @@ namespace yarp {
         bool GazeboYarpControlBoardDriver::getRefCurrents(double *v)
         {
             if (!v) return false;
-            for (size_t j = 0; j < m_numberOfJoints; ++j) {
-                v[j] = m_jntReferenceTorques[j];
+            for (size_t j = 0; j < m_numberOfJoints; ++j) 
+            {
+                v[j] = m_jntReferenceTorques[j]/m_kPWM[j];
             }
             return true;
         }

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -78,71 +78,7 @@ bool GazeboYarpControlBoardDriver::setVelLimits(int axis, double min, double max
     return true;
 }
 
-//Amplifiers
-bool GazeboYarpControlBoardDriver::enableAmp(int j) //NOT IMPLEMENTED
-{
-    if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-        m_amp[j] = 1;
-        m_controlMode[j] = VOCAB_CM_POSITION;
-        return true;
-    }
-    return false;
-}
-
-bool GazeboYarpControlBoardDriver::disableAmp(int j) //NOT IMPLEMENTED
-{
-    if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-        m_amp[j] = 0;
-        m_controlMode[j] = VOCAB_CM_IDLE;
-        return true;
-    }
-    return false;
-}
-
-bool GazeboYarpControlBoardDriver::getCurrent(int j, double* val) //NOT IMPLEMENTED
-{
-    if (val && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-        *val = m_amp[j];
-        return true;
-    }
-    return false;
-}
-
-bool GazeboYarpControlBoardDriver::getCurrents(double *vals) //NOT IMPLEMENTED
-{
-    if (!vals) return false;
-    for (size_t i = 0; i < m_numberOfJoints; ++i) {
-        vals[i] = m_amp[i];
-    }
-    return true;
-}
-
-bool GazeboYarpControlBoardDriver::setMaxCurrent(int, double) //NOT IMPLEMENTED
-{
-    return true;
-}
-
-bool GazeboYarpControlBoardDriver::getMaxCurrent(int j, double *v) //NOT IMPLEMENTED
-{
-    if (!v) return false;
-    *v = 0;
-    return true;
-}
-
-bool GazeboYarpControlBoardDriver::getAmpStatus(int *st) //NOT IMPLEMENTED
-{
-    if (!st) return false;
-    *st = 0;
-    return true;
-}
-
-bool GazeboYarpControlBoardDriver::getAmpStatus(int, int *v) //NOT IMPLEMENTED
-{
-    if (!v) return false;
-    *v = 0;
-    return true;
-}
-
+//CONTROL CALIBRATION
 bool GazeboYarpControlBoardDriver::calibrate2(int j, unsigned int iv, double v1, double v2, double v3) //NOT IMPLEMENTED
 {
     yDebug("fakebot: calibrating joint %d with parameters %u %f %f %f\n", j, iv, v1, v2, v3);

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -78,6 +78,54 @@ bool GazeboYarpControlBoardDriver::setVelLimits(int axis, double min, double max
     return true;
 }
 
+
+//Amplifiers
+bool GazeboYarpControlBoardDriver::enableAmp(int j) //NOT IMPLEMENTED
+{
+    if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
+        m_amp[j] = 1;
+        m_controlMode[j] = VOCAB_CM_POSITION;
+        return true;
+    }
+    return false;
+}
+
+bool GazeboYarpControlBoardDriver::disableAmp(int j) //NOT IMPLEMENTED
+{
+    if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
+        m_amp[j] = 0;
+        m_controlMode[j] = VOCAB_CM_IDLE;
+        return true;
+    }
+    return false;
+}
+
+bool GazeboYarpControlBoardDriver::setMaxCurrent(int, double) //NOT IMPLEMENTED
+{
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::getMaxCurrent(int j, double *v) //NOT IMPLEMENTED
+{
+    if (!v) return false;
+    *v = 0;
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::getAmpStatus(int *st) //NOT IMPLEMENTED
+{
+    if (!st) return false;
+    *st = 0;
+    return true;
+}
+
+bool GazeboYarpControlBoardDriver::getAmpStatus(int, int *v) //NOT IMPLEMENTED
+{
+    if (!v) return false;
+    *v = 0;
+    return true;
+}
+
 //CONTROL CALIBRATION
 bool GazeboYarpControlBoardDriver::calibrate2(int j, unsigned int iv, double v1, double v2, double v3) //NOT IMPLEMENTED
 {

--- a/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
@@ -96,8 +96,28 @@ bool GazeboYarpControlBoardDriver::getTorques(double* t)
     return true;
 }
 
-bool GazeboYarpControlBoardDriver::getTorqueRange(int, double*, double *){return false;}
-bool GazeboYarpControlBoardDriver::getTorqueRanges(double *, double *){return false;}
+bool GazeboYarpControlBoardDriver::getTorqueRange(int j, double *min, double *max)
+{
+    if (min && max && j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) 
+    {
+        *min = -m_maxTorques[j];
+        *max = m_maxTorques[j];
+        return true;
+    }
+    return false;
+}
+
+bool GazeboYarpControlBoardDriver::getTorqueRanges(double *min, double *max)
+{
+    if (!min || !(max)) return false;
+    for (size_t j = 0; j < m_numberOfJoints; ++j) 
+    {
+        min[j] = -m_maxTorques[j];
+        max[j] = m_maxTorques[j];
+    }
+    return true;
+}
+
 bool GazeboYarpControlBoardDriver::getBemfParam(int , double *){return false;}
 bool GazeboYarpControlBoardDriver::setBemfParam(int , double ){return false;}
 bool GazeboYarpControlBoardDriver::getMotorTorqueParams(int ,  yarp::dev::MotorTorqueParameters *){return false;}


### PR DESCRIPTION
Given the considerations at https://github.com/robotology/gazebo-yarp-plugins/pull/353:
* the `ICurrentControl` interface has been implemented by streaming the torque accordingly to a constant `m_kPWM`:
$ \tau = k_{PWM} \cdot i $

* `getTorqueRange` interface has been implemented 

* `getCurrent` and `getCurrents` defintions have been moved to `ControlBoardDriverCurrent.cpp`. However, differently from what stated in #353, the `IAmplifier` interface has been kept in order to avoid back-compatibility problems in the master branch.