### PR TITLE
Require YARP 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ cmake_minimum_required(VERSION 2.8.7)
 PROJECT(GazeboYARPPlugins)
 
 # Project version
-set(${PROJECT_NAME}_MAJOR_VERSION 2)
-set(${PROJECT_NAME}_MINOR_VERSION 3)
-set(${PROJECT_NAME}_PATCH_VERSION 73)
+set(${PROJECT_NAME}_MAJOR_VERSION 3)
+set(${PROJECT_NAME}_MINOR_VERSION 0)
+set(${PROJECT_NAME}_PATCH_VERSION 0)
 set(${PROJECT_NAME}_VERSION
     ${${PROJECT_NAME}_MAJOR_VERSION}.${${PROJECT_NAME}_MINOR_VERSION}.${${PROJECT_NAME}_PATCH_VERSION})
 
@@ -17,7 +17,7 @@ set(${PROJECT_NAME}_VERSION
 include(GNUInstallDirs)
 
 # Finding dependencies
-find_package(YARP 2.3.73.5 REQUIRED)
+find_package(YARP 3 REQUIRED)
 find_package(Boost REQUIRED serialization system)
 find_package(Protobuf REQUIRED)
 find_package(Gazebo REQUIRED)

--- a/thrift/clock/autogenerated/clock_rpc_thrift.cmake
+++ b/thrift/clock/autogenerated/clock_rpc_thrift.cmake
@@ -1,3 +1,9 @@
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
 ## This is an automatically-generated file.
 ## It could get re-generated if the ALLOW_IDL_GENERATION flag is on
 

--- a/thrift/clock/autogenerated/include/ClockServer.h
+++ b/thrift/clock/autogenerated/include/ClockServer.h
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #ifndef YARP_THRIFT_GENERATOR_ClockServer

--- a/thrift/clock/autogenerated/src/ClockServer.cpp
+++ b/thrift/clock/autogenerated/src/ClockServer.cpp
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #include <ClockServer.h>
@@ -10,14 +18,14 @@ namespace GazeboYarpPlugins {
 class ClockServer_pauseSimulation : public yarp::os::Portable {
 public:
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
 class ClockServer_continueSimulation : public yarp::os::Portable {
 public:
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -25,7 +33,7 @@ class ClockServer_stepSimulation : public yarp::os::Portable {
 public:
   std::int32_t numberOfSteps;
   void init(const std::int32_t numberOfSteps);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -33,14 +41,14 @@ class ClockServer_stepSimulationAndWait : public yarp::os::Portable {
 public:
   std::int32_t numberOfSteps;
   void init(const std::int32_t numberOfSteps);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
 class ClockServer_resetSimulationTime : public yarp::os::Portable {
 public:
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -48,7 +56,7 @@ class ClockServer_getSimulationTime : public yarp::os::Portable {
 public:
   double _return;
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -56,11 +64,11 @@ class ClockServer_getStepSize : public yarp::os::Portable {
 public:
   double _return;
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
-bool ClockServer_pauseSimulation::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_pauseSimulation::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("pauseSimulation",1,1)) return false;
@@ -75,7 +83,7 @@ bool ClockServer_pauseSimulation::read(yarp::os::ConnectionReader& connection) {
 void ClockServer_pauseSimulation::init() {
 }
 
-bool ClockServer_continueSimulation::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_continueSimulation::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("continueSimulation",1,1)) return false;
@@ -90,7 +98,7 @@ bool ClockServer_continueSimulation::read(yarp::os::ConnectionReader& connection
 void ClockServer_continueSimulation::init() {
 }
 
-bool ClockServer_stepSimulation::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_stepSimulation::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("stepSimulation",1,1)) return false;
@@ -107,7 +115,7 @@ void ClockServer_stepSimulation::init(const std::int32_t numberOfSteps) {
   this->numberOfSteps = numberOfSteps;
 }
 
-bool ClockServer_stepSimulationAndWait::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_stepSimulationAndWait::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("stepSimulationAndWait",1,1)) return false;
@@ -125,7 +133,7 @@ void ClockServer_stepSimulationAndWait::init(const std::int32_t numberOfSteps) {
   this->numberOfSteps = numberOfSteps;
 }
 
-bool ClockServer_resetSimulationTime::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_resetSimulationTime::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("resetSimulationTime",1,1)) return false;
@@ -140,7 +148,7 @@ bool ClockServer_resetSimulationTime::read(yarp::os::ConnectionReader& connectio
 void ClockServer_resetSimulationTime::init() {
 }
 
-bool ClockServer_getSimulationTime::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_getSimulationTime::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("getSimulationTime",1,1)) return false;
@@ -161,7 +169,7 @@ void ClockServer_getSimulationTime::init() {
   _return = (double)0;
 }
 
-bool ClockServer_getStepSize::write(yarp::os::ConnectionWriter& connection) {
+bool ClockServer_getStepSize::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("getStepSize",1,1)) return false;

--- a/thrift/worldinterface/autogenerated/include/Color.h
+++ b/thrift/worldinterface/autogenerated/include/Color.h
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #ifndef YARP_THRIFT_GENERATOR_STRUCT_Color
@@ -45,16 +53,16 @@ public:
   // read and write structure on a connection
   bool read(yarp::os::idl::WireReader& reader) override;
   bool read(yarp::os::ConnectionReader& connection) override;
-  bool write(yarp::os::idl::WireWriter& writer) override;
-  bool write(yarp::os::ConnectionWriter& connection) override;
+  bool write(const yarp::os::idl::WireWriter& writer) const override;
+  bool write(yarp::os::ConnectionWriter& connection) const override;
 
 private:
-  bool write_r(yarp::os::idl::WireWriter& writer);
-  bool nested_write_r(yarp::os::idl::WireWriter& writer);
-  bool write_g(yarp::os::idl::WireWriter& writer);
-  bool nested_write_g(yarp::os::idl::WireWriter& writer);
-  bool write_b(yarp::os::idl::WireWriter& writer);
-  bool nested_write_b(yarp::os::idl::WireWriter& writer);
+  bool write_r(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_r(const yarp::os::idl::WireWriter& writer) const;
+  bool write_g(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_g(const yarp::os::idl::WireWriter& writer) const;
+  bool write_b(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_b(const yarp::os::idl::WireWriter& writer) const;
   bool read_r(yarp::os::idl::WireReader& reader);
   bool nested_read_r(yarp::os::idl::WireReader& reader);
   bool read_g(yarp::os::idl::WireReader& reader);
@@ -64,7 +72,7 @@ private:
 
 public:
 
-  std::string toString();
+  std::string toString() const;
 
   // if you want to serialize this class without nesting, use this helper
   typedef yarp::os::idl::Unwrapped<GazeboYarpPlugins::Color > unwrapped;
@@ -151,7 +159,7 @@ public:
       dirty_flags(false);
     }
     bool read(yarp::os::ConnectionReader& connection) override;
-    bool write(yarp::os::ConnectionWriter& connection) override;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
   private:
 
     Color *obj;

--- a/thrift/worldinterface/autogenerated/include/Pose.h
+++ b/thrift/worldinterface/autogenerated/include/Pose.h
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #ifndef YARP_THRIFT_GENERATOR_STRUCT_Pose
@@ -54,22 +62,22 @@ public:
   // read and write structure on a connection
   bool read(yarp::os::idl::WireReader& reader) override;
   bool read(yarp::os::ConnectionReader& connection) override;
-  bool write(yarp::os::idl::WireWriter& writer) override;
-  bool write(yarp::os::ConnectionWriter& connection) override;
+  bool write(const yarp::os::idl::WireWriter& writer) const override;
+  bool write(yarp::os::ConnectionWriter& connection) const override;
 
 private:
-  bool write_x(yarp::os::idl::WireWriter& writer);
-  bool nested_write_x(yarp::os::idl::WireWriter& writer);
-  bool write_y(yarp::os::idl::WireWriter& writer);
-  bool nested_write_y(yarp::os::idl::WireWriter& writer);
-  bool write_z(yarp::os::idl::WireWriter& writer);
-  bool nested_write_z(yarp::os::idl::WireWriter& writer);
-  bool write_roll(yarp::os::idl::WireWriter& writer);
-  bool nested_write_roll(yarp::os::idl::WireWriter& writer);
-  bool write_pitch(yarp::os::idl::WireWriter& writer);
-  bool nested_write_pitch(yarp::os::idl::WireWriter& writer);
-  bool write_yaw(yarp::os::idl::WireWriter& writer);
-  bool nested_write_yaw(yarp::os::idl::WireWriter& writer);
+  bool write_x(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_x(const yarp::os::idl::WireWriter& writer) const;
+  bool write_y(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_y(const yarp::os::idl::WireWriter& writer) const;
+  bool write_z(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_z(const yarp::os::idl::WireWriter& writer) const;
+  bool write_roll(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_roll(const yarp::os::idl::WireWriter& writer) const;
+  bool write_pitch(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_pitch(const yarp::os::idl::WireWriter& writer) const;
+  bool write_yaw(const yarp::os::idl::WireWriter& writer) const;
+  bool nested_write_yaw(const yarp::os::idl::WireWriter& writer) const;
   bool read_x(yarp::os::idl::WireReader& reader);
   bool nested_read_x(yarp::os::idl::WireReader& reader);
   bool read_y(yarp::os::idl::WireReader& reader);
@@ -85,7 +93,7 @@ private:
 
 public:
 
-  std::string toString();
+  std::string toString() const;
 
   // if you want to serialize this class without nesting, use this helper
   typedef yarp::os::idl::Unwrapped<GazeboYarpPlugins::Pose > unwrapped;
@@ -208,7 +216,7 @@ public:
       dirty_flags(false);
     }
     bool read(yarp::os::ConnectionReader& connection) override;
-    bool write(yarp::os::ConnectionWriter& connection) override;
+    bool write(yarp::os::ConnectionWriter& connection) const override;
   private:
 
     Pose *obj;

--- a/thrift/worldinterface/autogenerated/include/WorldInterfaceServer.h
+++ b/thrift/worldinterface/autogenerated/include/WorldInterfaceServer.h
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #ifndef YARP_THRIFT_GENERATOR_WorldInterfaceServer

--- a/thrift/worldinterface/autogenerated/src/Color.cpp
+++ b/thrift/worldinterface/autogenerated/src/Color.cpp
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #include <Color.h>
@@ -59,43 +67,43 @@ bool Color::read(yarp::os::ConnectionReader& connection) {
   return read(reader);
 }
 
-bool Color::write_r(yarp::os::idl::WireWriter& writer) {
+bool Color::write_r(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(r)) return false;
   return true;
 }
-bool Color::nested_write_r(yarp::os::idl::WireWriter& writer) {
+bool Color::nested_write_r(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(r)) return false;
   return true;
 }
-bool Color::write_g(yarp::os::idl::WireWriter& writer) {
+bool Color::write_g(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(g)) return false;
   return true;
 }
-bool Color::nested_write_g(yarp::os::idl::WireWriter& writer) {
+bool Color::nested_write_g(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(g)) return false;
   return true;
 }
-bool Color::write_b(yarp::os::idl::WireWriter& writer) {
+bool Color::write_b(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(b)) return false;
   return true;
 }
-bool Color::nested_write_b(yarp::os::idl::WireWriter& writer) {
+bool Color::nested_write_b(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeI16(b)) return false;
   return true;
 }
-bool Color::write(yarp::os::idl::WireWriter& writer) {
+bool Color::write(const yarp::os::idl::WireWriter& writer) const {
   if (!write_r(writer)) return false;
   if (!write_g(writer)) return false;
   if (!write_b(writer)) return false;
   return !writer.isError();
 }
 
-bool Color::write(yarp::os::ConnectionWriter& connection) {
+bool Color::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
   return write(writer);
 }
-bool Color::Editor::write(yarp::os::ConnectionWriter& connection) {
+bool Color::Editor::write(yarp::os::ConnectionWriter& connection) const {
   if (!isValid()) return false;
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(dirty_count+1)) return false;
@@ -206,7 +214,7 @@ bool Color::Editor::read(yarp::os::ConnectionReader& connection) {
   return true;
 }
 
-std::string Color::toString() {
+std::string Color::toString() const {
   yarp::os::Bottle b;
   b.read(*this);
   return b.toString();

--- a/thrift/worldinterface/autogenerated/src/Pose.cpp
+++ b/thrift/worldinterface/autogenerated/src/Pose.cpp
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #include <Pose.h>
@@ -104,55 +112,55 @@ bool Pose::read(yarp::os::ConnectionReader& connection) {
   return read(reader);
 }
 
-bool Pose::write_x(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_x(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(x)) return false;
   return true;
 }
-bool Pose::nested_write_x(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_x(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(x)) return false;
   return true;
 }
-bool Pose::write_y(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_y(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(y)) return false;
   return true;
 }
-bool Pose::nested_write_y(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_y(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(y)) return false;
   return true;
 }
-bool Pose::write_z(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_z(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(z)) return false;
   return true;
 }
-bool Pose::nested_write_z(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_z(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(z)) return false;
   return true;
 }
-bool Pose::write_roll(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_roll(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(roll)) return false;
   return true;
 }
-bool Pose::nested_write_roll(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_roll(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(roll)) return false;
   return true;
 }
-bool Pose::write_pitch(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_pitch(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(pitch)) return false;
   return true;
 }
-bool Pose::nested_write_pitch(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_pitch(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(pitch)) return false;
   return true;
 }
-bool Pose::write_yaw(yarp::os::idl::WireWriter& writer) {
+bool Pose::write_yaw(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(yaw)) return false;
   return true;
 }
-bool Pose::nested_write_yaw(yarp::os::idl::WireWriter& writer) {
+bool Pose::nested_write_yaw(const yarp::os::idl::WireWriter& writer) const {
   if (!writer.writeFloat64(yaw)) return false;
   return true;
 }
-bool Pose::write(yarp::os::idl::WireWriter& writer) {
+bool Pose::write(const yarp::os::idl::WireWriter& writer) const {
   if (!write_x(writer)) return false;
   if (!write_y(writer)) return false;
   if (!write_z(writer)) return false;
@@ -162,12 +170,12 @@ bool Pose::write(yarp::os::idl::WireWriter& writer) {
   return !writer.isError();
 }
 
-bool Pose::write(yarp::os::ConnectionWriter& connection) {
+bool Pose::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(6)) return false;
   return write(writer);
 }
-bool Pose::Editor::write(yarp::os::ConnectionWriter& connection) {
+bool Pose::Editor::write(yarp::os::ConnectionWriter& connection) const {
   if (!isValid()) return false;
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(dirty_count+1)) return false;
@@ -323,7 +331,7 @@ bool Pose::Editor::read(yarp::os::ConnectionReader& connection) {
   return true;
 }
 
-std::string Pose::toString() {
+std::string Pose::toString() const {
   yarp::os::Bottle b;
   b.read(*this);
   return b.toString();

--- a/thrift/worldinterface/autogenerated/src/WorldInterfaceServer.cpp
+++ b/thrift/worldinterface/autogenerated/src/WorldInterfaceServer.cpp
@@ -1,4 +1,12 @@
-// This is an automatically-generated file.
+/*
+ * Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+ * All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the
+ * BSD-3-Clause license. See the accompanying LICENSE file for details.
+ */
+
+// This is an automatically generated file.
 // It could get re-generated if the ALLOW_IDL_GENERATION flag is on.
 
 #include <WorldInterfaceServer.h>
@@ -18,7 +26,7 @@ public:
   bool collision_enable;
   std::string _return;
   void init(const double radius, const Pose& pose, const Color& color, const std::string& frame_name, const std::string& object_name, const bool gravity_enable, const bool collision_enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -35,7 +43,7 @@ public:
   bool collision_enable;
   std::string _return;
   void init(const double width, const double height, const double thickness, const Pose& pose, const Color& color, const std::string& frame_name, const std::string& object_name, const bool gravity_enable, const bool collision_enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -51,7 +59,7 @@ public:
   bool collision_enable;
   std::string _return;
   void init(const double radius, const double length, const Pose& pose, const Color& color, const std::string& frame_name, const std::string& object_name, const bool gravity_enable, const bool collision_enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -66,7 +74,7 @@ public:
   bool collision_enable;
   std::string _return;
   void init(const double size, const Pose& pose, const Color& color, const std::string& frame_name, const std::string& object_name, const bool gravity_enable, const bool collision_enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -76,7 +84,7 @@ public:
   Color color;
   bool _return;
   void init(const std::string& id, const Color& color);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -87,7 +95,7 @@ public:
   std::string frame_name;
   bool _return;
   void init(const std::string& id, const Pose& pose, const std::string& frame_name);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -97,7 +105,7 @@ public:
   bool enable;
   bool _return;
   void init(const std::string& id, const bool enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -107,7 +115,7 @@ public:
   bool enable;
   bool _return;
   void init(const std::string& id, const bool enable);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -116,7 +124,7 @@ public:
   std::string id;
   Pose _return;
   void init(const std::string& id);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -125,7 +133,7 @@ public:
   std::string filename;
   bool _return;
   void init(const std::string& filename);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -134,7 +142,7 @@ public:
   std::string id;
   bool _return;
   void init(const std::string& id);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -142,7 +150,7 @@ class WorldInterfaceServer_deleteAll : public yarp::os::Portable {
 public:
   bool _return;
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -150,7 +158,7 @@ class WorldInterfaceServer_getList : public yarp::os::Portable {
 public:
   std::vector<std::string>  _return;
   void init();
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -160,7 +168,7 @@ public:
   std::string link_name;
   bool _return;
   void init(const std::string& id, const std::string& link_name);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -169,7 +177,7 @@ public:
   std::string id;
   bool _return;
   void init(const std::string& id);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
@@ -179,11 +187,11 @@ public:
   std::string new_name;
   bool _return;
   void init(const std::string& old_name, const std::string& new_name);
-  virtual bool write(yarp::os::ConnectionWriter& connection) override;
+  virtual bool write(yarp::os::ConnectionWriter& connection) const override;
   virtual bool read(yarp::os::ConnectionReader& connection) override;
 };
 
-bool WorldInterfaceServer_makeSphere::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_makeSphere::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(15)) return false;
   if (!writer.writeTag("makeSphere",1,1)) return false;
@@ -218,7 +226,7 @@ void WorldInterfaceServer_makeSphere::init(const double radius, const Pose& pose
   this->collision_enable = collision_enable;
 }
 
-bool WorldInterfaceServer_makeBox::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_makeBox::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(17)) return false;
   if (!writer.writeTag("makeBox",1,1)) return false;
@@ -257,7 +265,7 @@ void WorldInterfaceServer_makeBox::init(const double width, const double height,
   this->collision_enable = collision_enable;
 }
 
-bool WorldInterfaceServer_makeCylinder::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_makeCylinder::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(16)) return false;
   if (!writer.writeTag("makeCylinder",1,1)) return false;
@@ -294,7 +302,7 @@ void WorldInterfaceServer_makeCylinder::init(const double radius, const double l
   this->collision_enable = collision_enable;
 }
 
-bool WorldInterfaceServer_makeFrame::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_makeFrame::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(15)) return false;
   if (!writer.writeTag("makeFrame",1,1)) return false;
@@ -329,7 +337,7 @@ void WorldInterfaceServer_makeFrame::init(const double size, const Pose& pose, c
   this->collision_enable = collision_enable;
 }
 
-bool WorldInterfaceServer_changeColor::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_changeColor::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(5)) return false;
   if (!writer.writeTag("changeColor",1,1)) return false;
@@ -354,7 +362,7 @@ void WorldInterfaceServer_changeColor::init(const std::string& id, const Color& 
   this->color = color;
 }
 
-bool WorldInterfaceServer_setPose::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_setPose::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(9)) return false;
   if (!writer.writeTag("setPose",1,1)) return false;
@@ -381,7 +389,7 @@ void WorldInterfaceServer_setPose::init(const std::string& id, const Pose& pose,
   this->frame_name = frame_name;
 }
 
-bool WorldInterfaceServer_enableGravity::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_enableGravity::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
   if (!writer.writeTag("enableGravity",1,1)) return false;
@@ -406,7 +414,7 @@ void WorldInterfaceServer_enableGravity::init(const std::string& id, const bool 
   this->enable = enable;
 }
 
-bool WorldInterfaceServer_enableCollision::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_enableCollision::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
   if (!writer.writeTag("enableCollision",1,1)) return false;
@@ -431,7 +439,7 @@ void WorldInterfaceServer_enableCollision::init(const std::string& id, const boo
   this->enable = enable;
 }
 
-bool WorldInterfaceServer_getPose::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_getPose::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("getPose",1,1)) return false;
@@ -453,7 +461,7 @@ void WorldInterfaceServer_getPose::init(const std::string& id) {
   this->id = id;
 }
 
-bool WorldInterfaceServer_loadModelFromFile::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_loadModelFromFile::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("loadModelFromFile",1,1)) return false;
@@ -476,7 +484,7 @@ void WorldInterfaceServer_loadModelFromFile::init(const std::string& filename) {
   this->filename = filename;
 }
 
-bool WorldInterfaceServer_deleteObject::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_deleteObject::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("deleteObject",1,1)) return false;
@@ -499,7 +507,7 @@ void WorldInterfaceServer_deleteObject::init(const std::string& id) {
   this->id = id;
 }
 
-bool WorldInterfaceServer_deleteAll::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_deleteAll::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("deleteAll",1,1)) return false;
@@ -520,7 +528,7 @@ void WorldInterfaceServer_deleteAll::init() {
   _return = false;
 }
 
-bool WorldInterfaceServer_getList::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_getList::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(1)) return false;
   if (!writer.writeTag("getList",1,1)) return false;
@@ -552,7 +560,7 @@ bool WorldInterfaceServer_getList::read(yarp::os::ConnectionReader& connection) 
 void WorldInterfaceServer_getList::init() {
 }
 
-bool WorldInterfaceServer_attach::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_attach::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
   if (!writer.writeTag("attach",1,1)) return false;
@@ -577,7 +585,7 @@ void WorldInterfaceServer_attach::init(const std::string& id, const std::string&
   this->link_name = link_name;
 }
 
-bool WorldInterfaceServer_detach::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_detach::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(2)) return false;
   if (!writer.writeTag("detach",1,1)) return false;
@@ -600,7 +608,7 @@ void WorldInterfaceServer_detach::init(const std::string& id) {
   this->id = id;
 }
 
-bool WorldInterfaceServer_rename::write(yarp::os::ConnectionWriter& connection) {
+bool WorldInterfaceServer_rename::write(yarp::os::ConnectionWriter& connection) const {
   yarp::os::idl::WireWriter writer(connection);
   if (!writer.writeListHeader(3)) return false;
   if (!writer.writeTag("rename",1,1)) return false;
@@ -1136,7 +1144,7 @@ bool WorldInterfaceServer::read(yarp::os::ConnectionReader& connection) {
         if (!writer.writeListHeader(1)) return false;
         {
           if (!writer.writeListBegin(BOTTLE_TAG_STRING, static_cast<uint32_t>(_return.size()))) return false;
-          std::vector<std::string> ::iterator _iter5;
+          std::vector<std::string> ::const_iterator _iter5;
           for (_iter5 = _return.begin(); _iter5 != _return.end(); ++_iter5)
           {
             if (!writer.writeString((*_iter5))) return false;

--- a/thrift/worldinterface/autogenerated/worldinterface_rpc_thrift.cmake
+++ b/thrift/worldinterface/autogenerated/worldinterface_rpc_thrift.cmake
@@ -1,3 +1,9 @@
+# Copyright (C) 2006-2018 Istituto Italiano di Tecnologia (IIT)
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms of the
+# BSD-3-Clause license. See the accompanying LICENSE file for details.
+
 ## This is an automatically-generated file.
 ## It could get re-generated if the ALLOW_IDL_GENERATION flag is on
 


### PR DESCRIPTION
Bump version to 3.0.0 to match the YARP one, and regenerate
files generated from Thrift interfaces.