### PR TITLE
[videotexture] fixed image conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(${PROJECT_NAME}_VERSION
 include(GNUInstallDirs)
 
 # Finding dependencies
-find_package(YARP 3.2.102 REQUIRED)
+find_package(YARP 3.2.102 REQUIRED COMPONENTS os sig dev math cv)
 find_package(Gazebo REQUIRED)
 if (Gazebo_VERSION_MAJOR LESS 7.0)
     message(status "Gazebo version : " ${Gazebo_VERSION_MAJOR}.${Gazebo_VERSION_MINOR}.${Gazebo_VERSION_PATCH})

--- a/plugins/videotexture/src/VideoTexture.cc
+++ b/plugins/videotexture/src/VideoTexture.cc
@@ -14,6 +14,7 @@
 #include <yarp/dev/PolyDriver.h>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+#include <yarp/cv/Cv.h>
 
 using namespace Ogre;
 namespace gazebo 
@@ -50,7 +51,7 @@ namespace gazebo
             const cv::Mat*    image_ptr;
             pixelBuff         pixelBuffer;
 
-            image       = cv::cvarrToMat( static_cast<IplImage*>(img->getIplImage()) );
+            image       = yarp::cv::toCvMat(*img);
             image_ptr   = &image;
             pixelBuffer = this->m_texture->getBuffer();
 


### PR DESCRIPTION
This PR attempts to fix a compilation error happening while building the `videotexture` plugin.
Image conversion is now done through the standard `yarp::cv::toCvMat` function.