### PR TITLE
Avoid useless linking in gazebo_yarp_singleton

### DIFF
--- a/libraries/singleton/CMakeLists.txt
+++ b/libraries/singleton/CMakeLists.txt
@@ -14,7 +14,7 @@ set(Singleton_HEADERS include/GazeboYarpPlugins/Handler.hh
 add_gazebo_yarp_plugin_target(LIBRARY_NAME singleton
                               INCLUDE_DIRS include/GazeboYarpPlugins
                               SYSTEM_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
-                              LINKED_LIBRARIES YARP::YARP_os ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
+                              LINKED_LIBRARIES YARP::YARP_os YARP::YARP_dev ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
                               HEADERS ${Singleton_HEADERS}
                               SOURCES src/Handler.cc
                                       src/ConfHelpers.cc)

--- a/libraries/singleton/CMakeLists.txt
+++ b/libraries/singleton/CMakeLists.txt
@@ -14,7 +14,7 @@ set(Singleton_HEADERS include/GazeboYarpPlugins/Handler.hh
 add_gazebo_yarp_plugin_target(LIBRARY_NAME singleton
                               INCLUDE_DIRS include/GazeboYarpPlugins
                               SYSTEM_INCLUDE_DIRS ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}
-                              LINKED_LIBRARIES ${YARP_LIBRARIES} ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
+                              LINKED_LIBRARIES YARP::YARP_os ${SDFORMAT_LIBRARIES} ${GAZEBO_LIBRARIES} ${PROTOBUF_LIBRARIES} ${Boost_LIBRARIES}
                               HEADERS ${Singleton_HEADERS}
                               SOURCES src/Handler.cc
                                       src/ConfHelpers.cc)


### PR DESCRIPTION
`${YARP_LIBRARIES}` has the peculiar behavior that the contained targets depends on the arguments passed `find_package(YARP ...)` in this project. In particular, if (and only if) `GAZEBO_YARP_PLUGINS_HAS_OPENCV` is enabled, then  also the `YARP::YARP_cv` component of yarp is included, that is not required at all (see https://github.com/robotology/gazebo-yarp-plugins/pull/481).

For this reason, it is better to just link the libraries we actually depend on, otherwise it will be impossible to use `gazebo_yarp_singleton` in a downstream project that do not have the  `YARP::YARP_cv` target defined.

An alternative was to call `find_dependency(YARP ... COMPENENTS cv)` in the config file of `GazeboYARPPlugins` , but this does not make a lot of sense as `YARP::YARP_cv` is not actually a public dependency of any exported library. 