### PR TITLE
Add setMotorTorqueParams and getMotorTorqueParams methods to the controlboard class

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTorqueControl.cpp
@@ -109,6 +109,16 @@ bool GazeboYarpControlBoardDriver::getTorqueRanges(double *min, double *max)
     return true;
 }
 
+bool GazeboYarpControlBoardDriver::getMotorTorqueParams(int ,  yarp::dev::MotorTorqueParameters *)
+{
+    return false;
+}
+
+bool GazeboYarpControlBoardDriver::setMotorTorqueParams(int , const yarp::dev::MotorTorqueParameters )
+{
+    return false;
+}
+
 bool GazeboYarpControlBoardDriver::checkIfTorqueIsValid(const double* torques) const
 {
     if (!torques)


### PR DESCRIPTION
It was erroneously removed in  https://github.com/robotology/gazebo-yarp-plugins/commit/8bf4e24ada037d99d1fa50c67fc9239d012675bd#diff-732527c53bcfabfbb15e5399654ff8b6L123 .

Fix https://github.com/robotology/gazebo-yarp-plugins/issues/372 . 
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/373 . 