### PR TITLE
Fix relativeMove implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ## [Unreleased]
 
 ### Fixed 
-- Solve the problem of setting the intraction mode when the mode of actuator has been already set on the same requested interaction mode.  (https://github.com/robotology/gazebo-yarp-plugins/pull/464).
+- Solve the problem of setting the interaction mode when the mode of actuator has been already set on the same requested interaction mode (https://github.com/robotology/gazebo-yarp-plugins/pull/464).
+- Fix implementation of `yarp::dev::IPositionControl::relativeMove` in `gazebo_yarp_controlboard` (https://github.com/robotology/gazebo-yarp-plugins/pull/466).
 
 ## [3.3.0] - 2019-12-13
 

--- a/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
@@ -113,11 +113,7 @@ bool GazeboYarpControlBoardDriver::getRefSpeeds(double *spds) //WORKS
 
 bool GazeboYarpControlBoardDriver::relativeMove(int j, double delta) //NOT TESTED
 {
-    if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints) {
-        m_trajectoryGenerationReferencePosition[j] = m_positions[j] + delta; //TODO check if this is ok or m_trajectoryGenerationReferencePosition=m_trajectoryGenerationReferencePosition+delta!!!
-        return true;
-    }
-    return false;
+    return positionMove(j, m_positions[j] + delta);
 }
 
 bool GazeboYarpControlBoardDriver::relativeMove(const double *deltas) //NOT TESTED


### PR DESCRIPTION
`GazeboYarpControlBoardDriver::relativeMove` was not correctly implemented until now.
See https://www.yarp.it/classyarp_1_1dev_1_1IPositionControl.html#a32763b9f36c8751b589b23ff79915e0b for the documentation on how the `yarp::dev::IPositionControl::relativeMove` method should be implemented. 
 
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/465 .

