### PR TITLE
Travis: Disable clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
 
 compiler:
    - gcc
-   - clang
 
 before_install:
   - if [ ! $TRAVIS_BRANCH = "master" ] ; then DEPS_BRANCH_DOCKER="devel" ; fi


### PR DESCRIPTION
Travis ships a bugged Clang compiler, see https://github.com/robotology/yarp/issues/2086 . 
This PR disables it, as eventually we should migrate to GitHub Actions for CI in this repo.