### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: C++ CI Workflow
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+  
+  
+jobs:
+  build:
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@yarp:${{ matrix.yarp_version }}@gazebo:{{ matrix.gazebo_version }}]'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        gazebo_version: [gazebo9, gazebo10]
+        yarp_version [devel]
+
+    steps:
+    - uses: actions/checkout@master
+        
+    # Print environment variables to simplify development and debugging
+    - name: Environment Variables
+      shell: bash
+      run: env
+        
+    # ============
+    # DEPENDENCIES
+    # ============
+            
+    - name: Dependencies [macOS]
+      if: matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        brew cask install xquartz
+        brew install osrf/simulation/${{ matrix.gazebo_version }}
+    
+    - name: Dependencies [Ubuntu]
+      if: matrix.os == 'ubuntu-latest'
+      shell: bash
+      run: |
+        sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
+        wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get install git build-essential cmake 
+        sudo apt-get install lib${{ matrix.gazebo_version }}-dev
+        
+    - name: Source-based Dependencies [Ubuntu/macOS] 
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        # YCM
+        git clone https://github.com/robotology/ycm
+        cd ycm
+        git checkout devel
+        mkdir -p build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake --build . --config ${{ matrix.build_type }} --target install 
+        # YARP
+        git clone https://github.com/robotology/yarp
+        cd yarp
+        git checkout ${{ matrix.yarp_version }}
+        mkdir -p build
+        cd build
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        cmake --build . --config ${{ matrix.build_type }} --target install 
+ 
+    # ===================
+    # CMAKE-BASED PROJECT
+    # ===================
+   
+    - name: Configure [Ubuntu/macOS]
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        mkdir -p build
+        cd build    
+        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
+        
+    - name: Build
+      shell: bash
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }} 
+        
+    - name: Install [Ubuntu/macOS]
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }} --target install
+        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       shell: bash
       run: |
         brew cask install xquartz
-        brew install osrf/simulation/${{ matrix.gazebo_version }}
+        brew install ace eigen3 opencv@3 osrf/simulation/${{ matrix.gazebo_version }}
     
     - name: Dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'
@@ -46,7 +46,7 @@ jobs:
         sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
         wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
         sudo apt-get update
-        sudo apt-get install git build-essential cmake 
+        sudo apt-get install git build-essential cmake libace-dev libeigen3-dev libopencv-dev 
         sudo apt-get install lib${{ matrix.gazebo_version }}-dev
         
     - name: Source-based Dependencies [Ubuntu/macOS] 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # YARP
+        cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp
         cd yarp
         git checkout ${{ matrix.yarp_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   
 jobs:
   build:
-    name: '[${{ matrix.os }}@${{ matrix.build_type }}@yarp:${{ matrix.yarp_version }}@gazebo:{{ matrix.gazebo_version }}]'
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@yarp:${{ matrix.yarp_version }}@gazebo:${{ matrix.gazebo_version }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       shell: bash
       run: |
         brew cask install xquartz
-        brew install ace eigen3 opencv@3 osrf/simulation/${{ matrix.gazebo_version }}
+        brew install ace eigen opencv@3 osrf/simulation/${{ matrix.gazebo_version }}
     
     - name: Dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
         gazebo_version: [gazebo9, gazebo10]
         yarp_version: [devel]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         build_type: [Release, Debug]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         gazebo_version: [gazebo9, gazebo10]
-        yarp_version [devel]
+        yarp_version: [devel]
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
This PR adds a GitHub Actions-based Continuous Integration that can test both in Linux (Ubuntu 18.04) and macOS against configurable multiple version of Gazebo (currently 9 and 10) and YARP currently just the upcoming YARP 3.3 .

Travis failure is unrelated (it is actually related to https://github.com/robotology/gazebo-yarp-plugins/issues/442), and Travis will be removed when this PR gets merged.

Fixes  https://github.com/robotology/gazebo-yarp-plugins/issues/444 .
Fixes https://github.com/robotology/gazebo-yarp-plugins/issues/449 .