### PR TITLE
Added finger coupling management for iCub new Mk3 hand.

### DIFF
--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -164,4 +164,27 @@ public:
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
 };
 
+class HandMk3CouplingHandler : public BaseCouplingHandler
+{
+
+public:
+    HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+
+public:
+    bool decouplePos (yarp::sig::Vector& current_pos);
+    bool decoupleVel (yarp::sig::Vector& current_vel);
+    bool decoupleAcc (yarp::sig::Vector& current_acc);
+    bool decoupleTrq (yarp::sig::Vector& current_trq);
+
+    yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
+    yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
+    yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
+    
+protected:
+    double decouple (double q2, double lut[]);
+
+    double thumb_lut[4096];
+    double index_lut[4096];
+};
+
 #endif //GAZEBOYARP_COUPLING_H

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -169,6 +169,7 @@ class HandMk3CouplingHandler : public BaseCouplingHandler
 
 public:
     HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    virtual ~HandMk3CouplingHandler();
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -183,8 +184,10 @@ public:
 protected:
     double decouple (double q2, double lut[]);
 
-    double thumb_lut[4096];
-    double index_lut[4096];
+    const int LUTSIZE;
+
+    double *thumb_lut;
+    double *index_lut;
 };
 
 #endif //GAZEBOYARP_COUPLING_H

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -169,7 +169,6 @@ class HandMk3CouplingHandler : public BaseCouplingHandler
 
 public:
     HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
-    virtual ~HandMk3CouplingHandler();
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -182,12 +181,12 @@ public:
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
     
 protected:
-    double decouple (double q2, double lut[]);
+    double decouple (double q2, std::vector<double>& lut);
 
     const int LUTSIZE;
 
-    double *thumb_lut;
-    double *index_lut;
+    std::vector<double> thumb_lut;
+    std::vector<double> index_lut;
 };
 
 #endif //GAZEBOYARP_COUPLING_H

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -262,7 +262,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
             {
                 BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names);
                 m_coupling_handler.push_back(cpl);
-                yInfo() << "using left_hand_control";
+                yInfo() << "using icub_hand_mk3";
             }
             else if (coupling_bottle->get(0).asString()=="none")
             {

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -258,6 +258,12 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using cer_hand_control";
             }
+            else if (coupling_bottle->get(0).asString()=="icub_hand_mk3")
+            {
+                BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                m_coupling_handler.push_back(cpl);
+                yInfo() << "using left_hand_control";
+            }
             else if (coupling_bottle->get(0).asString()=="none")
             {
                 yDebug() << "Just for test";

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -578,8 +578,8 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
     
     m_couplingSize = 11;
     
-    thumb_lut = new double[LUTSIZE];
-    index_lut = new double[LUTSIZE];
+    thumb_lut.resize(LUTSIZE);
+    index_lut.resize(LUTSIZE);
     
     std::vector<double> num(LUTSIZE);
     
@@ -701,12 +701,6 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
     }
 }
 
-HandMk3CouplingHandler::~HandMk3CouplingHandler()
-{
-    delete [] thumb_lut;
-    delete [] index_lut;
-}
-
 bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
@@ -746,7 +740,7 @@ bool HandMk3CouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
     return false;
 }
 
