### PR TITLE
Refactoring of linkattacher plugin

### DIFF
--- a/plugins/linkattacher/README.md
+++ b/plugins/linkattacher/README.md
@@ -1,7 +1,8 @@
 ### LinkAttacher Plugin
-The LinkAttacher is a Gazebo _model plugin_. It can be used to attach/detach any _link_ of the _model_ spawned in Gazebo environment. The attachment is made by adding a _fixed joint_ between the links specified. The link of the model in Gazebo environment is the parent link and the link of the robot(to which this plugin) is used becomes the child link for the newly created fixed joint. So, the fixed joint is named by the `model_link_name` suffixed with the phrase *_magnet_joint* in the name e.g, l_hand_magnet_joint.
+The LinkAttacher is a Gazebo _model plugin_. It can be used to attach/detach two _link_ of _model_ spawned in Gazebo environment. The attachment is made by adding a _fixed joint_ between the links specified. The link of the model we want to attach is the parent link and the link of the robot model (to which this plugin is added) becomes the child link for the newly created fixed joint. So, the fixed joint is named by the `model_link_name` suffixed with the phrase *_magnet_joint* in the name e.g, l_hand_magnet_joint.
 
-Additionally, this plugin also provides control over _gravity_ of the models spawned in Gazebo environment. Currently, this plugin is used for coupling the hands of the robot model and human model in pHRI experiments. Also, this plugin can be used to attach objects to the robot links.
+Additionally, this plugin also provides control over _gravity_ of the models spawned in Gazebo environment.
+Currently, this plugin is used for coupling the hands of two robots, or those robot model and human model in pHRI experiments. Also, this plugin can be used to attach objects to the robot links.
 
 ### Usage
 Create a `linkattacher.ini` configuration file and add the following lines to it to open the rpc port for communicating with the linkattacher plugin
@@ -20,6 +21,7 @@ Now, add the following lines to the sdf model
 On launching the model in Gazebo, the _rpc_ port will be opened. Connect to this port and type `help` to know the available commands.
 
 The available commands are:
-- attachUnscoped
-- detachUnscoped
-- enableGravity
+- `attachUnscoped <parent_model_name> <parent_model_link_name> <child_model_name> <child_model_link_name>`
+- `detachUnscoped <model_name> <link_name>`
+- `enableGravity <model_name> <enable>`
+The `link_name` can be both the scoped or unscoped name of the link.

--- a/plugins/linkattacher/include/GazeboYarpPlugins/linkattacherserverimpl.h
+++ b/plugins/linkattacher/include/GazeboYarpPlugins/linkattacherserverimpl.h
@@ -39,25 +39,25 @@ public:
 
   /**
   * Attach any link of the models spawned in gazebo to a link of the robot using a fixed joint.
-  * @param model_name name that identifies model in gazebo (that are already spawned in gazebo)
-  * @param model_link_name name of a the link in the model you want to attach to the robot
-  * @param robot_name name of the robot
-  * @param robot_link_name name of the robot link to which you want to attached the model link
+  * @param parent_model_name name that identifies the first model
+  * @param parent_model_link_name name of the link in the first model you want to attach (scoped or unscoped name)
+  * @param child_model_name name that identifies the second model
+  * @param child_model_link_name name of the link in the second model you want to attach (scoped or unscoped name)
   * @return true if success, false otherwise
   */
-  virtual bool attachUnscoped(const std::string& model_name, const std::string& model_link_name, const std::string& robot_name, const std::string& robot_link_name);
+  virtual bool attachUnscoped(const std::string& parent_model_name, const std::string& parent_model_link_name, const std::string& child_model_name, const std::string& child_model_link_name);
 
   /**
   * Detach the model link which was previously attached to the robot link through a fixed joint.
-  * @param model_name name that identifies model in gazebo (that are already spawned in gazebo)
-  * @param model_link_name name of a the link in the model that is attached to the robot
+  * @param model_name name that identifies parent model
+  * @param model_link_name name of the link of the parent model that is attached
   * @return true if success, false otherwise
   */
   virtual bool detachUnscoped(const std::string& model_name, const std::string& model_link_name);
 
   /**
   * Enable/disables gravity for a model
-  * @param model_name name that identifies model in gazebo (that are already spawned in gazebo)
+  * @param model_name name that identifies model in gazebo
   * @param enable 1 to enable gravity, 0 otherwise
   * @return returns true or false on success failure
   */


### PR DESCRIPTION
As it was originally implemented, the `linkattacher` device was though to attach the link of a robot (`robot_model`) to that of an object (`object_model`).

In order to have a general device (to be used for example in order to simulate contacts in robot-robot interaction), it was not only necessary to change the name of the variables to more proper names (`parent_model` and `child_model`) but it was also necessary to be able to detect the link of both the models from scoped names (to understand why see https://github.com/robotology/gazebo-yarp-plugins/issues/342 ) instead of using [`GetLink()`](https://github.com/robotology/gazebo-yarp-plugins/compare/devel...lrapetti:linkattacher_refactoring?expand=1#diff-7e1089c30889bd5585eeb97aae62e840L38).

In addiction, I have used the [hasEnding()](https://github.com/robotology/gazebo-yarp-plugins/blob/master/libraries/common/include/GazeboYarpPlugins/common.h#L52) in place of the previous implementation of the search of the link from unscoped name, in this way it is possible to use both the scoped or unscoped name as input (this can be helpful to distinguish between links with the same unscoped name).

#### Further Implementation
Given that the search for the link from `model_name` and `link_name` is repeated along the code, and could be useful also for other plugins, I was thinking that it would be better to have this function defined only once in a shared place ([`common.h`](https://github.com/robotology/gazebo-yarp-plugins/blob/master/libraries/common/include/GazeboYarpPlugins/common.h)??) as something like:
```
gazebo::physics::LinkPtr GetLinkFromName(const string& model_name, const string& link_name)
```