### PR TITLE
External wrench smoothing feature for externalwrench gazebo yarp plugin

### DIFF
--- a/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
@@ -8,7 +8,6 @@
 #include <gazebo/physics/Link.hh>
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/Model.hh>
-#include <gazebo/physics/physics.hh>
 #include <GazeboYarpPlugins/common.h>
 
 #include <yarp/os/Network.h>

--- a/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
@@ -8,6 +8,7 @@
 #include <gazebo/physics/Link.hh>
 #include <gazebo/physics/World.hh>
 #include <gazebo/physics/Model.hh>
+#include <gazebo/physics/physics.hh>
 #include <GazeboYarpPlugins/common.h>
 
 #include <yarp/os/Network.h>
@@ -28,6 +29,12 @@ public:
     // variable for operation mode
     // single wrench or multiple wrenches
     std::string         m_mode;
+
+    // wrench smoothing flag
+    bool                m_wrenchSmoothing;
+
+    // gazebo simulation update period
+    double              m_simulationUpdatePeriod;
 
     int                 wrenchCount;
 

--- a/plugins/externalwrench/include/gazebo/ExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ExternalWrench.hh
@@ -55,6 +55,7 @@ private:
    // Smoothed wrench vector
    std::vector<yarp::sig::Vector> smoothedWrenchVec;
    bool                          wrenchSmoothingFlag;
+   std::size_t                   steps;
 
    int                           timeStepIndex;
    double                        tick;

--- a/plugins/externalwrench/include/gazebo/ExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ExternalWrench.hh
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "gazebo/gazebo.hh"
 #include <gazebo/physics/PhysicsEngine.hh>
@@ -51,6 +52,11 @@ private:
         double                   duration;
    } wrench;
 
+   // Smoothed wrench vector
+   std::vector<yarp::sig::Vector> smoothedWrenchVec;
+   bool                          wrenchSmoothingFlag;
+
+   int                           timeStepIndex;
    double                        tick;
    double                        tock;
 
@@ -67,22 +73,23 @@ private:
 
 public:
 
-    bool duration_done;
+   bool duration_done;
 
-    ExternalWrench();
-    ~ExternalWrench();
+   ExternalWrench();
+   ~ExternalWrench();
 
-    bool setWrench(physics::ModelPtr&, yarp::os::Bottle&);
-    bool getLink();
+   bool setWrench(physics::ModelPtr&, yarp::os::Bottle&, double&, bool&);
+   bool smoothWrench(const yarp::os::Bottle&, const double&);
+   bool getLink();
 
-    void setWrenchIndex(int& index);
-    void setWrenchColor();
-    void setTick(double& tickTime);
-    void setTock(double& tockTime);
-    void setVisual();
-    void applyWrench();
-    void deleteWrench();
-    void setModel();
+   void setWrenchIndex(int& index);
+   void setWrenchColor();
+   void setTick(double& tickTime);
+   void setTock(double& tockTime);
+   void setVisual();
+   void applyWrench();
+   void deleteWrench();
+   void setModel();
 };
 
 #endif //GAZEBO_YARP_PLUGINS_EXTERNALWRENCH_H

--- a/plugins/externalwrench/include/gazebo/ExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ExternalWrench.hh
@@ -50,10 +50,12 @@ private:
         yarp::sig::Vector        force;
         yarp::sig::Vector        torque;
         double                   duration;
+
+        // Smoothed wrench vector
+        std::vector<yarp::sig::Vector> smoothedWrenchVec;
+
    } wrench;
 
-   // Smoothed wrench vector
-   std::vector<yarp::sig::Vector> smoothedWrenchVec;
    bool                          wrenchSmoothingFlag;
    std::size_t                   steps;
 

--- a/plugins/externalwrench/include/gazebo/ExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ExternalWrench.hh
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <string>
 #include <memory>
-#include <vector>
 
 #include "gazebo/gazebo.hh"
 #include <gazebo/physics/PhysicsEngine.hh>
