### PR TITLE
Add setControlMode and setControlModes methods dummy definitions

### DIFF
--- a/plugins/fakecontrolboard/src/FakeControlBoardDriverControlMode.cpp
+++ b/plugins/fakecontrolboard/src/FakeControlBoardDriverControlMode.cpp
@@ -41,7 +41,16 @@ bool GazeboYarpFakeControlBoardDriver::getControlMode(int j, int *mode)
     return true;
 }
 
-bool GazeboYarpFakeControlBoardDriver::setControlModes(const int n_joint, const int *joints, int *modes) 
+bool GazeboYarpFakeControlBoardDriver::setControlModes(const int n_joint, const int *joints, int *modes)
 {
     return getTrueIfArgumentIsZero(n_joint);
+}
+
+bool GazeboYarpFakeControlBoardDriver::setControlMode(const int, const int)
+{
+    return false;
+}
+bool GazeboYarpFakeControlBoardDriver::setControlModes(int *)
+{
+    return false;
 }


### PR DESCRIPTION
Same fix as https://github.com/robotology/gazebo-yarp-plugins/pull/374, for the same reasons. These method definitions were erroneously removed in  https://github.com/robotology/gazebo-yarp-plugins/commit/8bf4e24ada037d99d1fa50c67fc9239d012675bd#diff-732527c53bcfabfbb15e5399654ff8b6L123 .