### PR TITLE
Update yarpmotorgui.ini of single_pendulum

### DIFF
--- a/tutorial/model/single_pendulum/yarpmotorgui.ini
+++ b/tutorial/model/single_pendulum/yarpmotorgui.ini
@@ -1,4 +1,4 @@
-name singlePendulumGazebo
+robot singlePendulumGazebo
 parts (body)
 
 


### PR DESCRIPTION
The `name` parameter has been renamed to `robot` in a previous YARP release. Updating the configuration file accordingly.