### PR TITLE
Disable externalwrench plugin if Gazebo version < 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Fix invalid camera parameters in `gazebo_depthCamera` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/408).
+
+## [Unreleased]
+### Fixed 
+- Fixed compilation on Gazebo 7 by disabling compilation of `externalwrench` plugin if the project is configured with Gazebo 7 (https://github.com/robotology/gazebo-yarp-plugins/pull/434) .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+### Fixed 
+- Fixed compilation on Gazebo 7 by disabling compilation of `externalwrench` plugin if the project is configured with Gazebo 7 (https://github.com/robotology/gazebo-yarp-plugins/pull/434).
+
 ## [3.2.0] - 2019-07-01
 ### Added
 - Add `resetSimulation` method to reset simulation state and time time, in the `gazebo_yarp_clock` RPC interface (https://github.com/robotology/gazebo-yarp-plugins/pull/345).
@@ -15,7 +19,3 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Fix invalid camera parameters in `gazebo_depthCamera` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/408).
-
-## [Unreleased]
-### Fixed 
-- Fixed compilation on Gazebo 7 by disabling compilation of `externalwrench` plugin if the project is configured with Gazebo 7 (https://github.com/robotology/gazebo-yarp-plugins/pull/434) .

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,7 +1,12 @@
 add_subdirectory(camera)
 add_subdirectory(clock)
 add_subdirectory(controlboard)
-add_subdirectory(externalwrench)
+
+# Disable externalwrench plugin if Gazebo version is < 8.0
+if (NOT GAZEBO_VERSION VERSION_LESS 8.0)
+    add_subdirectory(externalwrench)
+endif()
+
 add_subdirectory(fakecontrolboard)
 add_subdirectory(forcetorque)
 add_subdirectory(imu)


### PR DESCRIPTION
This fix allow to compile the repo with Gazebo 7. Tested on Ubuntu 16.04 LTS.