### PR TITLE
Fix invalid camera parameters in gazebo_depthCamera plugin

### DIFF
--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -94,7 +94,7 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     }
 
     //Open the driver
-    //Force the device to be of type "gazebo_forcetorque" (it make sense? probably yes)
+    //Force the device to be of type "gazebo_depthCamera" (it make sense? probably yes)
     m_driverParameters.put("device","gazebo_depthCamera");
     yDebug() << "CC: m_driverParameters:\t" << m_driverParameters.toString();
 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -334,6 +334,7 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
         distModel = camPtr->LensDistortion().get();
         if(distModel)
         {
+            intrinsic.put("physFocalLength", 0.0);
             intrinsic.put("focalLengthX",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
             intrinsic.put("focalLengthY",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
 #if GAZEBO_MAJOR_VERSION >= 8

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -334,8 +334,8 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
         distModel = camPtr->LensDistortion().get();
         if(distModel)
         {
-            intrinsic.put("focalLengthX",    camPtr->OgreCamera()->getFocalLength());
-            intrinsic.put("focalLengthY",    camPtr->OgreCamera()->getFocalLength() * camPtr->OgreCamera()->getAspectRatio());
+            intrinsic.put("focalLengthX",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
+            intrinsic.put("focalLengthY",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
 #if GAZEBO_MAJOR_VERSION >= 8
             intrinsic.put("k1",              distModel->K1());
             intrinsic.put("k2",              distModel->K2());


### PR DESCRIPTION
Fix for issue #407 

Fix `focalLengthX` and `focalLengthY` values returned by the plugin when asking the intrinsic parameters of the camera through rpc via the command `visr get intp`.
The new returned values are now pixel/meter ratios instead of meters, to be similar to the interface of the hardware cameras.

