### PR TITLE
Add exported targets for gazebo_yarp_lib_common and gazebo_yarp_singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,7 @@ Quick start
 -----------
 * [Downloading and Installing gazebo-yarp-plugins](http://robotology.gitlab.io/docs/gazebo-yarp-plugins/master/install.html)
 * [Use the gazebo-yarp-plugins in Gazebo Models](http://robotology.gitlab.io/docs/gazebo-yarp-plugins/master/embed_plugins.html)
+* [Use the gazebo-yarp-plugins as a C++ library using CMake](http://robotology.gitlab.io/docs/gazebo-yarp-plugins/master/use_as_library.html)
 * [Troubleshooting](http://robotology.gitlab.io/docs/gazebo-yarp-plugins/master/troubleshooting.html)
 * [Contributing](http://robotology.gitlab.io/docs/gazebo-yarp-plugins/master/contributing.html)
+

--- a/cmake/AddGazeboYarpPluginTarget.cmake
+++ b/cmake/AddGazeboYarpPluginTarget.cmake
@@ -63,6 +63,7 @@ target_include_directories(${GAZEBO_PLUGIN_LIBRARY_NAME} PUBLIC
 
 # Add install target
 install(TARGETS ${GAZEBO_PLUGIN_LIBRARY_NAME}
+        EXPORT GazeboYARPPlugins
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 

--- a/doc/main.md
+++ b/doc/main.md
@@ -14,5 +14,6 @@ Quick start
 -----------------------
 \li \ref install
 \li \ref embed_plugins
+\li \ref use_as_library
 \li \ref troubleshooting
 \li \ref contributing

--- a/doc/release/v3_0_0.md
+++ b/doc/release/v3_0_0.md
@@ -1,0 +1,13 @@
+
+YARP 3.0.0 (UNRELEASED) Release Notes                                 {#v3_0_0}
+=====================================
+
+
+
+Important Changes
+-----------------
+
+
+### Build System
+* The `GazeboYARPPlugins` CMake configuration file now export targets for the `gazebo_yarp_singleton` and the `gazebo_yarp_lib_common` C++ libraries.
+  See `doc/use_as_library.md` for more info.

--- a/doc/use_as_library.md
+++ b/doc/use_as_library.md
@@ -1,0 +1,22 @@
+
+
+# Use the gazebo-yarp-plugins as a C++ library using CMake {#use_as_library}
+
+# Use the gazebo-yarp-plugins as a C++ library using CMake
+
+You can search the `gazebo-yarp-plugins` as a CMake package, using the `GazeboYARPPlugins` CMake package name.
+
+~~~cmake
+find_package(GazeboYARPPlugins REQUIRED)
+~~~
+
+If the `GazeboYARPPlugins` CMake package, the following imported targets will be defined:
+
+| Target name        | Description          |
+|:------------------:|:--------------------:|
+| `GazeboYARPPlugins::gazebo_yarp_lib_common` | `INTERFACE` library containing just the `GazeboYarpPlugins/common.h` header file. |
+| `GazeboYARPPlugins::gazebo_yarp_singleton` | Library containing the `GazeboYarpPlugins::Handler` singleton library. |
+| `GazeboYARPPlugins::gazebo_yarp_rpc_worldinterface` | The [thrift-generated YARP RPC interface](http://www.yarp.it/thrift_tutorial_simple.html) to the `gazebo_yarp_worldinterface` plugin. |
+| `GazeboYARPPlugins::gazebo_yarp_rpc_clock` | The [thrift-generated YARP RPC interface](http://www.yarp.it/thrift_tutorial_simple.html) to the `gazebo_yarp_clock` plugin. |
+
+Furthermore every plugin location is encoded in the `GazeboYARPPlugins::gazebo_yarp_pluginname` CMake imported target.

--- a/libraries/common/CMakeLists.txt
+++ b/libraries/common/CMakeLists.txt
@@ -12,5 +12,10 @@ else()
     add_library(gazebo_yarp_lib_common INTERFACE)
     target_include_directories(gazebo_yarp_lib_common INTERFACE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
     )
+
+    install(TARGETS gazebo_yarp_lib_common EXPORT GazeboYARPPlugins)
+    install(FILES include/GazeboYarpPlugins/common.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GazeboYarpPlugins)
 endif()

--- a/libraries/singleton/CMakeLists.txt
+++ b/libraries/singleton/CMakeLists.txt
@@ -8,12 +8,19 @@ PROJECT(Library_Singleton)
 
 include(AddGazeboYarpPluginTarget)
 
+set(Singleton_HEADERS include/GazeboYarpPlugins/Handler.hh
+                      include/GazeboYarpPlugins/ConfHelpers.hh)
+
 add_gazebo_yarp_plugin_target(LIBRARY_NAME singleton
                               INCLUDE_DIRS include/GazeboYarpPlugins
                               SYSTEM_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
                               LINKED_LIBRARIES ${YARP_LIBRARIES} ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
-                              HEADERS include/GazeboYarpPlugins/Handler.hh
-                                      include/GazeboYarpPlugins/ConfHelpers.hh
+                              HEADERS ${Singleton_HEADERS}
                               SOURCES src/Handler.cc
                                       src/ConfHelpers.cc)
+
+install(FILES ${Singleton_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/GazeboYarpPlugins)
+
+
 


### PR DESCRIPTION
See `doc/use_as_library.md` for usage. 

cc @barbalberto @valegagge 