@@ -43,9 +42,9 @@ class ExternalWrench
 {
 private:
 
-   float      color[4];
-   struct wrenchCommand
-   {
+    float      color[4];
+    struct wrenchCommand
+    {
         std::string              link_name;
         yarp::sig::Vector        force;
         yarp::sig::Vector        torque;
@@ -53,46 +52,45 @@ private:
 
         // Smoothed wrench vector
         std::vector<yarp::sig::Vector> smoothedWrenchVec;
+    } wrench;
 
-   } wrench;
+    bool                          wrenchSmoothingFlag;
+    int                           timeStepIndex;
+    std::size_t                   steps;
 
-   bool                          wrenchSmoothingFlag;
-   std::size_t                   steps;
+    double                        tick;
+    double                        tock;
 
-   int                           timeStepIndex;
-   double                        tick;
-   double                        tock;
+    int                           wrenchIndex;
 
-   int                           wrenchIndex;
+    physics::ModelPtr             model;
+    physics::LinkPtr              link;
 
-   physics::ModelPtr             model;
-   physics::LinkPtr              link;
+    transport::NodePtr            node;
+    transport::PublisherPtr       visPub;
+    msgs::Visual                  visualMsg;
 
-   transport::NodePtr            node;
-   transport::PublisherPtr       visPub;
-   msgs::Visual                  visualMsg;
-
-   event::ConnectionPtr          updateConnection;
+    event::ConnectionPtr          updateConnection;
 
 public:
 
-   bool duration_done;
+    bool duration_done;
 
-   ExternalWrench();
-   ~ExternalWrench();
+    ExternalWrench();
+    ~ExternalWrench();
 
-   bool setWrench(physics::ModelPtr&, yarp::os::Bottle&, double&, bool&);
-   bool smoothWrench(const yarp::os::Bottle&, const double&);
-   bool getLink();
+    bool setWrench(physics::ModelPtr&, yarp::os::Bottle&, double&, bool&);
+    bool smoothWrench(const yarp::os::Bottle&, const double&);
+    bool getLink();
 
-   void setWrenchIndex(int& index);
-   void setWrenchColor();
-   void setTick(double& tickTime);
-   void setTock(double& tockTime);
-   void setVisual();
-   void applyWrench();
-   void deleteWrench();
-   void setModel();
+    void setWrenchIndex(int& index);
+    void setWrenchColor();
+    void setTick(double& tickTime);
+    void setTock(double& tockTime);
+    void setVisual();
+    void applyWrench();
+    void deleteWrench();
+    void setModel();
 };
 
 #endif //GAZEBO_YARP_PLUGINS_EXTERNALWRENCH_H

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -209,12 +209,12 @@ void RPCServerThread::run()
                     wrenchesVector.push_back(newWrench);
                 }
                 else
-                {   this->m_message = this->m_message + " but " + command.get(0).asString() + " link found in the model" ;
+                {   this->m_message = this->m_message + " but " + command.get(0).asString() + " link not found in the model" ;
                     this->m_reply.addString ( m_message );
                     this->m_rpcPort.reply ( m_reply );
                 }
             }
