### PR TITLE
Make OpenCV optional again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,17 @@ set(${PROJECT_NAME}_VERSION
 include(GNUInstallDirs)
 
 # Finding dependencies
-find_package(YARP 3.2.102 REQUIRED COMPONENTS os sig dev math cv)
+find_package(OpenCV QUIET)
+option(GAZEBO_YARP_PLUGINS_HAS_OPENCV "Compile plugins that depend on OpenCV" ${OpenCV_FOUND})
+
+if(GAZEBO_YARP_PLUGINS_HAS_OPENCV)
+    find_package(OpenCV REQUIRED)
+    set(YARP_ADDITIONAL_COMPONENTS_REQUIRED "cv")
+else()
+    set(YARP_ADDITIONAL_COMPONENTS_REQUIRED "")
+endif()
+
+find_package(YARP 3.2.102 REQUIRED COMPONENTS os sig dev math ${YARP_ADDITIONAL_COMPONENTS_REQUIRED})
 find_package(Gazebo REQUIRED)
 if (Gazebo_VERSION_MAJOR LESS 7.0)
     message(status "Gazebo version : " ${Gazebo_VERSION_MAJOR}.${Gazebo_VERSION_MINOR}.${Gazebo_VERSION_PATCH})

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -23,9 +23,6 @@ add_subdirectory(showmodelcom)
 add_subdirectory(multicamera)
 add_subdirectory(maissensor)
 
-find_package(OpenCV QUIET)
-option(GAZEBO_YARP_PLUGINS_HAS_OPENCV "Compile plugins that depend on OpenCV" ${OpenCV_FOUND})
-
 if(GAZEBO_YARP_PLUGINS_HAS_OPENCV)
     add_subdirectory(videotexture)
 else()

--- a/plugins/videotexture/CMakeLists.txt
+++ b/plugins/videotexture/CMakeLists.txt
@@ -7,11 +7,6 @@ PROJECT(Plugin_Videotexture)
 
 include(AddGazeboYarpPluginTarget)
 
-
-
-# find opencv dependency
-find_package(OpenCV REQUIRED)
-
 add_gazebo_yarp_plugin_target(LIBRARY_NAME videotexture
                               INCLUDE_DIRS include/gazebo include/yarp/dev
                               SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS}


### PR DESCRIPTION
OpenCV has always been optional for gazebo-yarp-plugins, but it was made a required dependency (transitively by depending on YARP's cv component) in  https://github.com/robotology/gazebo-yarp-plugins/pull/481 .

This PR makes the OpenCV dependency optional again.