### PR TITLE
Add joinType option to linkattacher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- Add the possibility to create different types of joints with the `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/461).
+
 ## [3.3.0] - 2019-12-13
 
 ### Added

--- a/plugins/linkattacher/README.md
+++ b/plugins/linkattacher/README.md
@@ -1,14 +1,16 @@
 ### LinkAttacher Plugin
-The LinkAttacher is a Gazebo _model plugin_. It can be used to attach/detach two _link_ of _model_ spawned in Gazebo environment. The attachment is made by adding a _fixed joint_ between the links specified. The link of the model we want to attach is the parent link and the link of the robot model (to which this plugin is added) becomes the child link for the newly created fixed joint. So, the fixed joint is named by the `model_link_name` suffixed with the phrase *_magnet_joint* in the name e.g, l_hand_magnet_joint.
+The LinkAttacher is a Gazebo _model plugin_. It can be used to attach/detach two _link_ of _model_ spawned in Gazebo environment. The attachment is made by adding a _joint_ between the links specified, with a given _jointType_ (available joint types are those in [SDF documentation](http://sdformat.org/spec?ver=1.6&elem=joint#joint_type) with the exception of `gearbox` that is not available). The link of the model we want to attach is the parent link and the link of the robot model (to which this plugin is added) becomes the child link for the newly created joint. So, the new joint is named by the `model_link_name` suffixed with the phrase *_jointType_joint* in the name e.g, l_hand_fixed_joint.
 
 Additionally, this plugin also provides control over _gravity_ of the models spawned in Gazebo environment.
 Currently, this plugin is used for coupling the hands of two robots, or those robot model and human model in pHRI experiments. Also, this plugin can be used to attach objects to the robot links.
 
 ### Usage
-Create a `linkattacher.ini` configuration file and add the following lines to it to open the rpc port for communicating with the linkattacher plugin
+Create a `linkattacher.ini` configuration file defining the rpc port name for communicating with the linkattacher plugin, and defining the desired type of joint (optional: default type is `fixed`).
+e.g.
 
 ```
 name /<model-name>/linkattacher/rpc:i
+jointType ball
 ```
 Now, add the following lines to the sdf model
 

--- a/plugins/linkattacher/include/GazeboYarpPlugins/linkattacherserverimpl.h
+++ b/plugins/linkattacher/include/GazeboYarpPlugins/linkattacherserverimpl.h
@@ -26,12 +26,18 @@
 #include <LinkAttacherServer.h>
 
 const std::string LogPrefix = "LinkAttacher:";
+// available joint types in SDF (http://sdformat.org/spec?ver=1.6&elem=joint#joint_type)
+// with the exception of gearbox joint
+const std::vector<std::string> jointTypes { "revolute", "revolute2",
+                                            "prismatic", "ball", "screw",
+                                            "universal", "fixed"};
 
 class LinkAttacherServerImpl: public GazeboYarpPlugins::LinkAttacherServer
 {
 private:
   gazebo::physics::WorldPtr _world;
   gazebo::physics::ModelPtr _model;
+  std::string jointType;
 
 public:
   LinkAttacherServerImpl();
@@ -72,6 +78,8 @@ public:
   {
     _model=p;
   }
+
+  bool setJointType(const std::string j);
 
 };
 

--- a/plugins/linkattacher/src/linkattacher.cc
+++ b/plugins/linkattacher/src/linkattacher.cc
@@ -53,6 +53,21 @@ void LinkAttacher::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
       return;
   }
 
+  std::string jointType;
+  if(m_parameters.check("jointType"))
+  {
+      jointType = m_parameters.find("jointType").asString();
+  }
+  else
+  {
+      jointType="fixed";
+  }
+
+  if(!m_la_server.setJointType(jointType))
+  {
+      return;
+  }
+  
   std::string portname;
   if(m_parameters.check("name"))
   {
@@ -72,5 +87,4 @@ void LinkAttacher::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   }
 
   m_la_server.yarp().attachAsServer(*m_rpcport);
-
 }


### PR DESCRIPTION
This PR add the possibility to use `linkattacher` plugin creating type of joint different from `fixed`. In particular, the fixed joint will remain the default type, but any other existing jointType can be used by defining `jointType` in the configuration as explained in https://github.com/lrapetti/gazebo-yarp-plugins/tree/update-linkattacher/plugins/linkattacher#usage