### PR TITLE
Fix Control Board wrong joint limits for coupled joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - Add the possibility to create different types of joints with the `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/461).
+- Add the possibility to decouple joint limits using method BaseCouplingHandler::decouplePosLimits(), within the 'controlboard' plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/472).
+
+### Fixed
+- Fix evaluation of joints position limits for physically coupled DoFs in method GazeboYarpControlBoardDriver::setMinMaxPos(), within the 'controlboard' plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/472).
 
 ## [3.3.0] - 2019-12-13
 

--- a/plugins/controlboard/CMakeLists.txt
+++ b/plugins/controlboard/CMakeLists.txt
@@ -34,7 +34,8 @@ set(controlBoard_source     src/ControlBoard.cc
 set(controlBoard_headers    include/gazebo/ControlBoard.hh
                             include/yarp/dev/ControlBoardDriver.h
                             include/yarp/dev/ControlBoardDriverTrajectory.h
-                            include/yarp/dev/ControlBoardDriverCoupling.h)
+                            include/yarp/dev/ControlBoardDriverCoupling.h
+                            include/yarp/dev/ControlBoardDriverRange.h)
                             
                             
                             

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -27,6 +27,7 @@
 #include <boost/shared_ptr.hpp>
 #include <ControlBoardDriverTrajectory.h>
 #include <ControlBoardDriverCoupling.h>
+#include <ControlBoardDriverRange.h>
 
 #include <gazebo/common/PID.hh>
 #include <gazebo/common/Time.hh>
@@ -347,12 +348,6 @@ private:
         JointType_Unknown = 0,
         JointType_Revolute,
         JointType_Prismatic
-    };
-
-    struct Range {
-        Range() : min(0), max(0){}
-        double min;
-        double max;
     };
 
     std::string m_deviceName;

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -9,6 +9,8 @@
 
 #include <gazebo/physics/Model.hh>
 
+#include <ControlBoardDriverRange.h>
+
 namespace yarp {
     namespace dev {
         enum CouplingType
@@ -36,6 +38,8 @@ public:
     virtual bool decoupleAcc(yarp::sig::Vector& current_acc) = 0;
     virtual bool decoupleTrq(yarp::sig::Vector& current_trq) = 0;
 
+    virtual bool decouplePosLimits(std::vector<Range>& pos_limits) = 0;
+
     virtual yarp::sig::VectorOf<int> getCoupledJoints();
     virtual std::string getCoupledJointName (int joint);
     virtual bool checkJointIsCoupled(int joint);
@@ -57,6 +61,8 @@ public:
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
 
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
+
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
@@ -73,6 +79,8 @@ public:
     bool decoupleVel (yarp::sig::Vector& current_vel);
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
+
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
 
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
@@ -91,6 +99,8 @@ public:
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
 
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
+
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
@@ -107,6 +117,8 @@ public:
     bool decoupleVel (yarp::sig::Vector& current_vel);
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
+
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
 
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
@@ -125,6 +137,8 @@ public:
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
 
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
+
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
@@ -142,6 +156,8 @@ public:
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
 
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
+
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
@@ -158,6 +174,8 @@ public:
     bool decoupleVel (yarp::sig::Vector& current_vel);
     bool decoupleAcc (yarp::sig::Vector& current_acc);
     bool decoupleTrq (yarp::sig::Vector& current_trq);
+
+    bool decouplePosLimits(std::vector<Range>& pos_limits);
 
     yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
     yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverRange.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverRange.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_CONTROLBOARDDRIVERRANGE_HH
+#define GAZEBOYARP_CONTROLBOARDDRIVERRANGE_HH
+
+struct Range {
+    Range() : min(0), max(0){}
+    double min;
+    double max;
+};
+
+#endif

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -686,6 +686,15 @@ bool GazeboYarpControlBoardDriver::setMinMaxPos()
         yWarning() << "Missing LIMITS section";
     }
 
+    // handle coupling
+    for (size_t cpl_cnt = 0; cpl_cnt < m_coupling_handler.size(); cpl_cnt++)
+    {
+        if (m_coupling_handler[cpl_cnt])
+        {
+            m_coupling_handler[cpl_cnt]->decouplePosLimits(m_jointPosLimits);
+        }
+    }
+
     return true;
 }
 

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -107,6 +107,11 @@ bool EyesCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
     return false;
 }
 
+bool EyesCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits) // NOT IMPLEMENTED
+{
+    return false;
+}
+
 yarp::sig::Vector EyesCouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
 {
     yarp::sig::Vector out = pos_ref;
@@ -169,6 +174,14 @@ bool ThumbCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     return false;
+}
+
+bool ThumbCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits)
+{
+    if (m_coupledJoints.size() != m_couplingSize) return false;
+    pos_limits[m_coupledJoints[2]].min = pos_limits[m_coupledJoints[2]].min + pos_limits[m_coupledJoints[3]].min;
+    pos_limits[m_coupledJoints[2]].max = pos_limits[m_coupledJoints[2]].max + pos_limits[m_coupledJoints[3]].max;
+    return true;
 }
 
 yarp::sig::Vector ThumbCouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
@@ -241,6 +254,14 @@ bool IndexCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
     return false;
 }
 
+bool IndexCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits)
+{
+    if (m_coupledJoints.size() != m_couplingSize) return false;
+    pos_limits[m_coupledJoints[1]].min = pos_limits[m_coupledJoints[1]].min + pos_limits[m_coupledJoints[2]].min;
+    pos_limits[m_coupledJoints[1]].max = pos_limits[m_coupledJoints[1]].max + pos_limits[m_coupledJoints[2]].max;
+    return true;
+}
+
 yarp::sig::Vector IndexCouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
 {
     yarp::sig::Vector out = pos_ref;
@@ -308,6 +329,14 @@ bool MiddleCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
     return false;
 }
 
+bool MiddleCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits)
+{
+    if (m_coupledJoints.size() != m_couplingSize) return false;
+    pos_limits[m_coupledJoints[1]].min = pos_limits[m_coupledJoints[1]].min + pos_limits[m_coupledJoints[2]].min;
+    pos_limits[m_coupledJoints[1]].max = pos_limits[m_coupledJoints[1]].max + pos_limits[m_coupledJoints[2]].max;
+    return true;
+}
+
 yarp::sig::Vector MiddleCouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
 {
     yarp::sig::Vector out = pos_ref;
@@ -373,6 +402,14 @@ bool PinkyCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     return false;
+}
+
+bool PinkyCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits)
+{
+    if (m_coupledJoints.size() != m_couplingSize) return false;
+    pos_limits[m_coupledJoints[0]].min = pos_limits[m_coupledJoints[0]].min + pos_limits[m_coupledJoints[1]].min + pos_limits[m_coupledJoints[2]].min;
+    pos_limits[m_coupledJoints[0]].max = pos_limits[m_coupledJoints[0]].max + pos_limits[m_coupledJoints[1]].max + pos_limits[m_coupledJoints[2]].max;
+    return true;
 }
 
 yarp::sig::Vector PinkyCouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
@@ -449,6 +486,11 @@ bool FingersAbductionCouplingHandler::decoupleAcc (yarp::sig::Vector& current_ac
 bool FingersAbductionCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
+    return false;
+}
+
+bool FingersAbductionCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits) // NOT IMPLEMENTED
+{
     return false;
 }
 
@@ -529,6 +571,11 @@ bool CerHandCouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
 bool CerHandCouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
+    return false;
+}
+
+bool CerHandCouplingHandler::decouplePosLimits (std::vector<Range>& pos_limits) // NOT IMPLEMENTED
+{
     return false;
 }
 


### PR DESCRIPTION
This PR fixes #348 

I had to move the private struct `yarp::dev::GazeboYarpControlBoardDriver::Range` in a separate header file as it is required both within class `yarp::dev::GazeboYarpControlBoardDriver` and  in the signature of a new method in classes `BaseCouplingHandler` and derived.

cc @randaz81 @kouroshD @traversaro 