### PR TITLE
solve the problem of change of the interaction mode if you are already on that mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed 
+- Solve the problem of setting the intraction mode when the mode of actuator has been already set on the same requested interaction mode.  (https://github.com/robotology/gazebo-yarp-plugins/pull/464).
+
 ## [3.3.0] - 2019-12-13
 
 ### Added

--- a/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
@@ -40,10 +40,10 @@ bool GazeboYarpControlBoardDriver::getInteractionModes(yarp::dev::InteractionMod
 
 bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
 {
-	// The joint is already in the specified interaction mode, return
+    // The joint is already in the specified interaction mode, return
     // See https://github.com/robotology/gazebo-yarp-plugins/issues/460 for more details
     if (m_interactionMode[j] == mode) {
-    return true;
+        return true;
     }
 
     resetAllPidsForJointAtIndex(j);

--- a/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
@@ -40,6 +40,12 @@ bool GazeboYarpControlBoardDriver::getInteractionModes(yarp::dev::InteractionMod
 
 bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::InteractionModeEnum mode)
 {
+	// The joint is already in the specified interaction mode, return
+    // See https://github.com/robotology/gazebo-yarp-plugins/issues/460 for more details
+    if (m_interactionMode[j] == mode) {
+    return true;
+    }
+
     resetAllPidsForJointAtIndex(j);
     m_interactionMode[j] = static_cast<int>(mode);
 


### PR DESCRIPTION
Here we solved the problem of asking to change the interaction mode, If we are already on that mode. For example if we are in stiff mode and we ask again to set to stiff mode, we shouldn't reset again to stiff mode because it resets the PID.
The related Issue #460

