### PR TITLE
Fixed initialization of the local simulation time from Gazebo simTime on first call of onUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ### Added
 - Add the possibility to create different types of joints with the `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/461).
 
+### Fixed
+- Fixed initialization of the local simulation time from Gazebo simTime on first call of onUpdate (https://github.com/robotology/gazebo-yarp-plugins/pull/478).
+
 ## [3.3.0] - 2019-12-13
 
 ### Added
 - Add the usage of `MultipleAnalogInterfaces`(https://www.yarp.it/group__dev__iface__multiple__analog.html)
   in the `gazebo_yarp_imu`.
 
-### Fixed 
+### Fixed
 - Fixed compilation on Gazebo 7 by disabling compilation of `externalwrench` plugin if the project is configured with Gazebo 7 (https://github.com/robotology/gazebo-yarp-plugins/pull/434).
 
 ### Removed
@@ -25,12 +28,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - Add `resetSimulation` method to reset simulation state and time time, in the `gazebo_yarp_clock` RPC interface (https://github.com/robotology/gazebo-yarp-plugins/pull/345).
 - Add `resetSimulationState` method to reset simulation state, but not the time, in the `gazebo_yarp_clock` RPC interface (https://github.com/robotology/gazebo-yarp-plugins/pull/424).
 - Add `gazebo_yarp_doublelaser` plugin to simulate a double laser device (https://github.com/robotology/gazebo-yarp-plugins/pull/419).
-- Add `gazebo_yarp_configurationoverride` plugin that can be attached to a model in order to override the [`sdf`](http://sdformat.org/spec) configuration of any other plugin that is attached to the same model (https://github.com/robotology/gazebo-yarp-plugins/pull/401). This plugin is particularly useful to set the initial configuration  of a given model, and is documented in https://github.com/robotology/gazebo-yarp-plugins/blob/v3.2.0/plugins/configurationoverride/README.md . 
+- Add `gazebo_yarp_configurationoverride` plugin that can be attached to a model in order to override the [`sdf`](http://sdformat.org/spec) configuration of any other plugin that is attached to the same model (https://github.com/robotology/gazebo-yarp-plugins/pull/401). This plugin is particularly useful to set the initial configuration  of a given model, and is documented in https://github.com/robotology/gazebo-yarp-plugins/blob/v3.2.0/plugins/configurationoverride/README.md .
 - Add features in `gazebo_yarp_externalwrench` to apply multiple external wrenchs at the same time (https://github.com/robotology/gazebo-yarp-plugins/pull/418) .
 - Add the  `yarpConfigurationString` to configure the YARP plugins with a single `yarpConfigurationString` embedded in the SDF code of the plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/396).
 - Add a ChangeLog document based on the format defined in [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix invalid camera parameters in `gazebo_depthCamera` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/408).
-
-

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -456,6 +456,7 @@ private:
     int m_clock;
     int _T_controller;
     gazebo::common::Time m_previousTime;
+    bool m_initTime; // Flag to reset the initial simulation time from Gazebo simTime.
 
     /**
      * Private methods

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -21,7 +21,7 @@ using namespace yarp::sig;
 using namespace yarp::dev;
 
 
-GazeboYarpControlBoardDriver::GazeboYarpControlBoardDriver() : m_deviceName("") {}
+GazeboYarpControlBoardDriver::GazeboYarpControlBoardDriver() : m_deviceName(""), m_initTime(true) {}
 
 GazeboYarpControlBoardDriver::~GazeboYarpControlBoardDriver() {}
 
@@ -117,6 +117,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_isMotionDone = new bool[m_numberOfJoints];
     m_clock = 0;
     m_torqueOffset = 0;
+    m_initTime = true; // Set to initialize the simulation time to Gazebo simTime on the first call to onUpdate().
 
 
     m_trajectory_generator.resize(m_numberOfJoints, NULL);
@@ -450,10 +451,8 @@ bool GazeboYarpControlBoardDriver::configureJointType()
 
 void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _info)
 {
-    //TODO: how to properly reset the initial time?
-    static bool firstTime = true;
-    if (firstTime) {
-        firstTime = false;
+    if (m_initTime) {
+        m_initTime = false;
         m_previousTime = _info.simTime;
     }
     gazebo::common::Time stepTime = _info.simTime - m_previousTime;
@@ -632,6 +631,7 @@ void GazeboYarpControlBoardDriver::onUpdate(const gazebo::common::UpdateInfo& _i
 void GazeboYarpControlBoardDriver::onReset()
 {
     m_previousTime = gazebo::common::Time::Zero;
+    m_initTime = true;
     resetPositionsAndTrajectoryGenerators();
 }
 


### PR DESCRIPTION
Fixes https://github.com/robotology/gazebo-yarp-plugins/issues/475.

Refer to the analysis in the respective issue.