### PR TITLE
Add use of loadConfigModelPlugin()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ Mirko Ferrati <mirko.ferrati@gmail.com>
 Nicola Piga <nicolapiga@gmail.com>
 Prashanth Ramadoss <prashanth.ramadoss@iit.it>
 Silvio Traversaro <silvio.traversaro@iit.it>
-Yeshasvi Tirupachuri<yeshasvi.tirupachuri@iit.it>
+Yeshasvi Tirupachuri <yeshasvi.tirupachuri@iit.it>
+Lorenzo Rapetti <lorenzo.rapetti@iit.it>

--- a/plugins/basestate/src/BaseState.cc
+++ b/plugins/basestate/src/BaseState.cc
@@ -65,33 +65,27 @@ namespace gazebo
         ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpBaseStateDriver>
                                         ("gazebo_basestate", "analogServer", "GazeboYarpBaseState"));
         
-        yarp::os::Bottle networkDeviceProp;
-        yarp::os::Bottle deviceDriverProp;
-        
-        if (_sdf->HasElement("yarpConfigurationFile"))
+        // Getting .ini configuration file parameters from sdf
+        bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, m_config);
+
+        if (!configuration_loaded)
         {
-            std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-            std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-            
-            GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_parent, _sdf, m_config);
-            
-            bool wipe = false;
-            if (ini_file_path != "" && m_config.fromConfigFile(ini_file_path.c_str(), wipe))
-            {
-                networkDeviceProp = m_config.findGroup("WRAPPER");
-                if (networkDeviceProp.isNull())
-                {
-                    yError() << "GazeboYarpBaseState plugin failed: [WRAPPER] group not found in config file";
-                    return;
-                }
-                
-                deviceDriverProp = m_config.findGroup("DRIVER");
-                if (deviceDriverProp.isNull())
-                {
-                    yError() << "GazeboYarpBaseState plugin failed: [DRIVER] group not found in config file";
-                    return;
-                }
-            }
+            yError() << "GazeboYarpBaseState : File .ini not found, load failed." ;
+            return;
+        }
+
+        yarp::os::Bottle networkDeviceProp = m_config.findGroup("WRAPPER");
+        if (networkDeviceProp.isNull())
+        {
+            yError() << "GazeboYarpBaseState plugin failed: [WRAPPER] group not found in config file";
+            return;
+        }
+        
+        yarp::os::Bottle deviceDriverProp = m_config.findGroup("DRIVER");
+        if (deviceDriverProp.isNull())
+        {
+            yError() << "GazeboYarpBaseState plugin failed: [DRIVER] group not found in config file";
+            return;
         }
       
         if (networkDeviceProp.find("device").isNull())

--- a/plugins/contactloadcellarray/src/ContactLoadCellArray.cc
+++ b/plugins/contactloadcellarray/src/ContactLoadCellArray.cc
@@ -74,46 +74,30 @@ namespace gazebo
         // Add the gazebo device driver to the factory
         ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpContactLoadCellArrayDriver>
                                            ("gazebo_contactloadcellarray", "analogServer", "GazeboYarpContactLoadCellArray"));
-           
-        // Getting .ini config file from _sdf
-        yarp::os::Bottle wrapper_properties;
-        yarp::os::Bottle driver_properties;
-    
-        bool configuration_loaded = false;
-        if (_sdf->HasElement("yarpConfigurationFile"))
-        {
-            std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-            std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-      
-            GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_parent, _sdf, m_parameters);
-      
-            bool wipe = false;
-            if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str(), wipe))
-            {
-                wrapper_properties = m_parameters.findGroup("WRAPPER");
-                if (wrapper_properties.isNull())
-                {
-                    yError() << "GazeboYarpContactLoadCellArray Plugin failed: [WRAPPER] group not found in config file";
-                    return;  
-                }
 
-                driver_properties = m_parameters.findGroup("DRIVER");
-                if (driver_properties.isNull())
-                {
-                    yError() << "GazeboYarpContactLoadCellArray Plugin failed: [DRIVER] group not found in config file";
-                    return;
-                }
+        // Getting .ini configuration file parameters from sdf
+        bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, m_parameters);
 
-                configuration_loaded = true;
-            }
-        }
-    
         if (!configuration_loaded)
         {
-            yError() << "GazeboYarpContactLoadCellArray Plugin Failed: File .ini not found, load failed";
+            yError() << "GazeboYarpContactLoadCellArray : File .ini not found, load failed." ;
             return;
         }
