### PR TITLE
Add gazebo_yarp_contactforcetorques

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(camera)
 add_subdirectory(clock)
+add_subdirectory(contactforcetorques)
 add_subdirectory(controlboard)
 
 # Disable externalwrench plugin if Gazebo version is < 8.0

--- a/plugins/contactforcetorques/CMakeLists.txt
+++ b/plugins/contactforcetorques/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+# Authors: see AUTHORS file.
+# CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
+
+include(AddGazeboYarpPluginTarget)
+
+add_gazebo_yarp_plugin_target(LIBRARY_NAME contactforcetorques
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                              INCLUDE_DIRS include/gazebo 
+                                           include/yarp/dev
+                              SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
+                              LINKED_LIBRARIES gazebo_yarp_lib_common gazebo_yarp_singleton ${YARP_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES} ${SDFORMAT_LIBRARIES}
+                              HEADERS include/gazebo/ContactForceTorques.hh
+                              SOURCES src/ContactForceTorques.cc)
+
+                                      

--- a/plugins/contactforcetorques/include/gazebo/ContactForceTorques.hh
+++ b/plugins/contactforcetorques/include/gazebo/ContactForceTorques.hh
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBO_YARP_CONTACTFORCETORQUES_HH
+#define GAZEBO_YARP_CONTACTFORCETORQUES_HH
+
+#include <string>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/UpdateInfo.hh>
+#include <gazebo/physics/Link.hh>
+
+#include <GazeboYarpPlugins/Handler.hh>
+#include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
+
+#include <yarp/sig/Vector.h>
+
+namespace gazebo
+{
+    /**
+     * \class GazeboYarpContactForceTorques
+     * Gazebo plugin simulating the estimation of contact force torques
+     *.
+     * This plugin does not simulate any physical sensor, but it simulates
+     * the output of the estimators of external contact force torques,
+     * similarly to how the gazebo_yarp_basestate plugin simulates the output
+     * of floating base position estimators.
+     *
+     * On real robot, the contact forcetorques are estimated by a dedicated
+     * software based on the available sensor measurements (such as motor currents,
+     * six axis force-torque sensors measures and distribute tactile sensor measurements)
+     * and/or a-priori assumptions on the location of the contact (for example on
+     * industrial manipulators the external contact is usually assume to be only possible
+     * on the end-effector). For example, on the iCub robot the wholebodydynamics software
+     * is responsible for such an estimation.
+     * In a simulation, it is possible to obtain directly this information
+     * for the simulator state and inputs, if it is necessary to have a perfect estimate.
+     *
+     * Differntly for other kind of functionalities such as sensor or  motor interfaces,
+     * at the moment YARP does not provide any kind of standard interface of message to represent
+     * contact force torques (see https://github.com/robotology/yarp/issues/2134 for more details),
+     * so at the moment the plugin only permits to stream the total contact force torque being applied
+     * on a given link on  a single YARP port that streams a yarp::sig::Vector, similarly to how the
+     * wholebodydynamics software streams contact information. The first three elements represent the force
+     * expressed in N, while the last three elements the torque expressed in Nm. The forcetorque estimated is the
+     * one applied on the link.
+     *
+     * This plugin can be used by adding the following element as a child of your sdf model tag:
+     *  ```
+     *      <plugin name="contactforcetorques_instance" filename="libgazebo_yarp_contactforcetorque.so">
+     *          <yarpConfigurationFile>model://path-to-the-configuration-file</yarpConfigurationFile>
+     *      </plugin>
+     *  ```
+     *
+     * The plugin .ini configuration file must contain a parameter called periodInSeconds, and a group called [OUTPUT_EXTERNAL_FORCETORQUES_PORTS],
+     * and may contain a group called [OUTPUT_EXTERNAL_FORCETORQUES_FRAMES] .
+     *
+     * The periodInSeconds parameter is required, and represent the publishing period in seconds.
+     *
+     * The OUTPUT_EXTERNAL_FORCETORQUES_PORTS specifies the port that should be opened by the plugin, with the following format:
+     *
+     * | Parameter name| Type |Units|Default Value|Required |                 Description                |              Notes             |
+     * |:-------------:|:----:|:---:|:-----------:|:-------:|:------------------------------------------:|:------------------------------:|
+     * |   portName_1   |  The name of the parameter specifies the port name, while the value is  Bottle of three elements describing the force torque published on the port. | - | - | No    | Bottle of three elements describing the wrench published on the port: the first element is the link of which the published external forcetorque is applied. This forcetorque is expressed around the origin of the frame named as second parameter, and with the orientation of the third parameter.  |  |
+     * | ...  | ... | - | ..                                        | No       | ..  |  |
+     * | portName_n  | ... | - | ..                                        | No       | ..  |  |
+     *
+     *
+     * The OUTPUT_EXTERNAL_FORCETORQUES_PORTS
+     * group has a similar format to the WBD_OUTPUT_EXTERNAL_WRENCH_PORTS of wholebodydynamics (document in
+     *  https://github.com/robotology/codyco-modules/blob/master/src/devices/wholeBodyDynamics/WholeBodyDynamicsDevice.h#L139 ).
+     *
+     * While the first parameter of the bottle of each line of OUTPUT_EXTERNAL_FORCETORQUES_PORTS identifies a link,
+     * the second and the third can also just refer to a additional frame of a link. Unfortunatly, additional frames are removed
+     * in the conversion of URDF to SDF, and in general are not contained in SDF version <= 1.6 . For this reason, you can
+     * specify additional frames directly in the configuration file of this plugin using the `OUTPUT_EXTERNAL_FORCETORQUES_FRAMES` group, with the following format:
+     *
+     * | Parameter name| Type |Units|Default Value|Required |                 Description                |              Notes             |
+     * |:-------------:|:----:|:---:|:-----------:|:-------:|:------------------------------------------:|:------------------------------:|
+     * |   additionalFrameName_1   |  The name of the parameter specifies the additional frame name, while the value is  Bottle of seven elements describing the . | - | - | No    | Bottle of seven elements elements describing the additional frame: the first element is the link to which the additional frame is attached, the rest of the elements specify the link_H_additionalFrame transfrom in the SDF convention. |  |
+     * | ...  | ... | - | ..                                        | No       | ..  |  |
+     * | additionalFrameName_n  | ... | - | ..                                        | No       | ..  |  |
+     *
+     * An example configuration file might look like:
+     *
+     * ```
+     * periodInSeconds 0.01
+     *
+     * [OUTPUT_EXTERNAL_FORCETORQUES_PORTS]
+     * /wholeBodyDynamics/left_foot/cartesianEndEffectorWrench:o (l_foot,l_sole,l_sole)
+     * /wholeBodyDynamics/right_foot/cartesianEndEffectorWrench:o (r_foot,r_sole,r_sole)
+     *
+     * [OUTPUT_EXTERNAL_FORCETORQUES_FRAMES]
+     * l_sole (l_foot,0.0035,0.0,0.004,-3.14159265359,0.0,0.0)
+     * r_sole (r_foot,0.0035,0.0,0.004,-3.14159265359,0.0,0.0)
+     *
+     * ```
+     */
+    class GazeboYarpContactForceTorques : public ModelPlugin
+    {
+    public:
+        GazeboYarpContactForceTorques();
+        virtual ~GazeboYarpContactForceTorques();
+        
+        /**
+         * Loads robot model, reads configuration, 
+         * opens network wrapper device and opens device driver
+         */
+        void Load(physics::ModelPtr model, sdf::ElementPtr _sdf);
+
+        /**
+         * Callback for the WorldUpdateBegin Gazebo event.
+         */
+        void onUpdate(const gazebo::common::UpdateInfo&);
+
+        /**
+         *
+         */
+        void onReset();
+    private:
+        struct Pimpl;
+        struct AdditionalFrameInformation;
+        struct OutputWrenchPortInformation;
+        struct ForceTorque;
+
+        /**
+         * Load and validate parameters.
+         */
+        bool LoadParams(physics::ModelPtr model);
+
+        /**
+         * Load and validate parameters related to additional frames.
+         */
+        bool LoadAdditionalFrameParams(physics::ModelPtr model);
+
+        /**
+         * Load and validate parameters related to streaming ports.
+         */
+        bool LoadStreamingPortParams(physics::ModelPtr model);
+
+        /**
+         * Open YARP ports.
+         */
+        bool openPorts();
+
+        /**
+         * Close yarp ports.
+         */
+        bool closePorts();
+
+        /**
+         * Change the forcetorque expressed in a frame to be expressed (both origin and orientation) in another frame.
+         */
+        GazeboYarpContactForceTorques::ForceTorque applyTransformToForceTorque(ignition::math::Pose3d& newFrame_H_oldFrame,
+                                                                                GazeboYarpContactForceTorques::ForceTorque&  ft_oldFrame);
+
+        /**
+         * Convert a GazeboYarpContactForceTorques::ForceTorque to a YARP vector.
+         */
+        void toYARP(GazeboYarpContactForceTorques::ForceTorque& ft_gazebo,
+                    yarp::sig::Vector& ft_yarp);
+
+        /**
+         * Get total force that the enviroment applies on a link, expressed in the link frame (both origin and orientation)
+         */
+        GazeboYarpContactForceTorques::ForceTorque getTotalForceTorqueAppliedOnLink(gazebo::physics::LinkPtr link);
+
+        std::unique_ptr<Pimpl> m_pimpl;
+    };
+}
+
+#endif
+

