### PR TITLE
Improved WorldInterface::getPose(..)

### DIFF
--- a/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
+++ b/plugins/worldinterface/src/worldinterfaceserverimpl.cpp
@@ -40,9 +40,9 @@ bool WorldInterfaceServerImpl::setPose(const std::string& id, const GazeboYarpPl
   return proxy->setPose(id, pose, frame_name);
 }
 
-GazeboYarpPlugins::Pose WorldInterfaceServerImpl::getPose(const std::string& id)
+GazeboYarpPlugins::Pose WorldInterfaceServerImpl::getPose(const std::string& id, const std::string& frame_name)
 {
-  return proxy->getPose(id); 
+    return proxy->getPose(id, frame_name);
 }
   
 bool WorldInterfaceServerImpl::enableGravity(const std::string& id, const bool enable)

--- a/plugins/worldinterface/src/worldinterfaceserverimpl.h
+++ b/plugins/worldinterface/src/worldinterfaceserverimpl.h
@@ -59,9 +59,10 @@ public:
     /**
      * Get object pose.
      * @param id string that identifies object in gazebo (returned after creation)
+     * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL1::link). Otherwise, world it will be used.
      * @return returns value of the pose in the world reference frame
      */
-    virtual GazeboYarpPlugins::Pose getPose(const std::string& id);
+    virtual GazeboYarpPlugins::Pose getPose(const std::string& id, const std::string& frame_name = "");
 
     /**
      * Enable/disables gravity for an object

--- a/plugins/worldinterface/src/worldproxy.cpp
+++ b/plugins/worldinterface/src/worldproxy.cpp
@@ -139,8 +139,15 @@ std::string WorldProxy::makeSphere(const double radius, const GazeboYarpPlugins:
 
   int nobjects=++objects.count;
   ostringstream objlabel;
-  objlabel << "sphere"<< nobjects;
-
+  
+  if(object_name!="")
+  {
+      objlabel << object_name;
+  }
+  else
+  {
+     objlabel << "sphere"<< nobjects;
+  }
   sdf::ElementPtr model = getSDFRoot(sphereSDF)->GetElement("model");
 
   model->GetAttribute("name")->SetFromString(objlabel.str());

--- a/plugins/worldinterface/src/worldproxy.h
+++ b/plugins/worldinterface/src/worldproxy.h
@@ -136,9 +136,10 @@ public:
   /**
    * Get object pose.
    * @param id string that identifies object in gazebo (returned after creation)
+   * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL1::link). Otherwise, world it will be used.
    * @return returns value of the pose expressed in the world reference frame
    */
-  virtual GazeboYarpPlugins::Pose getPose(const std::string& id);
+  virtual GazeboYarpPlugins::Pose getPose(const std::string& id, const std::string& frame_name);
     /**
    * Enable/disables gravity for an object
    * @param id object id

--- a/thrift/worldinterface/autogenerated/include/WorldInterfaceServer.h
+++ b/thrift/worldinterface/autogenerated/include/WorldInterfaceServer.h
@@ -108,9 +108,10 @@ public:
   /**
    * Get object pose.
    * @param id string that identifies object in gazebo (returned after creation)
+   * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL_ID::FRAME_ID). Otherwise, world it will be used.
    * @return returns value of the pose in the world reference frame
    */
-  virtual Pose getPose(const std::string& id);
+  virtual Pose getPose(const std::string& id, const std::string& frame_name = "");
   /**
    * Load a model from file.
    * @param id string that specifies the name of the model

--- a/thrift/worldinterface/autogenerated/src/Color.cpp
+++ b/thrift/worldinterface/autogenerated/src/Color.cpp
@@ -210,8 +210,7 @@ bool Color::Editor::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireWriter writer(reader);
   if (writer.isNull()) return true;
   writer.writeListHeader(1);
-  //writer.writeVocab(yarp::os::createVocab('o','k')); changed by thrift
-  writer.writeVocab(VOCAB2('o','k'));
+  writer.writeVocab(yarp::os::createVocab('o','k'));
   return true;
 }
 

--- a/thrift/worldinterface/autogenerated/src/Color.cpp
+++ b/thrift/worldinterface/autogenerated/src/Color.cpp
@@ -210,6 +210,7 @@ bool Color::Editor::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireWriter writer(reader);
   if (writer.isNull()) return true;
   writer.writeListHeader(1);
+  //writer.writeVocab(yarp::os::createVocab('o','k')); changed by thrift
   writer.writeVocab(VOCAB2('o','k'));
   return true;
 }

--- a/thrift/worldinterface/autogenerated/src/Pose.cpp
+++ b/thrift/worldinterface/autogenerated/src/Pose.cpp
@@ -327,6 +327,7 @@ bool Pose::Editor::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireWriter writer(reader);
   if (writer.isNull()) return true;
   writer.writeListHeader(1);
+  //writer.writeVocab(yarp::os::createVocab('o','k')); changed by thrift
   writer.writeVocab(VOCAB2('o','k'));
   return true;
 }

--- a/thrift/worldinterface/autogenerated/src/Pose.cpp
+++ b/thrift/worldinterface/autogenerated/src/Pose.cpp
@@ -327,8 +327,7 @@ bool Pose::Editor::read(yarp::os::ConnectionReader& connection) {
   yarp::os::idl::WireWriter writer(reader);
   if (writer.isNull()) return true;
   writer.writeListHeader(1);
-  //writer.writeVocab(yarp::os::createVocab('o','k')); changed by thrift
-  writer.writeVocab(VOCAB2('o','k'));
+  writer.writeVocab(yarp::os::createVocab('o','k'));
   return true;
 }
 

--- a/thrift/worldinterface/worldinterface_rpc.thrift
+++ b/thrift/worldinterface/worldinterface_rpc.thrift
@@ -91,7 +91,7 @@ service WorldInterfaceServer {
     * Set new object pose.
     * @param id object id
     * @param pose new pose
-    * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL_ID::FRAME_ID). Otherwise, world it will be used. 
+    * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL_ID::FRAME_ID). Otherwise, world it will be used.
     * @return returns true or false on success failure
     */
     bool setPose(1: string id, 2: Pose pose, 3: string frame_name="");
@@ -115,9 +115,10 @@ service WorldInterfaceServer {
      /** 
     * Get object pose.
     * @param id string that identifies object in gazebo (returned after creation)
+    * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL_ID::FRAME_ID). Otherwise, world it will be used.
     * @return returns value of the pose in the world reference frame
     */
-    Pose getPose(1:string id);
+    Pose getPose(1:string id, 2: string frame_name="");
     
     /**
     * Load a model from file.


### PR DESCRIPTION
I improved getPose in order to get the pose of an object refer to a given frame.

```
Now the signature of getPose function is:
 /**
    * Get object pose.
    * @param id string that identifies object in gazebo (returned after creation)
    * @param frame_name (optional) is specified, the pose will be relative to the specified fully scoped frame (e.g. MODEL_ID::FRAME_ID). Otherwise, world it will be used.
    * @return returns value of the pose in the world reference frame
    */
    Pose getPose(1:string id, 2: string frame_name="");
```
Moreover I fixed a small bug in makeSphere: now the objectname parameter is used to label the created sphere. see https://github.com/robotology/gazebo-yarp-plugins/commit/de34ac26bcbd8565d1d55875d7d7c2ec34b93302

This branch should solve issue https://github.com/hsp-iit/project-mobile-manipulation/issues/10