-double HandMk3CouplingHandler::decouple (double q2, double lut[])
+double HandMk3CouplingHandler::decouple (double q2, std::vector<double>& lut)
 {
     double dindex = q2*10.0;
     int iindex = int(dindex);

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -10,6 +10,7 @@
 
 #include <ControlBoardDriverCoupling.h>
 #include <cstdio>
+#include <cmath>
 #include <gazebo/physics/Model.hh>
 
 #include <yarp/os/LogStream.h>
@@ -562,5 +563,233 @@ yarp::sig::Vector CerHandCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq
     out[m_coupledJoints[1]] = trq_ref[m_coupledJoints[0]]/2;
     out[m_coupledJoints[2]] = trq_ref[m_coupledJoints[1]]/2;
     out[m_coupledJoints[3]] = trq_ref[m_coupledJoints[1]]/2;
+    return out;
+}
+
+//------------------------------------------------------------------------------------------------------------------
+// HandMk3CouplingHandler
+//------------------------------------------------------------------------------------------------------------------
+
+HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+{
+    const double RAD2DEG = 180.0/atan2(0.0,-1.0);
+    const double DEG2RAD = 1.0/RAD2DEG;
+    
+    m_couplingSize = 11;
+    
+    double num[4096];
+    
+    for (int n = 0; n < 4096; ++n)
+    {
+        num[n] = 0.0;
+        thumb_lut[n] = 0.0;
+    }
+
+    // thumb
+    {        
+        double L0x = -0.00555,          L0y = 0.00195+0.0009;
+        double P1x =  0.020,            P1y = 0.0015;
+        double L1x =  P1x-0.0055-0.003, L1y = P1y-0.002+0.0019;
+        
+        double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
+        double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
+        
+        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        
+        for (double q1 = 0.0; q1 <= 85.5; q1 += 0.01)
+        {
+            double cq1 = cos(DEG2RAD*q1);
+            double sq1 = sin(DEG2RAD*q1);
+            
+            double P1xr = cq1*P1x-sq1*P1y;
+            double P1yr = sq1*P1x+cq1*P1y;
+            
+            double h2 = (P1xr - L0x)*(P1xr - L0x) + (P1yr - L0y)*(P1yr - L0y);
+            
+            double alfa = RAD2DEG*atan2(L0y - P1yr, L0x - P1xr);
+            
+            double beta = RAD2DEG*acos((h2 + l2 - k2)/(2.0*sqrt(h2*l2)));
+            
+            double q2 = alfa + beta - offset;
+            
+            while (q2 <    0.0) q2 += 360.0;
+            while (q2 >= 360.0) q2 -= 360.0;
+            
+            double dindex = q2*10.0;
+            
+            int iindex = int(dindex);
+            
+            double w = dindex - double(iindex);
+            
+            thumb_lut[iindex] += (1.0 - w)*q1;
+            num[iindex] += (1.0 - w);
+            
+            thumb_lut[iindex + 1] += w*q1;
+            num[iindex + 1] += w;
+        }
+        
+        for (int n = 0; n < 4096; ++n)
+        {
+            if (num[n] > 0.0)
+            {
+                thumb_lut[n] /= num[n];
+            }
+        }
+    }
+    
+    //for (int n=0; n<1500; ++n) yDebug() << thumb_lut[n];
+    
+    for (int n = 0; n < 4096; ++n)
+    {
+        num[n] = 0.0;
+        index_lut[n] = 0.0;
+    }
+    
+    // finger
+    {    
+        double P1x =  0.0300, P1y = 0.0015;
+        double L0x = -0.0050, L0y = 0.0040;
+        double L1x =  0.0240, L1y = 0.0008;
+        
+        double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
+        double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
+        
+        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        
+        for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
+        {
+            double cq1 = cos(DEG2RAD*q1);
+            double sq1 = sin(DEG2RAD*q1);
+            
+            double P1xr = cq1*P1x-sq1*P1y;
+            double P1yr = sq1*P1x+cq1*P1y;
+            
+            double h2 = (P1xr - L0x)*(P1xr - L0x) + (P1yr - L0y)*(P1yr - L0y);
+            
+            double alfa = RAD2DEG*atan2(L0y - P1yr, L0x - P1xr);
+            
+            double beta = RAD2DEG*acos((h2 + l2 - k2)/(2.0*sqrt(h2*l2)));
+            
+            double q2 = alfa + beta - offset;
+            
+            while (q2 <    0.0) q2 += 360.0;
+            while (q2 >= 360.0) q2 -= 360.0;
+            
+            double dindex = q2*10.0;
+            
+            int iindex = int(dindex);
+            
+            double w = dindex - double(iindex);
+            
+            index_lut[iindex] += (1.0 - w)*q1;
+            num[iindex] += (1.0 - w);
+            
+            index_lut[iindex + 1] += w*q1;
+            num[iindex + 1] += w;
+        }
+        
+        for (int n = 0; n < 4096; ++n)
+        {
+            if (num[n] > 0.0)
+            {
+                index_lut[n] /= num[n];
+            }
+        }
+    }
+}
+
+bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_pos[m_coupledJoints[2]] = current_pos[m_coupledJoints[2]] + current_pos[m_coupledJoints[3]];
+    current_pos[m_coupledJoints[3]] = current_pos[m_coupledJoints[4]];
+    current_pos[m_coupledJoints[4]] = current_pos[m_coupledJoints[5]] + current_pos[m_coupledJoints[6]];
+    current_pos[m_coupledJoints[5]] = current_pos[m_coupledJoints[7]] + current_pos[m_coupledJoints[8]];
+    current_pos[m_coupledJoints[6]] = current_pos[m_coupledJoints[9]] + current_pos[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_vel[m_coupledJoints[2]] = current_vel[m_coupledJoints[2]] + current_vel[m_coupledJoints[3]];
+    current_vel[m_coupledJoints[3]] = current_vel[m_coupledJoints[4]];
+    current_vel[m_coupledJoints[4]] = current_vel[m_coupledJoints[5]] + current_vel[m_coupledJoints[6]];
+    current_vel[m_coupledJoints[5]] = current_vel[m_coupledJoints[7]] + current_vel[m_coupledJoints[8]];
+    current_vel[m_coupledJoints[6]] = current_vel[m_coupledJoints[9]] + current_vel[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
+{	
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_acc[m_coupledJoints[2]] = current_acc[m_coupledJoints[2]] + current_acc[m_coupledJoints[3]];
+    current_acc[m_coupledJoints[3]] = current_acc[m_coupledJoints[4]];
+    current_acc[m_coupledJoints[4]] = current_acc[m_coupledJoints[5]] + current_acc[m_coupledJoints[6]];
+    current_acc[m_coupledJoints[5]] = current_acc[m_coupledJoints[7]] + current_acc[m_coupledJoints[8]];
+    current_acc[m_coupledJoints[6]] = current_acc[m_coupledJoints[9]] + current_acc[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    return false;
+}
+
+double HandMk3CouplingHandler::decouple (double q2, double lut[])
+{
+    double dindex = q2*10.0;
+    int iindex = int(dindex);
+    double w = dindex - double(iindex);
+    return lut[iindex]*(1.0 - w) + lut[iindex + 1]*w;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
+{
+    yarp::sig::Vector out = pos_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yError() << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(pos_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = pos_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = pos_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(pos_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = pos_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(pos_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = pos_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(pos_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = pos_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
+    return out;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefVel (yarp::sig::Vector& vel_ref)
+{
+    yarp::sig::Vector out = vel_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yError() << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(vel_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = vel_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = vel_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(vel_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = vel_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(vel_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = vel_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(vel_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = vel_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
+    return out;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_ref)
+{
+    yarp::sig::Vector out =trq_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yError() << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(trq_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = trq_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = trq_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(trq_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = trq_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(trq_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = trq_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(trq_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = trq_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
     return out;
 }

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -571,16 +571,19 @@ yarp::sig::Vector CerHandCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq
 //------------------------------------------------------------------------------------------------------------------
 
 HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names), LUTSIZE(4096)
 {
     const double RAD2DEG = 180.0/atan2(0.0,-1.0);
     const double DEG2RAD = 1.0/RAD2DEG;
     
     m_couplingSize = 11;
     
-    double num[4096];
+    thumb_lut = new double[LUTSIZE];
+    index_lut = new double[LUTSIZE];
     
-    for (int n = 0; n < 4096; ++n)
+    double num[LUTSIZE];
+    
+    for (int n = 0; n < LUTSIZE; ++n)
     {
         num[n] = 0.0;
         thumb_lut[n] = 0.0;
@@ -629,7 +632,7 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
             num[iindex + 1] += w;
         }
         
-        for (int n = 0; n < 4096; ++n)
+        for (int n = 0; n < LUTSIZE; ++n)
         {
             if (num[n] > 0.0)
             {
@@ -639,7 +642,7 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
     }
     
     
-    for (int n = 0; n < 4096; ++n)
+    for (int n = 0; n < LUTSIZE; ++n)
     {
         num[n] = 0.0;
         index_lut[n] = 0.0;
@@ -688,7 +691,7 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
             num[iindex + 1] += w;
         }
         
-        for (int n = 0; n < 4096; ++n)
+        for (int n = 0; n < LUTSIZE; ++n)
         {
             if (num[n] > 0.0)
             {
@@ -696,6 +699,12 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
             }
         }
     }
+}
+
+HandMk3CouplingHandler::~HandMk3CouplingHandler()
+{
+    delete [] thumb_lut;
+    delete [] index_lut;
 }
 
 bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -638,7 +638,6 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
         }
     }
     
-    //for (int n=0; n<1500; ++n) yDebug() << thumb_lut[n];
     
     for (int n = 0; n < 4096; ++n)
     {

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -581,7 +581,7 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
     thumb_lut = new double[LUTSIZE];
     index_lut = new double[LUTSIZE];
     
-    double num[LUTSIZE];
+    std::vector<double> num(LUTSIZE);
     
     for (int n = 0; n < LUTSIZE; ++n)
     {


### PR DESCRIPTION
I've added the coupling class of the new iCub hand under developmente at present.
Since the coupling between the second and first phalanges is not linear, and thus not easily invertible, it makes use of an interpolated look up table that will be also useful in firmware implementation in control boards.