-            else if (command.size() == 1 && command.get(0).isString()) {
+            else if (command.size() == 1 && command.get(0).isString() && (command.get(0).asString() == "single" || command.get(0).asString() == "multiple")) {
 
                 this->m_mode = command.get(0).asString();
 

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -154,9 +154,9 @@ void RPCServerThread::run()
         m_rpcPort.read ( command,true );
         if ( command.get ( 0 ).asString() == "help" ) {
             this->m_reply.addVocab ( yarp::os::Vocab::encode ( "many" ) );
-            this->m_reply.addString ( "The defaul operation mode is with single wrench and without wrench smoothing" );
+            this->m_reply.addString ( "The defaul operation mode is with single wrench without wrench smoothing" );
             this->m_reply.addString ( "Insert [single] or [multiple] to change the operation mode" );
-            this->m_reply.addString ( "Insert [smoothing on] or [smoothing off] to change the wrench smoothing" );
+            this->m_reply.addString ( "Insert [smoothing on] or [smoothing off] to set the wrench smoothing option" );
             this->m_reply.addString ( "Insert a command with the following format:" );
             this->m_reply.addString ( "[link] [force] [torque] [duration]" );
             this->m_reply.addString ( "e.g. chest 10 0 0 0 0 0 1");
@@ -180,6 +180,8 @@ void RPCServerThread::run()
 
                 if (this->m_mode == "single") {
 
+                    this->m_lock.lock();
+
                     // Reset wrench count
                     wrenchCount = 0;
 
@@ -193,6 +195,7 @@ void RPCServerThread::run()
                         wrenchesVector.clear();
                     }
 
+                    this->m_lock.unlock();
                 }
 
                 // Create new instances of external wrenches
@@ -243,6 +246,8 @@ void RPCServerThread::run()
                 // Reset wrench count
                 wrenchCount = 0;
 
+                this->m_lock.lock();
+
                 // Delete the previous wrenches
                 if (wrenchesVector.size() != 0) {
                     this->m_message = this->m_message + ". Clearing previous wrenches.";
@@ -253,6 +258,8 @@ void RPCServerThread::run()
                     }
                     wrenchesVector.clear();
                 }
+
+                this->m_lock.unlock();
 
                 this->m_reply.addString (m_message);
                 this->m_rpcPort.reply ( m_reply );
@@ -272,7 +279,6 @@ void RPCServerThread::run()
 
                 this->m_reply.addString (m_message);
                 this->m_rpcPort.reply ( m_reply );
-
             }
             else {
                 this->m_reply.clear();

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -5,6 +5,7 @@
  */
 
 #include "ApplyExternalWrench.hh"
+#include <gazebo/physics/PhysicsTypes.hh>
 
 namespace gazebo
 {

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -154,8 +154,9 @@ void RPCServerThread::run()
         m_rpcPort.read ( command,true );
         if ( command.get ( 0 ).asString() == "help" ) {
             this->m_reply.addVocab ( yarp::os::Vocab::encode ( "many" ) );
-            this->m_reply.addString ( "The defaul operation mode is with single wrench" );
+            this->m_reply.addString ( "The defaul operation mode is with single wrench and without wrench smoothing" );
             this->m_reply.addString ( "Insert [single] or [multiple] to change the operation mode" );
+            this->m_reply.addString ( "Insert [smoothing on] or [smoothing off] to change the wrench smoothing" );
             this->m_reply.addString ( "Insert a command with the following format:" );
             this->m_reply.addString ( "[link] [force] [torque] [duration]" );
             this->m_reply.addString ( "e.g. chest 10 0 0 0 0 0 1");
@@ -232,12 +233,19 @@ void RPCServerThread::run()
 
                 this->m_message = command.get(0).asString() + " wrench operation mode set";
 
+                if (this->m_wrenchSmoothing == true) {
+                    this->m_message = this->m_message + " with wrench smoothing on";
+                }
+                else {
+                    this->m_message = this->m_message + " with wrench smoothing off";
+                }
+
                 // Reset wrench count
                 wrenchCount = 0;
 
                 // Delete the previous wrenches
                 if (wrenchesVector.size() != 0) {
-                    this->m_message = this->m_message + " . Clearing previous wrenches.";
+                    this->m_message = this->m_message + ". Clearing previous wrenches.";
                     for (int i = 0; i < wrenchesVector.size(); i++)
                     {
                         ExternalWrench wrench = wrenchesVector.at(i);

--- a/plugins/externalwrench/src/ExternalWrench.cc
+++ b/plugins/externalwrench/src/ExternalWrench.cc
@@ -165,17 +165,9 @@ bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& sim
     wrench.smoothedWrenchVec.clear();
 
     double duration = cmd.get(7).asDouble();
-    if ((duration <= 0) && (duration <= simulationUpdatePeriod)) {
-        yError() << "Failed to smooth wrench as given duration is very small";
-        return false;
-    }
-
-    yInfo() << "Inside wrench smoothing";
 
     // Compute time steps
     steps = duration/simulationUpdatePeriod;
-
-    yInfo() << "Total time steps : " << steps;
 
     // Get original wrench
     yarp::sig::Vector originalWrench;
@@ -187,10 +179,6 @@ bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& sim
     originalWrench[3]  =  cmd.get(4).asDouble();
     originalWrench[4]  =  cmd.get(5).asDouble();
     originalWrench[5]  =  cmd.get(6).asDouble();
-
-    yInfo() << "Original wrench : " << originalWrench.toString().c_str();
-
-    yInfo() << "Computing smoothing coefficients";
 
     double time = 0;
     std::vector<double> smoothingCoefficients;
@@ -204,15 +192,11 @@ bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& sim
         time = time + simulationUpdatePeriod;
     }
 
-    yInfo() << "Computed smoothing coefficients";
-
     // Normalize smoothing coefficients
     double smoothingCoefficientMax = *std::max_element(smoothingCoefficients.begin(), smoothingCoefficients.end());
     for (int timeStep = 0; timeStep <= steps; timeStep++) {
         smoothingCoefficients.at(timeStep) =  smoothingCoefficients.at(timeStep) / smoothingCoefficientMax;
     }
-
-    yInfo() << "Normalized smoothing coefficients";
 
     yarp::sig::Vector smoothedWrench;
     smoothedWrench.resize(6,0);
@@ -222,13 +206,8 @@ bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& sim
         smoothedWrench = originalWrench * smoothingCoefficients.at(timeStep);
 
         wrench.smoothedWrenchVec.push_back(smoothedWrench);
-        yInfo() << smoothedWrench[0] << " " << smoothedWrench[1] << " " << smoothedWrench[2] << " " \
-                << smoothedWrench[3] << " " << smoothedWrench[4] << " " << smoothedWrench[5] << " ";
-
         smoothedWrench.clear();
     }
-
-    yInfo() << "Size of smoothed wrenches vector : " << wrench.smoothedWrenchVec.size();
 
     return true;
 }

--- a/plugins/externalwrench/src/ExternalWrench.cc
+++ b/plugins/externalwrench/src/ExternalWrench.cc
@@ -146,7 +146,7 @@ bool ExternalWrench::setWrench(physics::ModelPtr& _model,yarp::os::Bottle& cmd, 
 bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& simulationUpdatePeriod)
 {
     // Clear smoothed wrenches vector
-    smoothedWrenchVec.clear();
+    wrench.smoothedWrenchVec.clear();
 
     double duration = cmd.get(7).asDouble();
     if ((duration <= 0) && (duration <= simulationUpdatePeriod)) {
@@ -205,13 +205,13 @@ bool ExternalWrench::smoothWrench(const yarp::os::Bottle& cmd, const double& sim
 
         smoothedWrench = originalWrench * smoothingCoefficients.at(timeStep);
 
-        smoothedWrenchVec.push_back(smoothedWrench);
+        wrench.smoothedWrenchVec.push_back(smoothedWrench);
         //yInfo() << smoothedWrench.toString().c_str();
 
         smoothedWrench.clear();
     }
 
-    yInfo() << "Size of smoothed wrenches vector : " << smoothedWrenchVec.size();
+    yInfo() << "Size of smoothed wrenches vector : " << wrench.smoothedWrenchVec.size();
 
     return true;
 }
@@ -224,9 +224,9 @@ void ExternalWrench::applyWrench()
         ignition::math::Vector3d force;
         ignition::math::Vector3d torque;
 
-        if (wrenchSmoothingFlag)
-        {
-            yarp::sig::Vector smoothedWrench = smoothedWrenchVec.at(timeStepIndex);
+        if (wrenchSmoothingFlag) {
+
+            yarp::sig::Vector smoothedWrench = wrench.smoothedWrenchVec.at(timeStepIndex);
 
             wrench.force[0] = smoothedWrench[0];
             wrench.force[1] = smoothedWrench[1];
@@ -301,6 +301,10 @@ void ExternalWrench::deleteWrench()
     this->wrench.force.clear();
     this->wrench.torque.clear();
     this->wrench.duration = 0;
+
+    if (wrenchSmoothingFlag) {
+        this->wrench.smoothedWrenchVec.clear();
+    }
 
     this->visualMsg.set_visible(0);
     this->visualMsg.clear_geometry();


### PR DESCRIPTION
Currently, the external wrench plugin lets a user to apply any external wrench on a robot model but this wrench is applied as an impulse input. For example if the user input command is `l_hand 10 0 0 0 0 0 10`, this lets user to apply a wrench of `10 N` along the +ve x-direction for a duration of `10 seconds`. This behavior of the external wrench plugin is reasonable in the case of use external wrenches as disturbances for testing controllers like yoga in gazebo simulation. However, to test controllers in case of physical Human-Robot Interaction (pHRI) scenarios, such an impulse input of the external wrenches is not desirable Instead, one good alternative is to smooth the input wrench over the given duration such that the wrench has a smooth profile. In this issue we will track the details related to the feature of smoothing the external wrenches of the external wrench gazebo yarp plugin. 

@traversaro 