### PR TITLE
Add the option for the external force orientation to be reperesented in the link frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - Add the option for the external force orientation to be reperesented in the link frame with the `externalwrench` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/463).
 - Add the possibility to create different types of joints with the `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/461).
 
+### Fixed
+- Fixed the case if the user writes any 1-word command other than single, the mode is switched to multiple wrenches mode (see https://github.com/robotology/gazebo-yarp-plugins/pull/418). Now, if the user writes any 1-word command other than `single`, `multiple`, `orient_global`, `orient_local`, they will receive an error message (https://github.com/robotology/gazebo-yarp-plugins/pull/463).
+
 ## [3.3.0] - 2019-12-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- Add the option for the external force orientation to be reperesented in the link frame with the `externalwrench` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/463).
+
 ## [3.3.0] - 2019-12-13
 
 ### Added

--- a/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
@@ -29,6 +29,10 @@ public:
     // single wrench or multiple wrenches
     std::string         m_mode;
 
+    // variable for orientation mode
+    // base link or local orientations
+    std::string         m_orient;
+
     int                 wrenchCount;
 
     virtual bool        threadInit();

--- a/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ApplyExternalWrench.hh
@@ -30,7 +30,7 @@ public:
     std::string         m_mode;
 
     // variable for orientation mode
-    // base link or local orientations
+    // global or local orientation modes
     std::string         m_orient;
 
     int                 wrenchCount;

--- a/plugins/externalwrench/include/gazebo/ExternalWrench.hh
+++ b/plugins/externalwrench/include/gazebo/ExternalWrench.hh
@@ -80,7 +80,8 @@ public:
     void setTick(double& tickTime);
     void setTock(double& tockTime);
     void setVisual();
-    void applyWrench();
+    void applyGlobalOrientationWrench();
+    void applyLocalOrientationWrench();
     void deleteWrench();
     void setModel();
 };

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -157,14 +157,14 @@ void RPCServerThread::run()
             this->m_reply.addVocab ( yarp::os::Vocab::encode ( "many" ) );
             this->m_reply.addString ( "The default operation mode is with single wrench" );
             this->m_reply.addString ( "Insert [single] or [multiple] to change the operation mode" );
-            this->m_reply.addString ( "The default frame orientation is the one of the base/root frame" );
+            this->m_reply.addString ( "The default frame orientation is the one of the base/root frame ([orient_global])" );
             this->m_reply.addString ( "Insert [orient_global] or [orient_local] to change the frame orientation mode" );
             this->m_reply.addString ( "Insert a command with the following format:" );
             this->m_reply.addString ( "[link] [force] [torque] [duration]" );
             this->m_reply.addString ( "e.g. chest 10 0 0 0 0 0 1");
             this->m_reply.addString ( "[link]:     (string) Link ID of the robot as specified in robot's SDF" );
-            this->m_reply.addString ( "[force]:    (double x, y, z) Force components in N w.r.t. world reference frame (or link refernce frame if [orient_local] is selected)" );
-            this->m_reply.addString ( "[torque]:   (double x, y, z) Torque components in N.m w.r.t world reference frame (or link refernce frame if [orient_local] is selected)" );
+            this->m_reply.addString ( "[force]:    (double x, y, z) Force components in N w.r.t. world reference frame (or link reference frame if [orient_local] is selected)" );
+            this->m_reply.addString ( "[torque]:   (double x, y, z) Torque components in N.m w.r.t world reference frame (or link reference frame if [orient_local] is selected)" );
             this->m_reply.addString ( "[duration]: (double) Duration of the applied force in seconds" );
             this->m_reply.addString ( "Note: If orientation is set to [orient_global], the reference frame is the base/root robot frame with x pointing backwards and z upwards.");
             this->m_rpcPort.reply ( this->m_reply );

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -276,16 +276,32 @@ void RPCServerThread::run()
 
                     this->m_message = command.get(0).asString() + " wrench orientation option set";
 
-                    // Not clearing previous wrenches!
-
+                    // Delete the previous wrenches
+                    if (wrenchesVector.size() != 0) {
+                        this->m_message = this->m_message + " . Clearing previous wrenches.";
+                        for (int i = 0; i < wrenchesVector.size(); i++)
+                        {
+                            ExternalWrench wrench = wrenchesVector.at(i);
+                            wrench.deleteWrench();
+                        }
+                        wrenchesVector.clear();
+                    }
                 }
                 else if (command.get(0).asString() == "orient_local") {
                     this->m_orient = command.get(0).asString();
 
                     this->m_message = command.get(0).asString() + " wrench orientation option set";
 
-                    // Not clearing previous wrenches!
-
+                    // Delete the previous wrenches
+                    if (wrenchesVector.size() != 0) {
+                        this->m_message = this->m_message + " . Clearing previous wrenches.";
+                        for (int i = 0; i < wrenchesVector.size(); i++)
+                        {
+                            ExternalWrench wrench = wrenchesVector.at(i);
+                            wrench.deleteWrench();
+                        }
+                        wrenchesVector.clear();
+                    }
                 }
                 else {
                     this->m_reply.clear();

--- a/plugins/externalwrench/src/ApplyExternalWrench.cc
+++ b/plugins/externalwrench/src/ApplyExternalWrench.cc
@@ -163,8 +163,8 @@ void RPCServerThread::run()
             this->m_reply.addString ( "[link] [force] [torque] [duration]" );
             this->m_reply.addString ( "e.g. chest 10 0 0 0 0 0 1");
             this->m_reply.addString ( "[link]:     (string) Link ID of the robot as specified in robot's SDF" );
-            this->m_reply.addString ( "[force]:    (double x, y, z) Force components in N w.r.t. world reference frame" );
-            this->m_reply.addString ( "[torque]:   (double x, y, z) Torque components in N.m w.r.t world reference frame" );
+            this->m_reply.addString ( "[force]:    (double x, y, z) Force components in N w.r.t. world reference frame (or link refernce frame if [orient_local] is selected)" );
+            this->m_reply.addString ( "[torque]:   (double x, y, z) Torque components in N.m w.r.t world reference frame (or link refernce frame if [orient_local] is selected)" );
             this->m_reply.addString ( "[duration]: (double) Duration of the applied force in seconds" );
             this->m_reply.addString ( "Note: If orientation is set to [orient_global], the reference frame is the base/root robot frame with x pointing backwards and z upwards.");
             this->m_rpcPort.reply ( this->m_reply );

--- a/plugins/externalwrench/src/ExternalWrench.cc
+++ b/plugins/externalwrench/src/ExternalWrench.cc
@@ -227,15 +227,13 @@ void ExternalWrench::applyLocalOrientationWrench()
         ignition::math::Vector3d newY = newZ.Cross (newX);
 
         ignition::math::Matrix4d Lg_T_F = ignition::math::Matrix4d (newX[0],newY[0],newZ[0],0,newX[1],newY[1],newZ[1],0,newX[2],newY[2],newZ[2],0, 0, 0, 0, 1);
-        ignition::math::Quaterniond Lg_R_F = Lg_T_F.Rotation();
 
         //Transformation from World frame -> Link CoG (Lg) frame
         ignition::math::Matrix4d W_T_Lg = ignition::math::Matrix4d (link->WorldCoGPose());
-        ignition::math::Quaterniond W_R_Lg = W_T_Lg.Rotation();
 
         //Transformation from World frame ->  Applied Force (F) frame
         ignition::math::Matrix4d W_T_F = W_T_Lg*Lg_T_F;
-        ignition::math::Quaterniond W_R_F = W_R_Lg*Lg_R_F;
+        ignition::math::Quaterniond W_R_F = W_T_F.Rotation();
 
         //For the cylindrical shapes used to visualize the applied forces
         const ignition::math::Vector3d cylinderHalfLength = ignition::math::Vector3d ( 0,0,-0.15 );
@@ -272,15 +270,13 @@ void ExternalWrench::applyLocalOrientationWrench()
         math::Vector3d newY = newZ.Cross (newX);
 
         math::Matrix4d Lg_T_F = math::Matrix4d (newX[0],newY[0],newZ[0],0,newX[1],newY[1],newZ[1],0,newX[2],newY[2],newZ[2],0, 0, 0, 0, 1);
-        math::Quaterniond Lg_R_F = Lg_T_F.Rotation();
 
         //Transformation from World frame -> Link CoG (Lg) frame
         math::Matrix4d W_T_Lg = math::Matrix4d (link->WorldCoGPose());
-        math::Quaterniond W_R_Lg = W_T_Lg.Rotation();
 
         //Transformation from World frame ->  Applied Force (F) frame
         math::Matrix4d W_T_F = W_T_Lg*Lg_T_F;
-        math::Quaterniond W_R_F = W_R_Lg*Lg_R_F;
+        math::Quaterniond W_R_F = W_T_F.Rotation();
 
         //For the cylindrical shapes used to visualize the applied forces
         const math::Vector3d cylinderHalfLength = math::Vector3d ( 0,0,-0.15 );

--- a/plugins/externalwrench/src/ExternalWrench.cc
+++ b/plugins/externalwrench/src/ExternalWrench.cc
@@ -147,7 +147,7 @@ void ExternalWrench::applyGlobalOrientationWrench()
         ignition::math::Vector3d newY = newZ.Cross (newX);
         ignition::math::Matrix4d rotation = ignition::math::Matrix4d (newX[0],newY[0],newZ[0],0,newX[1],newY[1],newZ[1],0,newX[2],newY[2],newZ[2],0, 0, 0, 0, 1);
         ignition::math::Quaterniond forceOrientation = rotation.Rotation();
-        ignition::math::Pose3d linkCoGPose (linkCoGPos - rotation*ignition::math::Vector3d ( 0,0,.15 ), forceOrientation);
+        ignition::math::Pose3d W_p_F (linkCoGPos - rotation*ignition::math::Vector3d ( 0,0,.15 ), forceOrientation);
 #else
         math::Vector3d force (wrench.force[0], wrench.force[1], wrench.force[2]);
         math::Vector3d torque (wrench.torque[0], wrench.torque[1], wrench.torque[2]);
@@ -161,13 +161,13 @@ void ExternalWrench::applyGlobalOrientationWrench()
         math::Vector3d newY = newZ.Cross (newX);
         math::Matrix4d rotation = ignition::math::Matrix4d (newX[0],newY[0],newZ[0],0,newX[1],newY[1],newZ[1],0,newX[2],newY[2],newZ[2],0, 0, 0, 0, 1);
         math::Quaterniond forceOrientation = rotation.Rotation();
-        math::Pose3d linkCoGPose (linkCoGPos - rotation*ignition::math::Vector3d ( 0,0,.15 ), forceOrientation);
+        math::Pose3d W_p_F (linkCoGPos - rotation*ignition::math::Vector3d ( 0,0,.15 ), forceOrientation);
 #endif
 
 #if GAZEBO_MAJOR_VERSION == 7
-        msgs::Set(visualMsg.mutable_pose(), linkCoGPose.Ign());
+        msgs::Set(visualMsg.mutable_pose(), W_p_F.Ign());
 #else
-        msgs::Set(visualMsg.mutable_pose(), linkCoGPose);
+        msgs::Set(visualMsg.mutable_pose(), W_p_F);
 #endif
 #if GAZEBO_MAJOR_VERSION >= 9
         msgs::Set(visualMsg.mutable_material()->mutable_ambient(), ignition::math::Color(color[0],color[1],color[2],color[3]));
@@ -226,9 +226,9 @@ void ExternalWrench::applyLocalOrientationWrench()
         ignition::math::Quaterniond W_Q_F = W_Q_Lg*Lg_Q_F;
         ignition::math::Matrix4d W_T_F = W_T_Lg*Lg_T_F;
 
-        const ignition::math::Vector3d cylinderHalfLenght = ignition::math::Vector3d ( 0,0,-0.15 );
+        const ignition::math::Vector3d cylinderHalfLength = ignition::math::Vector3d ( 0,0,-0.15 );
 
-        ignition::math::Pose3d linkCoGPose (W_T_F*cylinderHalfLenght, W_Q_F);
+        ignition::math::Pose3d W_p_F (W_T_F*cylinderHalfLength, W_Q_F);
 #else
         math::Vector3d force (wrench.force[0], wrench.force[1], wrench.force[2]);
         math::Vector3d torque (wrench.torque[0], wrench.torque[1], wrench.torque[2]);
@@ -268,15 +268,15 @@ void ExternalWrench::applyLocalOrientationWrench()
         math::Quaterniond W_Q_F = W_Q_Lg*Lg_Q_F;
         math::Matrix4d W_T_F = W_T_Lg*Lg_T_F;
 
-        const math::Vector3d cylinderHalfLenght = ignition::math::Vector3d ( 0,0,-0.15 );
+        const math::Vector3d cylinderHalfLength = ignition::math::Vector3d ( 0,0,-0.15 );
 
-        math::Pose3d linkCoGPose (W_T_F*cylinderHalfLenght, W_Q_F);
+        math::Pose3d W_p_F (W_T_F*cylinderHalfLength, W_Q_F);
 #endif
 
 #if GAZEBO_MAJOR_VERSION == 7
-        msgs::Set(visualMsg.mutable_pose(), linkCoGPose.Ign());
+        msgs::Set(visualMsg.mutable_pose(), W_p_F.Ign());
 #else
-        msgs::Set(visualMsg.mutable_pose(), linkCoGPose);
+        msgs::Set(visualMsg.mutable_pose(), W_p_F);
 #endif
 #if GAZEBO_MAJOR_VERSION >= 9
         msgs::Set(visualMsg.mutable_material()->mutable_ambient(), ignition::math::Color(color[0],color[1],color[2],color[3]));


### PR DESCRIPTION
## Proposed feature to add:

- To have an option to specify the wrenches orientations in the link frame.

- The user interface can be similar to what had been done in https://github.com/robotology/gazebo-yarp-plugins/pull/418

Where the user can write a command:

```
orient_local
```

And the mode will change to "orient_local" where the applied forces will have the orientation of the link frame. Moreover, the user will specify the force components w.r.t the link frame.

Writing the command:

```
orient_global
```

Will switch to the already implemented settings.

- The default setting is `orient_global`.

Related issue: https://github.com/robotology/gazebo-yarp-plugins/issues/462

## Other modification:
Before: If the user writes any 1-word command other than `single`, the mode is switched to multiple wrenches mode (see https://github.com/robotology/gazebo-yarp-plugins/pull/418).

After: If the user commands any 1-word command other than `single`, `multiple`, `orient_global`, `orient_local`, they will receive an error and a message:

```
ERROR: Incorrect command format. Insert [help] to know the correct command format
```