### PR TITLE
Add <yarpConfigurationString> parameter

### DIFF
--- a/doc/embed_plugins.md
+++ b/doc/embed_plugins.md
@@ -55,7 +55,10 @@ For model plugins such as the `gazebo_yarp_controlboard`, a plugin can be loaded
 </plugin>
 ~~~
 Most Model and Sensor plugins present in `gazebo-yarp-plugins` read their configuration from the file referenced in the `yarpConfigurationFile` tag.
-The location of the file is defined by using a [Gazebo URI](https://bitbucket.org/osrf/gazebo/wiki/uri), while the file is a [.ini YARP configuration file](http://www.yarp.it/yarp_config_files.html).
+The location of the file is defined by using a [Gazebo URI](https://bitbucket.org/osrf/gazebo/wiki/uri), while the file is a [.ini YARP configuration file](http://www.yarp.it/yarp_config_files.html). Alternatively, parameters can be passed directly in the `sdf` with the [`Bottle`](http://www.yarp.it/classyarp_1_1os_1_1Bottle.html) format using the `yarpConfigurationString` tag (e.g. `<yarpConfigurationString>(name /iCub/linkattacher/rpc:i)</yarpConfigurationString>`). When using `yarpConfigurationString`, it is important to remember that:
+- only **one** `yarpConfigurationString` can be defined for each plugin.
+- the tags `<yarpConfigurationFile>` and `<yarpConfigurationString>` can coexist, but if a parameter is defined in both the value in `<yarpConfigurationString>` will **always** be used.
+
 For specific information consumed by each plugin, please refer to the doxygen documentation of the specific plugin class.
 
 System plugins instead need to be loaded at the beginning of the simulation, and hence they are passed as command line arguments when launching `gazebo` (or `gzserver`).

--- a/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/ConfHelpers.hh
@@ -45,7 +45,9 @@ std::vector<std::string> splitString(const std::string &s, const std::string &de
  * Load the configuration for a given model plugin,
  * and save the configuration in the plugin_parameters output object.
  * This involves calling addGazeboEnviromentalVariablesModel and then loading
- * the yarp configuration file specified in the sdf with the yarpConfigurationFile tag.
+ * the yarp configuration file specified in the sdf with the yarpConfigurationFile and
+ * yarpConfigurationString tags. In case a parameter is defined in both, the yarpConfigurationString
+ * has the priority.
  */
 bool loadConfigModelPlugin(gazebo::physics::ModelPtr _parent,
                            sdf::ElementPtr _sdf,
@@ -74,7 +76,9 @@ bool addGazeboEnviromentalVariablesModel(gazebo::physics::ModelPtr _parent,
  * Load the configuration for a given sensor plugin,
  * and save the configuration in the plugin_parameters output object.
  * This involves calling addGazeboEnviromentalVariablesSensor and then loading
- * the yarp configuration file specified in the sdf with the yarpConfigurationFile tag.
+ * the yarp configuration file specified in the sdf with the yarpConfigurationFile and
+ * yarpConfigurationString tags. In case a parameter is defined in both, the yarpConfigurationString
+ * has the priority.
  */
 bool loadConfigSensorPlugin(gazebo::sensors::SensorPtr _sensor,
                             sdf::ElementPtr _sdf,

--- a/libraries/singleton/src/ConfHelpers.cc
+++ b/libraries/singleton/src/ConfHelpers.cc
@@ -60,23 +60,33 @@ bool loadConfigModelPlugin(physics::ModelPtr _model,
                            sdf::ElementPtr _sdf,
                            yarp::os::Property& plugin_parameters)
 {
-    if (_sdf->HasElement("yarpConfigurationFile")) {
+    GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_model,_sdf,plugin_parameters);
+    bool wipe = false;
+    bool loaded_configuration = true;
+
+    if (_sdf->HasElement("yarpConfigurationFile"))
+    {
         std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
         std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
 
-        GazeboYarpPlugins::addGazeboEnviromentalVariablesModel(_model,_sdf,plugin_parameters);
-
-        bool wipe = false;
         if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe)) {
-            return true;
+            loaded_configuration = true;
         } else {
             yError() << "GazeboYarpPlugins error: failure in loading configuration for model" << _model->GetName() << "\n"
                       << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << "\n"
                       << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path;
-            return false;
+            loaded_configuration = false;
         }
     }
-    return true;
+
+    if (_sdf->HasElement("yarpConfigurationString"))
+    {
+        std::string configuration_string = _sdf->Get<std::string>("yarpConfigurationString");
+        plugin_parameters.fromString(configuration_string, wipe);
+        yInfo() << "GazeboYarpPlugins: configuration of model " << _model->GetName() << " loaded from yarpConfigurationString : " << configuration_string << "\n";
+    }
+
+    return loaded_configuration;
 }
 
 bool addGazeboEnviromentalVariablesSensor(gazebo::sensors::SensorPtr _sensor,
@@ -122,31 +132,41 @@ bool loadConfigSensorPlugin(sensors::SensorPtr _sensor,
                             sdf::ElementPtr _sdf,
                             yarp::os::Property& plugin_parameters)
 {
-    if (_sdf->HasElement("yarpConfigurationFile")) {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+    GazeboYarpPlugins::addGazeboEnviromentalVariablesSensor(_sensor,_sdf,plugin_parameters);
+    bool wipe = false;
+    bool loaded_configuration = true;
 
-        GazeboYarpPlugins::addGazeboEnviromentalVariablesSensor(_sensor,_sdf,plugin_parameters);
-
-        bool wipe = false;
-        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe))
-        {
-            return true;
-        }
-        else
-        {
 #if GAZEBO_MAJOR_VERSION >= 7
     std::string sensorName = _sensor->Name();
 #else
     std::string sensorName = _sensor->GetName();
 #endif
+
+    if (_sdf->HasElement("yarpConfigurationFile")) {
+        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
+        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
+        
+        if (ini_file_path != "" && plugin_parameters.fromConfigFile(ini_file_path.c_str(),wipe))
+        {
+            loaded_configuration = true;
+        }
+        else
+        {
             yError()  << "GazeboYarpPlugins error: failure in loading configuration for sensor " << sensorName << "\n"
                       << "GazeboYarpPlugins error: yarpConfigurationFile : " << ini_file_name << "\n"
                       << "GazeboYarpPlugins error: yarpConfigurationFile absolute path : " << ini_file_path ;
-            return false;
+            loaded_configuration = false;
         }
     }
-    return true;
+
+    if (_sdf->HasElement("yarpConfigurationString"))
+    {
+        std::string configuration_string = _sdf->Get<std::string>("yarpConfigurationString");
+        plugin_parameters.fromString(configuration_string, wipe);
+        yInfo() << "GazeboYarpPlugins: configuration of sensor " << sensorName << " loaded from yarpConfigurationString : " << configuration_string << "\n";
+    }
+
+    return loaded_configuration;
 }
 
 


### PR DESCRIPTION
As discussed in https://github.com/robotology/gazebo-yarp-plugins/issues/142 I am adding a `yarpConfigurationString` option that allows to simply define a configuration for a plugin without editing/writing an `.ini`.

The implementation is based on the [Property::fromString()](http://www.yarp.it/classyarp_1_1os_1_1Property.html#a0b938dbb6cf9e92a845cb18509865c62), so it is using the same format of [`Bottle`](http://www.yarp.it/classyarp_1_1os_1_1Bottle.html).
e.g. in order to define the `name` property of a `linkattacher` plugin without passing trough a `.ini`:
```xml
    <model name="iCub">
      <include>
          <uri>model://icub_standup</uri>
      </include>
      <plugin name='link_attacher' filename='libgazebo_yarp_linkattacher.so'>
        <yarpConfigurationString>(name /iCub/linkattacher/rpc:i)</yarpConfigurationString>
      </plugin>
    </model>
```

### Observations
- In case of coexistence of `yarpConfigurationFile`  and `yarpConfigurationString`, the parameters will be loaded from both the file and the string. If a parameter is present in both, it will be **always** used the one from `yarpConfigurationString`.
- `loadConfigSensorPlugin()` and `loadConfigModelPlugin()` are almost identical a part from the fact that the sensor name is read using `Name()` instead of `GetName()` when [`GAZEBO_MAJOR_VERSION >= 7`](https://github.com/robotology/gazebo-yarp-plugins/compare/devel...lrapetti:add_yarpConfigurationString?expand=1#diff-6374fb85025a47ba5644e9484e15b2e7L138). Probably, in the future it would make sense to merge the two function or to wrap the common part in a single function.
- At the moment I have decided to use `fromString()` instead of `fromCommand()` because it would require a conversion of `std::string` to `argc` and `argv`, but I have not found any compact implementation. If we decide to implement this type conversion, I think it would be better to do it in `yarp::os::Property` by defining there a method like `fromCommand(std::String & command, bool skipFirst, bool wipe)`.
- I have tested the `yarpConfigurationString` with different devices and options and it was working correctly. However, I have observed in the [`ControlBoard`](https://github.com/robotology/gazebo-yarp-plugins/blob/devel/plugins/controlboard/src/ControlBoard.cc#L72) that when I change the `gazeboYarpPluginsRobotName` using `yarpConfigurationString`, the property in `m_parameters` changes accordingly. But if a different `gazeboYarpPluginsRobotName` was defined somewhere else (e.g. in the [`.ini`](https://github.com/robotology/icub-gazebo/blob/master/icub/conf/gazebo_icub_torso.ini#L1)), this old name is used:

**e.g.** if I am using this `sdf`
```xml
    <plugin name='controlboard_right_leg' filename='libgazebo_yarp_controlboard.so'>
      <yarpConfigurationFile>model://icub/conf/gazebo_icub_right_leg.ini</yarpConfigurationFile>
      <yarpConfigurationString>(gazeboYarpPluginsRobotName new_iCub)</yarpConfigurationString>
    </plugin>
```  

  I can print [here](https://github.com/robotology/gazebo-yarp-plugins/blob/devel/plugins/controlboard/src/ControlBoard.cc#L73) `m_parameters.findGroup("gazeboYarpPluginsRobotName").toString()` -> `new_iCub`, but the port prefix that is used in the controlboard is `icubSim` like if the port is opened before loading the new property (if the `gazeboYarpPluginsRobotName` is not defined anywhere else, it is correctly using `new_iCub` as prefix).