### PR TITLE
Change behavior of method GazeboYarpControlBoardDriver::checkMotionDone so that it adheres to that of the real control board

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
@@ -218,12 +218,15 @@ bool GazeboYarpControlBoardDriver::relativeMove(const int n_joint, const int *jo
     return ret;
 }
 
-bool GazeboYarpControlBoardDriver::checkMotionDone(const int n_joint, const int *joints, bool *flags)
+bool GazeboYarpControlBoardDriver::checkMotionDone(const int n_joint, const int *joints, bool *flag)
 {
-    if (!joints || !flags) return false;
+    if (!joints || !flag) return false;
     bool ret = true;
+    *flag = true;
     for (int i = 0; i < n_joint && ret; i++) {
-        ret = checkMotionDone(joints[i], &flags[i]);
+        bool done;
+        ret = checkMotionDone(joints[i], &done);
+        (*flag) &= done;
     }
     return ret;
 }


### PR DESCRIPTION
This PR fixes the implementation of the method

`
yarp::dev::IPositionControl::checkMotionDone (const int n_joint, const int * joints, bool * flags)
`
within the control board plugin as described in the issue #377.

Fixes #377 

