### PR TITLE
Fix laser plugin

### DIFF
--- a/plugins/lasersensor/src/LaserSensor.cc
+++ b/plugins/lasersensor/src/LaserSensor.cc
@@ -54,7 +54,7 @@ void GazeboYarpLaserSensor::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
     // Add my gazebo device driver to the factory.
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpLaserSensorDriver>
-                                      ("gazebo_laserSensor", "Rangefinder2DWrapper", "GazeboYarpLaserSensorDriver"));
+                                      ("gazebo_yarp_lasersensor", "Rangefinder2DWrapper", "GazeboYarpLaserSensorDriver"));
 
     //Getting .ini configuration file from sdf
     ::yarp::os::Property wrapper_properties;
@@ -68,18 +68,19 @@ void GazeboYarpLaserSensor::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     };
 
 
-    ///< \todo TODO handle in a better way the parameters that are for the wrapper and the one that are for driver
-    wrapper_properties = driver_properties;
-
     m_sensorName = _sensor->ScopedName();
 
     //Insert the pointer in the singleton handler for retriving it in the yarp driver
     GazeboYarpPlugins::Handler::getHandler()->setSensor(_sensor.get());
 
     driver_properties.put(YarpLaserSensorScopedName.c_str(), m_sensorName.c_str());
-        
+
+    ///< \todo TODO handle in a better way the parameters that are for the wrapper and the one that are for driver
+    wrapper_properties = driver_properties;
+
     //Open the wrapper
     wrapper_properties.put("device","Rangefinder2DWrapper");
+
     if( m_laserWrapper.open(wrapper_properties) ) {
     } else
     {
@@ -89,13 +90,14 @@ void GazeboYarpLaserSensor::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
     //Open the driver
     //Force the device to be of type "gazebo_forcetorque" (it make sense? probably yes)
-    driver_properties.put("device","gazebo_laserSensor");
+    //driver_properties.put("device","gazebo_cer_laser_sensor");
     if( m_laserDriver.open(driver_properties) ) {
-    } else 
+    } else
     {
         yError()<<"GazeboYarpLaserSensor Plugin failed: error in opening yarp driver";
         return;
     }
+
 
     //Attach the driver to the wrapper
     ::yarp::dev::PolyDriverList driver_list;


### PR DESCRIPTION
When I tried to read laser values in Gazebo I couldn't read nothing because of the following error:
`[ERROR]Cannot find "gazebo_lasersensor" plugin (not built in, and no .ini file found for it)
[ERROR]Check that YARP_DATA_DIRS leads to at least one directory with plugins/gazebo_lasersensor.ini or share/yarp/plugins/gazebo_lasersensor.ini in it
yarpdev: ***ERROR*** could not find device <gazebo_lasersensor>
[ERROR]RangeFinder2DWrapper: failed to open subdevice.. check params 
yarpdev: ***ERROR*** driver <Rangefinder2DWrapper> was found but could not open
[ERROR]GazeboYarpLaserSensor Plugin failed: error in opening yarp driver wrapper 
`

Therefore I try to fix this issue con this PR.
Now Laser works fine on my setup. 
@barbalberto could you check if this fix is correct?
Thanks!