-    
+
+        yarp::os::Bottle wrapper_properties = m_parameters.findGroup("WRAPPER");
+        if (wrapper_properties.isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: [WRAPPER] group not found in config file";
+            return;  
+        }
+
+        yarp::os::Bottle driver_properties = m_parameters.findGroup("DRIVER");
+        if (driver_properties.isNull())
+        {
+            yError() << "GazeboYarpContactLoadCellArray Plugin failed: [DRIVER] group not found in config file";
+            return;
+        }
+
         // Check on Required Parameter for Analog Sensor Wrapper
         if (wrapper_properties.find("device").isNull())
         {

--- a/plugins/inertialmtbPart/src/inertialMTBPart.cc
+++ b/plugins/inertialmtbPart/src/inertialMTBPart.cc
@@ -55,10 +55,10 @@ void GazeboYarpInertialMTBPart::Load(physics::ModelPtr _parent, sdf::ElementPtr 
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpInertialMTBPartDriver>
                                         ("gazebo_inertialMTB", "analogServer", "GazeboYarpInertialMTBPartDriver"));
 
-    //Getting .ini configuration file parameters from sdf
+    // Getting .ini configuration file parameters from sdf
     ::yarp::os::Property plugin_properties;
 
-    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent,_sdf,plugin_properties);
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, plugin_properties);
 
     if (!configuration_loaded)
     {

--- a/plugins/jointsensors/src/JointSensors.cc
+++ b/plugins/jointsensors/src/JointSensors.cc
@@ -57,13 +57,15 @@ void GazeboYarpJointSensors::Load(physics::ModelPtr _parent, sdf::ElementPtr _sd
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpJointSensorsDriver>
                                       ("gazebo_jointsensors", "analogServer", "GazeboYarpJointSensorsDriver"));
 
-    //Getting .ini configuration file from sdf
+    // Getting .ini configuration file from sdf
     ::yarp::os::Property wrapper_properties;
     ::yarp::os::Property driver_properties;
 
-    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent,_sdf,driver_properties);
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, driver_properties);
 
-    if (!configuration_loaded) {
+    if (!configuration_loaded)
+    {
+        yError() << "GazeboYarpJointSensors : File .ini not found, load failed." ;
         return;
     };
 

--- a/plugins/videotexture/src/VideoTexture.cc
+++ b/plugins/videotexture/src/VideoTexture.cc
@@ -78,29 +78,17 @@ namespace gazebo
        return;
     }
 
-    //Getting .ini configuration file from sdf
-    bool configuration_loaded = false;
-
+    // Getting .ini configuration file parameters from sdf
     if(!sdf->HasElement("yarpConfigurationFile") && sdf->HasElement("sdf"))
     {
         sdf = sdf->GetElement("sdf");
     }
 
-    if (sdf->HasElement("yarpConfigurationFile"))
-    {
-        std::string ini_file_name = sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-
-        if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str()))
-        {
-            //yInfo() << "Found yarpConfigurationFile: loading from " << ini_file_path ;
-            configuration_loaded = true;
-        }
-     }
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, m_parameters);
 
     if (!configuration_loaded)
     {
-        //yError() << "VideoTexture::Load error could not load configuration file";
+        yError() << "VideoTexture : File .ini not found, load failed." ;
         return;
     }
 


### PR DESCRIPTION
As discussed in https://github.com/robotology/gazebo-yarp-plugins/issues/142#issuecomment-437087190, after introducing [GazeboYarpPlugins::loadConfigModelPlugin()](https://github.com/robotology/gazebo-yarp-plugins/blob/master/libraries/singleton/src/ConfHelpers.cc#L59) with https://github.com/robotology/gazebo-yarp-plugins/commit/1528523e1b1d193dfb5aabd542b80203f57914a1, the plugins have never been cleaned up and this function was almost unused (it was used just in `jointsensors` and `inertialmtbPart`, while it was done consistently with `loadConfigSensorPlugin()` in https://github.com/robotology/gazebo-yarp-plugins/commit/1528523e1b1d193dfb5aabd542b80203f57914a1).

A spread use of `loadConfigModelPlugin()` will facilitate changes in the way parameters are loaded, so with this PR I am updating all the plugins in order to use it.
The update plugins are:
- `GazeboYarpBaseState`
- `GazeboYarpContactLoadCellArray `
- `GazeboYarpControlBoard`
- `GazeboYarpFakeControlBoard`
- `GazeboYarpLinkattacher`
- `GazeboYarpMaisSensor`
- `GazeboYarpVideoTexture`

#### Observation
- In the [`GazeboYarpControlBoard`](https://github.com/robotology/gazebo-yarp-plugins/pull/394/files#diff-350377892a04885f201132a7178fbec9L85) and [`GazeboYarpFakeControlBoard`](https://github.com/robotology/gazebo-yarp-plugins/pull/394/files#diff-41ad1594192efebe9071a061089932bbL85), a property containing the path of the `.ini` configuration file was add to the `parameters` as `"gazebo_ini_file_path"`. This operation was not replicated in any of the other plugins and it is not implemented in `loadConfigModelPlugin()`. However, the `"gazebo_ini_file_path"` property seems to be unused so removing it should not be a problem.
- In `GazeboYarpVideoTexture` the print functions were commented out, and using `loadConfigModelPlugin()` the print will be added again. Since I don't know why they were commented out, I don't know it this could be a problem. Furthermore, in the `GazeboYarpVideoTexture` the [`addGazeboEnviromentalVariablesModel `](https://github.com/robotology/gazebo-yarp-plugins/blob/master/libraries/singleton/src/ConfHelpers.cc#L67) function was previously not called and it is introduced by the `loadConfigModelPlugin()`, but this should just add some unused variable but it should not cause any problem (I have no example using this function so I was not able to test it).