### PR TITLE
[controlboard] Fix trajectory generation problem with non-standard simulatiom timestep

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
@@ -59,7 +59,7 @@ protected:
     double m_xf;
     double m_speed;
     double m_computed_reference;
-    unsigned int m_controllerPeriod;
+    double m_controllerPeriod;
     double m_joint_min;
     double m_joint_max;
     TrajectoryGenerator(gazebo::physics::Model* model);

--- a/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverTrajectory.cpp
@@ -210,7 +210,7 @@ bool MinJerkTrajectoryGenerator::initTrajectory (double current_pos, double fina
 #else
     gazebo::physics::PhysicsEnginePtr physics = this->m_robot->GetWorld()->GetPhysicsEngine();
 #endif
-    m_controllerPeriod = static_cast<unsigned>(physics->GetUpdatePeriod() * 1000.0);
+    m_controllerPeriod = physics->GetUpdatePeriod() * 1000.0;
     double speedf = fabs(speed);
     double dx0 =0;
     m_computed_reference = current_pos;
@@ -231,7 +231,7 @@ bool MinJerkTrajectoryGenerator::initTrajectory (double current_pos, double fina
 
     //double step = (m_trajectoryGenerationReferenceSpeed[j] / 1000.0) * m_robotRefreshPeriod * _T_controller;
 
-    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / double (m_controllerPeriod);
+    m_tf = (1000 * fabs(m_xf - m_x0) / speedf) / m_controllerPeriod;
     m_dx0 = m_dx0 * m_tf;
 
     dx0  = m_dx0;
@@ -391,7 +391,7 @@ bool ConstSpeedTrajectoryGenerator::initTrajectory (double current_pos, double f
 #else
     gazebo::physics::PhysicsEnginePtr physics = this->m_robot->GetWorld()->GetPhysicsEngine();
 #endif
-    m_controllerPeriod = static_cast<unsigned>(physics->GetUpdatePeriod() * 1000.0);
+    m_controllerPeriod = physics->GetUpdatePeriod() * 1000.0;
     m_x0 = current_pos;
     m_xf = final_pos;
     if (m_xf > m_joint_max) m_xf = m_joint_max;


### PR DESCRIPTION
Original fix by @emilio-cartoni in https://github.com/robotology/gazebo-yarp-plugins/pull/302.

Sorry for taking so long @emilio-cartoni ! Indeed the problem was due to the fact that `m_controlboardPeriod` variable (that I guess is the period of the trajectory generation expressed in **milliseconds**) was an integer, and so if the controller period  was less than 0.5 milliseconds, the period was approximated to 0, causing the trajectory generation to never leave the initial point. 

I just opened a new PR as apparently `GetUpdatePeriod` and `GetMaxTimeStep` actually return the same value, so there is no need to change that. 