--- a/plugins/contactforcetorques/src/ContactForceTorques.cc
+++ b/plugins/contactforcetorques/src/ContactForceTorques.cc
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2019 Fondazione Istituto Italiano di Tecnologia
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#include <vector>
+
+#include "ContactForceTorques.hh"
+
+#include <yarp/os/Log.h>
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Bottle.h>
+#include <yarp/os/BufferedPort.h>
+#include <yarp/os/Network.h>
+#include <yarp/sig/Vector.h>
+
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/Collision.hh>
+#include <gazebo/physics/ContactManager.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/PhysicsEngine.hh>
+#include <gazebo/physics/World.hh>
+
+#include <ignition/math/Pose3.hh>
+
+GZ_REGISTER_MODEL_PLUGIN(gazebo::GazeboYarpContactForceTorques)
+
+namespace gazebo
+{
+struct GazeboYarpContactForceTorques::ForceTorque
+{
+    ignition::math::Vector3d force;
+    ignition::math::Vector3d torque;
+};
+
+
+struct GazeboYarpContactForceTorques::AdditionalFrameInformation
+{
+    std::string additionalFrame_name;
+    std::string link_name;
+    gazebo::physics::LinkPtr link;
+    ignition::math::Pose3d link_H_frame;
+};
+
+struct GazeboYarpContactForceTorques::OutputWrenchPortInformation
+{
+    std::string port_name{""};
+    std::string link_name{""};
+    gazebo::physics::LinkPtr link;
+    std::string orientation_frame{""};
+    std::string origin_frame{""};
+    int link_index{0};
+    int orientation_frame_index{0};
+    int origin_frame_index{0};
+    yarp::sig::Vector output_vector;
+    ignition::math::Pose3d publishingFrame_H_linkFrame;
+    yarp::os::BufferedPort<yarp::sig::Vector>* output_port;
+
+    OutputWrenchPortInformation(): output_port(new yarp::os::BufferedPort<yarp::sig::Vector>())
+    {
+    }
+
+    ~OutputWrenchPortInformation()
+    {
+        if (output_port) {
+            delete output_port;
+        }
+        output_port = nullptr;
+    }
+};
+
+struct GazeboYarpContactForceTorques::Pimpl
+{
+    double publishingPeriodInSeconds {-1.0};
+    double latestUpdateInstantInSeconds {-1.0};
+    gazebo::physics::ContactManager* contactManager {nullptr};
+    std::string robot{""};
+    yarp::os::Property config;
+    gazebo::event::ConnectionPtr updateConnection;
+    gazebo::event::ConnectionPtr resetConnection;
+    std::vector<  GazeboYarpContactForceTorques::AdditionalFrameInformation > additionalFrameInfos;
+    std::vector<  GazeboYarpContactForceTorques::OutputWrenchPortInformation > outputFTPorts;
+};
+
+GazeboYarpContactForceTorques::GazeboYarpContactForceTorques() : ModelPlugin(), m_pimpl(new GazeboYarpContactForceTorques::Pimpl())
+{
+
+}
+
+GazeboYarpContactForceTorques::~GazeboYarpContactForceTorques()
+{
+    GazeboYarpPlugins::Handler::getHandler()->removeRobot(m_pimpl->robot);
+    closePorts();
+    yarp::os::Network::fini();
+}
+
+void GazeboYarpContactForceTorques::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
+{
+    // Get  contact manager
+    m_pimpl->contactManager = _parent->GetWorld()->Physics()->GetContactManager();
+
+
+    yarp::os::Network::init();
+    if (!yarp::os::Network::checkNetwork(GazeboYarpPlugins::yarpNetworkInitializationTimeout))
+    {
+        yError() << "GazeboYarpContactForceTorques::Load erros: yarp network does not seem to be available, is the yarp server running?";
+        return;
+    }
+
+    if (!_parent)
+    {
+        yError() << "GazeboYarpContactForceTorques plugin requires a parent \n";
+        return;
+    }
+
+    GazeboYarpPlugins::Handler::getHandler()->setRobot(boost::get_pointer(_parent));
+    m_pimpl->robot = _parent->GetScopedName();
+
+    // Getting .ini configuration file parameters from sdf
+    bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_parent, _sdf, m_pimpl->config);
+
+    if (!configuration_loaded) {
+        yError() << "GazeboYarpContactForceTorques : File .ini not found, load failed." ;
+        return;
+    }
+
+    // Try to parse and load parameters
+    bool okLoadParams = this->LoadParams(_parent);
+
+    if (!okLoadParams) {
+        yError() << "GazeboYarpContactForceTorques : File .ini malformed, load of the plugin  failed." ;
+        return;
+    }
+
+    // Try to open the YARP ports
+    if (!this->openPorts()) {
+        return;
+    }
+
+    // Create callback
+    m_pimpl->updateConnection =
+        gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpContactForceTorques::onUpdate,
+                this, _1));
+
+    m_pimpl->resetConnection =
+        gazebo::event::Events::ConnectWorldReset(boost::bind(&GazeboYarpContactForceTorques::onReset, this));
+
+}
+
+bool GazeboYarpContactForceTorques::LoadAdditionalFrameParams(physics::ModelPtr model)
+{
+    yarp::os::Bottle portsProp = m_pimpl->config.findGroup("OUTPUT_EXTERNAL_FORCETORQUES_FRAMES");
+
+    // The group is optional
+    if (portsProp.isNull())
+    {
+        return true;
+    }
+
+    for(size_t i = 1; i < portsProp.size(); i++)
+    {
+        GazeboYarpContactForceTorques::AdditionalFrameInformation additionalFrameStruct;
+        yarp::os::Bottle *additional_frame = portsProp.get(i).asList();
+        if( additional_frame == NULL || additional_frame->isNull() || additional_frame->size() != 2
+                || additional_frame->get(1).asList() == NULL
+                || !(additional_frame->get(1).asList()->size() == 7) )
+        {
+            yError() << "GazeboYarpContactForceTorques plugin failed: malformed OUTPUT_EXTERNAL_FORCETORQUES_FRAMES group found in configuration, exiting";
+            if (additional_frame)
+            {
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed line " << additional_frame->toString();
+            }
+            else
+            {
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed line " << portsProp.get(i).toString();
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed group " << portsProp.toString();
+            }
+            return false;
+        }
+
+        additionalFrameStruct.additionalFrame_name = additional_frame->get(0).asString();
+        additionalFrameStruct.link_name = additional_frame->get(1).asList()->get(0).asString();
+
+        // Get the exact link with only link name instead of full_scoped_link_name
+        physics::Link_V links = model->GetLinks();
+        size_t lnk=0;
+        for(lnk=0; lnk < links.size(); lnk++)
+        {
+            std::string candidate_link_name = links[lnk]->GetScopedName();
+
+            // hasEnding compare ending of the condidate model link name to the given link name, in order to be able to use unscoped names
+            if (GazeboYarpPlugins::hasEnding(candidate_link_name, additionalFrameStruct.link_name))
+            {
+                additionalFrameStruct.link = links[lnk];
+                break;
+            }
+        }
+
+        // If no link was found
+        if (lnk == links.size()) {
+            yError() << "GazeboYarpContactForceTorques plugin failed: link with name "
+                     <<  additionalFrameStruct.link_name << " not found in the model";
+            return false;
+        }
+
+        double x = additional_frame->get(1).asList()->get(1).asFloat64();
+        double y = additional_frame->get(1).asList()->get(2).asFloat64();
+        double z = additional_frame->get(1).asList()->get(3).asFloat64();
+        double roll = additional_frame->get(1).asList()->get(4).asFloat64();
+        double pitch = additional_frame->get(1).asList()->get(5).asFloat64();
+        double yaw = additional_frame->get(1).asList()->get(6).asFloat64();
+
+        additionalFrameStruct.link_H_frame =
+            ignition::math::Pose3d(x, y, z, roll, pitch, yaw);
+
+        m_pimpl->additionalFrameInfos.push_back(additionalFrameStruct);
+    }
+
+
+    return true;
+}
+
+bool GazeboYarpContactForceTorques::LoadStreamingPortParams(physics::ModelPtr model)
+{
+    yarp::os::Bottle portsProp = m_pimpl->config.findGroup("OUTPUT_EXTERNAL_FORCETORQUES_PORTS");
+    if (portsProp.isNull())
+    {
+        yError() << "GazeboYarpContactForceTorques plugin failed: [OUTPUT_EXTERNAL_FORCETORQUES_PORTS] group not found in config file";
+        return false;
+    }
+
+    // Load values
+    m_pimpl->outputFTPorts.clear();
+    m_pimpl->outputFTPorts.resize(portsProp.size()-1);
+    for(size_t output_wrench_port = 1; output_wrench_port < portsProp.size(); output_wrench_port++)
+    {
+        GazeboYarpContactForceTorques::OutputWrenchPortInformation& wrench_port_struct = m_pimpl->outputFTPorts[output_wrench_port-1];
+        yarp::os::Bottle *wrench_port = portsProp.get(output_wrench_port).asList();
+        if( wrench_port == NULL || wrench_port->isNull() || wrench_port->size() != 2
+                || wrench_port->get(1).asList() == NULL
+                || !(wrench_port->get(1).asList()->size() == 2 || wrench_port->get(1).asList()->size() == 3 ) )
+        {
+            yError() << "GazeboYarpContactForceTorques plugin failed: malformed OUTPUT_EXTERNAL_FORCETORQUES_PORTS group found in configuration, exiting";
+            if( wrench_port )
+            {
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed line " << wrench_port->toString();
+            }
+            else
+            {
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed line " << portsProp.get(output_wrench_port).toString();
+                yError() << "GazeboYarpContactForceTorques plugin failed: malformed group " << portsProp.toString();
+            }
+            return false;
+        }
+
+        wrench_port_struct.port_name = wrench_port->get(0).asString();
+        wrench_port_struct.link_name = wrench_port->get(1).asList()->get(0).asString();
+
+        // Get the exact link with only link name instead of full_scoped_link_name
+        physics::Link_V links = model->GetLinks();
+        size_t lnk=0;
+        for(lnk=0; lnk < links.size(); lnk++)
+        {
+            std::string candidate_link_name = links[lnk]->GetScopedName();
+
+            // hasEnding compare ending of the condidate model link name to the given link name, in order to be able to use unscoped names
+            if (GazeboYarpPlugins::hasEnding(candidate_link_name, wrench_port_struct.link_name))
+            {
+                wrench_port_struct.link = links[lnk];
+                break;
+            }
+        }
+
+        // If no link was found
+        if (lnk == links.size()) {
+            yError() << "GazeboYarpContactForceTorques plugin failed: link with name "
+                     << wrench_port_struct.link_name << " not found in the model";
+            return false;
+        }
+
+        if( wrench_port->get(1).asList()->size() == 2 )
+        {
+            // Simple configuration, both the origin and the orientation of the
+            // force belong to the same frame
+            wrench_port_struct.orientation_frame = wrench_port->get(1).asList()->get(1).asString();
+            wrench_port_struct.origin_frame = wrench_port_struct.orientation_frame;
+        }
+        else
+        {
+            assert(wrench_port->get(1).asList()->size() != 3);
+            // Complex configuration: the first parameter is the frame of the point of expression,
+            // the second parameter is the frame of orientation
+            wrench_port_struct.origin_frame = wrench_port->get(1).asList()->get(1).asString();
+            wrench_port_struct.orientation_frame = wrench_port->get(1).asList()->get(2).asString();
+        }
+
+        // TODO(traversaro): eventually, support the complete case, for now the following two restriction will hold:
+        // * origin_frame and orientation_frame need to match
+        // * origin_frame and  orientation_frame can be either the link frame, or an additional frame rigidly attached to the link of interest
+        if (wrench_port_struct.origin_frame != wrench_port_struct.orientation_frame) {
+            yError() << "GazeboYarpContactForceTorques plugin failed: link with name "
+                     << wrench_port_struct.link_name << " requested with different orientation frame and  origin frame, currently not supported.";
+            return false;
+        }
+
+        // If wrench_port_struct.origin_frame == wrench_port_struct.orientation_frame == wrench_port_struct.link_name, then
+        // the publishingFrame_H_linkFrame transform is just the identity
+        wrench_port_struct.publishingFrame_H_linkFrame = ignition::math::Pose3d(0, 0, 0, 0, 0, 0);
+        if (wrench_port_struct.origin_frame != wrench_port_struct.link_name) {
+            bool additionalFrameFound=false;
+            for(auto&& additionalFrame: m_pimpl->additionalFrameInfos) {
+                if (additionalFrame.additionalFrame_name == wrench_port_struct.origin_frame) {
+                    if (additionalFrame.link_name != wrench_port_struct.link_name) {
+                        yError() << "GazeboYarpContactForceTorques plugin failed: link with name "
+                                 << wrench_port_struct.link_name << " requested with an additional frame that rigidly attached to another link, currently not supported.";
+                        return false;
+                    }
+                    additionalFrameFound = true;
+                    wrench_port_struct.publishingFrame_H_linkFrame = additionalFrame.link_H_frame.Inverse();
+                }
+            }
+            if (!additionalFrameFound) {
+                yError() << "GazeboYarpContactForceTorques plugin failed: link with name "
+                                 << wrench_port_struct.link_name << " requested an additional frame that is not specified.";
+                return false;
+            }
+
+        }
+    }
+
+    return true;
+}
+
+bool GazeboYarpContactForceTorques::LoadParams(physics::ModelPtr model)
+{
+    // First load periodInSeconds
+    if (!m_pimpl->config.check("periodInSeconds")) {
+        yError() << "GazeboYarpContactForceTorques plugin failed: required parameter periodInSeconds not found in config file";
+        return false;
+    }
+
+    m_pimpl->publishingPeriodInSeconds = m_pimpl->config.find("periodInSeconds").asFloat64();
+
+    if (m_pimpl->publishingPeriodInSeconds <= 0.0) {
+        yError() << "GazeboYarpContactForceTorques plugin failed: required parameter periodInSeconds has unsupported negative or null value.";
+        return false;
+    }
+
+    // Then load additonal frames data
+    if (!this->LoadAdditionalFrameParams(model)) {
+        return false;
+    }
+
+    // Then load streaming ports data
+    if (!this->LoadStreamingPortParams(model)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool GazeboYarpContactForceTorques::openPorts()
+{
+    for(unsigned int i = 0; i < m_pimpl->outputFTPorts.size(); i++ )
+    {
+        size_t nrOfChannelsOfYARPFTSensor = 6;
+        if (!m_pimpl->outputFTPorts[i].output_port->open(m_pimpl->outputFTPorts[i].port_name)) {
+            yError() << "GazeboYarpContactForceTorques plugin failed: impossible to open port "
+                     << m_pimpl->outputFTPorts[i].port_name;
+            return false;
+        }
+        m_pimpl->outputFTPorts[i].output_vector.resize(nrOfChannelsOfYARPFTSensor);
+    }
+    return true;
+}
+
+bool GazeboYarpContactForceTorques::closePorts()
+{
+    for(unsigned int i = 0; i < m_pimpl->outputFTPorts.size(); i++ )
+    {
+        m_pimpl->outputFTPorts[i].output_port->close();
+    }
+    return true;
+}
+
+/**
+ * Return ft_newFrame
+ */
+GazeboYarpContactForceTorques::ForceTorque
+GazeboYarpContactForceTorques::applyTransformToForceTorque(ignition::math::Pose3d& newFrame_H_oldFrame,
+                                                           GazeboYarpContactForceTorques::ForceTorque&  ft_oldFrame)
+{
+    // Implement the same formula of https://robotology.github.io/idyntree/master/classiDynTree_1_1Transform.html#af120c9b238d9efdf947109b47c4e4fdf
+    GazeboYarpContactForceTorques::ForceTorque ft_newFrame;
+    ignition::math::Quaterniond newFrame_R_oldFrame = newFrame_H_oldFrame.Rot();
+
+    ft_newFrame.force = newFrame_R_oldFrame*ft_oldFrame.force;
+    ft_newFrame.torque = newFrame_H_oldFrame.Pos().Cross(ft_newFrame.force) + newFrame_R_oldFrame*ft_oldFrame.torque;
+
+    return ft_newFrame;
+}
+
+
+void GazeboYarpContactForceTorques::toYARP(GazeboYarpContactForceTorques::ForceTorque& ft_gazebo,
+                                           yarp::sig::Vector& ft_yarp)
+{
+    ft_yarp.resize(6);
+    ft_yarp[0] = ft_gazebo.force.X();
+    ft_yarp[1] = ft_gazebo.force.Y();
+    ft_yarp[2] = ft_gazebo.force.Z();
+    ft_yarp[3] = ft_gazebo.torque.X();
+    ft_yarp[4] = ft_gazebo.torque.Y();
+    ft_yarp[5] = ft_gazebo.torque.Z();
+    return;
+}
+
+GazeboYarpContactForceTorques::ForceTorque GazeboYarpContactForceTorques::getTotalForceTorqueAppliedOnLink(gazebo::physics::LinkPtr link)
+{
+    // Buffer for total contact force torque of the link, expressed at the link center of mass and with the orientation of the link, initially zero
+    // This is done due to:
+    // \url https://bitbucket.org/osrf/gazebo/issues/545/request-change-contact-reference-frame
+    // \url https://bitbucket.org/osrf/gazebo/pull-requests/355/bullet-contact-sensor/diff
+    // According to the above issue and PR, the force torque feedback values are acting at the CG with respect to the link origin frame.
+    GazeboYarpContactForceTorques::ForceTorque ft_linkCOM;
+    ft_linkCOM.force = ignition::math::Vector3d::Zero;
+    ft_linkCOM.torque = ignition::math::Vector3d::Zero;
+
+    // This loop can probably be improved by just looping over the
+    // contacts once and computing the total force for all links
+    const std::vector< gazebo::physics::Contact* >& contacts = m_pimpl->contactManager->GetContacts();
+    for(auto&& contact : contacts) {
+        // Collision1 belongs to the link of interested
+        if (contact->collision1->GetLink()->GetId() == link->GetId() ) {
+            for(int cntIdx=0; cntIdx < contact->count; cntIdx++) {
+                ft_linkCOM.force += contact->wrench->body1Force;
+                ft_linkCOM.torque += contact->wrench->body1Torque;
+            }
+        }
+
+        // Collision2 belongs to the link of interested
+        if (contact->collision2->GetLink()->GetId() == link->GetId() ) {
+            for(int cntIdx=0; cntIdx < contact->count; cntIdx++) {
+                ft_linkCOM.force += contact->wrench->body2Force;
+                ft_linkCOM.torque += contact->wrench->body2Torque;
+            }
+        }
+    }
+
+    // Transform the force/torque from the link com to the link origin
+    ignition::math::Pose3d linkFrame_H_linkCOM =
+        ignition::math::Pose3d(link->GetInertial().get()->Pose().Pos(), ignition::math::Quaterniond::Identity);
+
+    return applyTransformToForceTorque(linkFrame_H_linkCOM, ft_linkCOM);
+}
+
+void GazeboYarpContactForceTorques::onUpdate(const gazebo::common::UpdateInfo& info)
+{
+    // Get force torques from the contact manager and publish it on the port
+    if (info.simTime.Double() - m_pimpl->latestUpdateInstantInSeconds < m_pimpl->publishingPeriodInSeconds) {
+        return;
+    }
+
+
+    for(size_t i=0; i < m_pimpl->outputFTPorts.size(); i++ )
+    {
+        // Get the force torque applied by the enviroment on the link in the link frame
+        // Get total applied force on link from contact manager
+        GazeboYarpContactForceTorques::ForceTorque ft_link =
+            getTotalForceTorqueAppliedOnLink(m_pimpl->outputFTPorts[i].link);
+
+
+        // Transform the force torque  in the desired frame
+        GazeboYarpContactForceTorques::ForceTorque ft_specifiedFrame =
+            applyTransformToForceTorque(m_pimpl->outputFTPorts[i].publishingFrame_H_linkFrame, ft_link);
+
+        // Convert the force/torque in YARP format
+        //
+        toYARP(ft_specifiedFrame, m_pimpl->outputFTPorts[i].output_vector);
+
+        // write on port
+        m_pimpl->outputFTPorts[i].output_port->prepare() = m_pimpl->outputFTPorts[i].output_vector;
+        m_pimpl->outputFTPorts[i].output_port->write();
+    }
+
+    m_pimpl->latestUpdateInstantInSeconds = info.simTime.Double();
+    return;
+}
+
+void gazebo::GazeboYarpContactForceTorques::onReset()
+{
+    m_pimpl->latestUpdateInstantInSeconds = -1.0;
+}
+
+
+}
+

--- a/tutorial/model/contactforcetorques/contactforcetorques.ini
+++ b/tutorial/model/contactforcetorques/contactforcetorques.ini
@@ -1,0 +1,8 @@
+periodInSeconds 1.0
+
+[OUTPUT_EXTERNAL_FORCETORQUES_PORTS]
+/wholeBodyDynamics/cube/link_frame:o (link,link,link)
+/wholeBodyDynamics/cube/link_other_frame:o (link,additional_frame,additional_frame)
+
+[OUTPUT_EXTERNAL_FORCETORQUES_FRAMES]
+additional_frame (link,0.5,0.0,0.0,-3.14159265359,0.0,0.0)

--- a/tutorial/model/contactforcetorques/model.config
+++ b/tutorial/model/contactforcetorques/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Cube with gazebo_yarp_contactforcetorques plugin</name>
+  <version>1.0</version>
+  <sdf version="1.5">model.sdf</sdf>
+
+  <author>
+    <name>Silvio Traversaro</name>
+    <email>silvio.traversaro@iit.it</email>
+  </author>
+
+  <description>
+    A simple cube that publishes its contact force using the gazebo_yarp_contactforcetorques plugin.
+  </description>
+</model>

--- a/tutorial/model/contactforcetorques/model.sdf
+++ b/tutorial/model/contactforcetorques/model.sdf
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <model name="cube_contactforcetorqueexample">
+    <pose>0 0 0.1 0 0 0</pose>
+    <link name="link">
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+        <max_contacts>4</max_contacts>
+        <surface>
+            <contact>
+                <ode>
+                    <soft_erp>0.2</soft_erp>
+                    <soft_cfm>0</soft_cfm>
+                    <kp>18000000</kp>
+                    <kd>100</kd>
+                    <max_vel>100</max_vel>
+                    <min_depth>0.0001</min_depth>
+                </ode>
+            </contact>
+            <friction>
+                <ode>
+                    <mu>1</mu>
+                    <mu2>1</mu2>
+                    <fdir1>0 0 0</fdir1>
+                    <slip1>0</slip1>
+                    <slip2>0</slip2>
+                </ode>
+            </friction>
+            <bounce>
+                <restitution_coefficient>0</restitution_coefficient>
+                <threshold>100000</threshold>
+            </bounce>
+        </surface>
+      </collision>
+      <sensor name='my_contact' type='contact'>
+          <contact>
+            <collision>collision</collision>
+          </contact>
+      </sensor>
+    </link>
+    <plugin name="contactforcetorques_instance" filename="libgazebo_yarp_contactforcetorques.so">
+      <yarpConfigurationFile>model://contactforcetorques/contactforcetorques.ini</yarpConfigurationFile>
+    </plugin>
+  </model>
+</sdf>


### PR DESCRIPTION
Add gazebo plugin simulating the estimation of contact force torques

This plugin does not simulate any physical sensor, but it simulates the output of the estimators of external contact force torques,
similarly to how the gazebo_yarp_basestate plugin simulates the output of floating base position estimators.

On real robot, the contact forcetorques are estimated by a dedicated software based on the available sensor measurements (such as motor currents, six axis force-torque sensors measures and distribute tactile sensor measurements) and/or a-priori assumptions on the location of the contact (for example on industrial manipulators the external contact is usually assume to be only possible on the end-effector). For example, on the iCub robot the [`wholebodydynamics` software](https://github.com/robotology/whole-body-estimators) based on the [`iDynTree::ExtWrenchesAndJointTorquesEstimator` class](https://robotology.github.io/idyntree/master/classiDynTree_1_1ExtWrenchesAndJointTorquesEstimator.html) is responsible for such an estimation. In a simulation, it is possible to obtain directly this information for the simulator state and inputs, if it is necessary to have a "perfect" estimate.

For more info, see the docs in the doxygen block of the GazeboYarpContactForceTorques, and the example in ` tutorial/model/contactforcetorques`.