### PR TITLE
laser sensors plugins refactored

### DIFF
--- a/plugins/doublelaser/src/DoubleLaser.cc
+++ b/plugins/doublelaser/src/DoubleLaser.cc
@@ -173,7 +173,6 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpDoubleLaser)
             yError() << "GazeboYarpDoubleLaser: LASERFRONT-CFG group is missing in configuration file";
             return;
         }
-
         doublelaser_dev_parameters.addGroup("LASERFRONT-CFG").fromString(m_parameters.findGroup("LASERFRONT-CFG").toString());
 
         if(!m_parameters.check("LASERBACK-CFG"))
@@ -182,7 +181,10 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpDoubleLaser)
             return;
         }
         doublelaser_dev_parameters.addGroup("LASERBACK-CFG").fromString(m_parameters.findGroup("LASERBACK-CFG").toString());
-
+        
+        if(m_parameters.check("SENSOR")) {doublelaser_dev_parameters.addGroup("SENSOR").fromString(m_parameters.findGroup("SENSOR").toString());}
+        if(m_parameters.check("SKIP"))   {doublelaser_dev_parameters.addGroup("SKIP").fromString(m_parameters.findGroup("SKIP").toString());}
+                
         if(!m_driver_doublelaser.open(doublelaser_dev_parameters) )
         {
             yError()<<"GazeboYarpDoubleLaser: error opening DoubleLaser yarp device ";

--- a/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
+++ b/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
@@ -10,6 +10,7 @@
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IRangefinder2D.h>
 #include <yarp/dev/LaserMeasurementData.h>
+#include <yarp/dev/Lidar2DDeviceBase.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <boost/shared_ptr.hpp>
@@ -37,16 +38,10 @@ namespace gazebo {
     }
 }
 
-struct Range_t
-{
-    double min;
-    double max;
-};
-
 extern const std::string YarpLaserSensorScopedName;
 
 class yarp::dev::GazeboYarpLaserSensorDriver: 
-    public yarp::dev::IRangefinder2D,
+    public yarp::dev::Lidar2DDeviceBase,
     public yarp::dev::IPreciselyTimed,
     public yarp::dev::DeviceDriver
 {
@@ -61,49 +56,30 @@ public:
      */
 
     //DEVICE DRIVER
-    virtual bool open(yarp::os::Searchable& config);
-    virtual bool close();
+    virtual bool open(yarp::os::Searchable& config) override;
+    virtual bool close() override;
 
-    //ANALOG SENSOR
-    virtual bool getLaserMeasurement (std::vector<yarp::dev::LaserMeasurementData> &data);
-    virtual bool getRawData (yarp::sig::Vector &data);
-    virtual bool getDeviceStatus (Device_status &status);
-    virtual bool getDistanceRange (double &min, double &max);
-    virtual bool setDistanceRange (double min, double max);
-    virtual bool getScanLimits (double &min, double &max);
-    virtual bool setScanLimits (double min, double max);
-    virtual bool getHorizontalResolution (double &step);
-    virtual bool setHorizontalResolution (double step);
-    virtual bool getScanRate (double &rate);
-    virtual bool setScanRate (double rate);
-    virtual bool getDeviceInfo (std::string &device_info);
+    //IRangefinder2D
+    virtual bool setDistanceRange (double min, double max) override;
+    virtual bool setScanLimits (double min, double max) override;
+    virtual bool setHorizontalResolution (double step) override;
+    virtual bool setScanRate (double rate) override;
 
     //PRECISELY TIMED
-    virtual yarp::os::Stamp getLastInputStamp();
+    virtual yarp::os::Stamp getLastInputStamp() override;
 
 
 private:
-    double m_max_angle; 
-    double m_min_angle; 
-    double m_max_clip_range; 
-    double m_min_clip_range; 
-    double m_max_discard_range; 
-    double m_min_discard_range;
-    double m_max_gazebo_range; 
-    double m_min_gazebo_range;
-    double m_samples;  
-    double m_resolution;
-    double m_rate; 
-    bool   m_enable_clip_range;
-    bool   m_enable_discard_range;
+    double m_gazebo_max_angle;
+    double m_gazebo_min_angle;
+    double m_gazebo_max_range;
+    double m_gazebo_min_range;
+    double m_gazebo_resolution;
+    size_t m_gazebo_samples;
+    double m_gazebo_scan_rate;
     bool   m_first_run;
     
-    Device_status m_device_status;
-    std::vector <Range_t> range_skip_vector;
-    
-    std::vector<double> m_sensorData; //buffer for laser data
     yarp::os::Stamp m_lastTimestamp; //buffer for last timestamp data
-    std::mutex m_mutex; //mutex for accessing the data
     gazebo::sensors::RaySensor* m_parentSensor;
     gazebo::event::ConnectionPtr m_updateConnection;
 

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -8,7 +8,7 @@
 #include "LaserSensorDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 
-#include <yarp/os/LogStream.h>
+#include <yarp/os/Log.h>
 #include <gazebo/sensors/sensors.hh>
 #include <yarp/os/LogStream.h>
 
@@ -21,17 +21,33 @@ GazeboYarpLaserSensorDriver::~GazeboYarpLaserSensorDriver() {}
 
 /**
  *
- * Export a force/torque sensor.
+ * Export a laser sensor.
  *
- * \todo check forcetorque data
  */
 void GazeboYarpLaserSensorDriver::onUpdate(const gazebo::common::UpdateInfo& _info)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    this->m_parentSensor->Ranges(m_sensorData);
+    std::vector<double> tmp;
+    this->m_parentSensor->Ranges(tmp);
+    
+    if (tmp.size() != m_laser_data.size())
+    {
+        yError() << "size error";
+    }
 
-
+#if 0
+    //looking for an efficient way to convert a std::vector into a yarp::sig::vector
+    double* ptr = m_laser_data.data();
+    ptr = tmp.data();
+#else
+    for (size_t i=0; i< tmp.size(); i++)
+    {
+        m_laser_data[i]=tmp[i];
+    }
+#endif
+    
+    this->applyLimitsOnLaserData();
     m_lastTimestamp.update(_info.simTime.Double());
     m_first_run = false;
     return;
@@ -57,76 +73,22 @@ bool GazeboYarpLaserSensorDriver::open(yarp::os::Searchable& config)
     //Connect the driver to the gazebo simulation
     this->m_updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboYarpLaserSensorDriver::onUpdate, this, _1));
 
+    //this block of parameters is obtained from gazebo
+    m_gazebo_max_angle = m_parentSensor->AngleMax().Degree();            //m_max_angles is expressed in degrees
+    m_gazebo_min_angle = m_parentSensor->AngleMin().Degree();            //m_min_angles is expressed in degrees
+    m_gazebo_max_range = m_parentSensor->RangeMax();                     //m
+    m_gazebo_min_range = m_parentSensor->RangeMin();                     //m
+    m_gazebo_resolution = m_parentSensor->AngleResolution()*180.0/M_PI;  //m_resolution is expressed in degrees
+    m_gazebo_samples   = m_parentSensor->RangeCount();
+    m_gazebo_scan_rate = m_parentSensor->UpdateRate();
 
-    m_max_angle = m_parentSensor->AngleMax().Degree();            //m_max_angles is expressed in degrees
-    m_min_angle = m_parentSensor->AngleMin().Degree();            //m_min_angles is expressed in degrees
-    m_max_gazebo_range = m_parentSensor->RangeMax();              //m
-    m_min_gazebo_range = m_parentSensor->RangeMin();              //m
-    m_resolution = m_parentSensor->AngleResolution()*180.0/M_PI;  //m_resolution is expressed in degrees
-    m_samples   = m_parentSensor->RangeCount();
-    m_rate      = m_parentSensor->UpdateRate();
-
-    m_sensorData.resize(m_samples, 0.0);
-
-    bool bg = config.check("GENERAL");
-    if (bg != false)
+     //parse all the parameters related to the linear/angular range of the sensor
+    if (this->parseConfiguration(config) == false)
     {
-        yarp::os::Searchable& general_config = config.findGroup("GENERAL");
-        if (general_config.check("clip_min_range")==false) {yError() << "Missing clip_min_range"; return false; }
-        m_min_clip_range = general_config.find("clip_min_range").asDouble();
-        if (general_config.check("clip_max_range")==false) {yError() << "Missing clip_max_range"; return false; }
-        m_max_clip_range = general_config.find("clip_max_range").asDouble();
-        if (general_config.check("discard_min_range")==false) {yError() << "Missing discard_min_range"; return false; }
-        m_min_discard_range = general_config.find("discard_min_range").asDouble();
-        if (general_config.check("discard_max_range")==false) {yError() << "Missing discard_max_range"; return false; }
-        m_max_discard_range = general_config.find("discard_max_range").asDouble();
-        if (general_config.check("enable_clip_range")==false) {yError() << "Missing enable_clip_range"; return false; }
-        m_enable_clip_range = (general_config.find("enable_clip_range").asInt32()==1);
-        if (general_config.check("enable_discard_range")==false) {yError() << "Missing enable_discard_range"; return false; }
-        m_enable_discard_range = (general_config.find("enable_discard_range").asInt32()==1);
-
-        if (m_enable_clip_range==true && m_enable_discard_range)
-        {
-            yError() << "enable_clip_range and enable_discard_range both enabled! Choose one";
-            return false;
-        }
-    }
-    else
-    {
-        yError() << "Missing GENERAL section";
+        yError() << "GazeboYarpLaserSensorDriver: error parsing parameters";
         return false;
     }
 
-    bool bs = config.check("SKIP");
-    if (bs != false)
-    {
-        yarp::os::Searchable& skip_config = config.findGroup("SKIP");
-        yarp::os::Bottle mins = skip_config.findGroup("min");
-        yarp::os::Bottle maxs = skip_config.findGroup("max");
-        size_t s_mins = mins.size();
-        size_t s_maxs = mins.size();
-        if (s_mins == s_maxs && s_maxs > 1 )
-        {
-            for (size_t s = 1; s < s_maxs; s++)
-            {
-                Range_t range;
-                range.max = maxs.get(s).asDouble();
-                range.min = mins.get(s).asDouble();
-                if (range.max >= 0 && range.max <= 360 &&
-                    range.min >= 0 && range.min <= 360 &&
-                    range.max > range.min)
-                {
-                    range_skip_vector.push_back(range);
-                    yDebug() << "Laser sensor: skipping angle between" << range.min << "and" << range.max;
-                }
-                else
-                {
-                    yError() << "Invalid range in SKIP section";
-                    return false;
-                }
-            }
-        }
-    }
     return true;
 }
 
@@ -143,156 +105,11 @@ yarp::os::Stamp GazeboYarpLaserSensorDriver::getLastInputStamp()
     return m_lastTimestamp;
 }
 
-bool GazeboYarpLaserSensorDriver::getRawData (yarp::sig::Vector &data)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    ///< \todo TODO in my opinion the reader should care of passing a vector of the proper dimension to the driver, but apparently this is not the case
-    /*
-    if( (int)m_forceTorqueData.size() != YarpForceTorqueChannelsNumber ||
-        (int)out.size() != YarpForceTorqueChannelsNumber ) {
-        return AS_ERROR;
-    }
-    */
-
-   if (m_sensorData.size() != m_samples)
-   {
-       if (m_first_run)
-       {
-          m_device_status = DEVICE_TIMEOUT;
-          return false;
-       }
-       else
-       {
-          m_device_status = DEVICE_GENERAL_ERROR;
-          yError() << "Internal error";
-          return false ;
-       }
-   }
-
-   if (data.size() != m_samples)
-   {
-       data.resize(m_samples);
-   }
-
-    for (unsigned int i=0; i<m_samples; i++)
-    {
-
-      if (m_enable_discard_range)
-      {
-        if (m_sensorData[i]>=m_max_discard_range) m_sensorData[i]=INFINITY;
-        if (m_sensorData[i]<=m_min_discard_range) m_sensorData[i]=INFINITY;
-      }
-      else if (m_enable_clip_range)
-      {
-        if (m_sensorData[i]>=m_max_clip_range) m_sensorData[i]=m_max_clip_range;
-        if (m_sensorData[i]<=m_min_clip_range) m_sensorData[i]=m_min_clip_range;
-      }
-
-      double angle = i * m_resolution;
-      for (size_t s = 0; s < range_skip_vector.size(); s++)
-      {
-        if (angle>=range_skip_vector[s].min && angle <= range_skip_vector[s].max)
-        {
-            m_sensorData[i] = INFINITY;
-            //yDebug() <<"skipping" << s << angle << range_skip_vector[s].min << range_skip_vector[s].max;
-        }
-      }
-      data[i]=m_sensorData[i];
-    }
-
-    m_device_status = DEVICE_OK_IN_USE;
-	return true;
-}
-
-bool GazeboYarpLaserSensorDriver::getLaserMeasurement (std::vector<yarp::dev::LaserMeasurementData> &data)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    ///< \todo TODO in my opinion the reader should care of passing a vector of the proper dimension to the driver, but apparently this is not the case
-    /*
-    if( (int)m_forceTorqueData.size() != YarpForceTorqueChannelsNumber ||
-        (int)out.size() != YarpForceTorqueChannelsNumber ) {
-        return AS_ERROR;
-    }
-    */
-
-   if (m_sensorData.size() != m_samples)
-   {
-       if (m_first_run)
-       {
-          m_device_status = DEVICE_TIMEOUT;
-          return false;
-       }
-       else
-       {
-          m_device_status = DEVICE_GENERAL_ERROR;
-          yError() << "Internal error";
-          return false ;
-       }
-   }
-
-   if (data.size() != m_samples)
-   {
-       data.resize(m_samples);
-   }
-
-    for (unsigned int i=0; i<m_samples; i++)
-    {
-
-      if (m_enable_discard_range)
-      {
-        if (m_sensorData[i]>=m_max_discard_range) m_sensorData[i]=INFINITY;
-        if (m_sensorData[i]<=m_min_discard_range) m_sensorData[i]=INFINITY;
-      }
-      else if (m_enable_clip_range)
-      {
-        if (m_sensorData[i]>=m_max_clip_range) m_sensorData[i]=m_max_clip_range;
-        if (m_sensorData[i]<=m_min_clip_range) m_sensorData[i]=m_min_clip_range;
-      }
-
-      double angle = i * m_resolution;
-      for (size_t s = 0; s < range_skip_vector.size(); s++)
-      {
-        if (angle>=range_skip_vector[s].min && angle <= range_skip_vector[s].max)
-        {
-            m_sensorData[i] = INFINITY;
-            //yDebug() <<"skipping" << s << angle << range_skip_vector[s].min << range_skip_vector[s].max;
-        }
-      }
-      data[i].set_polar(m_sensorData[i],angle);
-    }
-
-    m_device_status = DEVICE_OK_IN_USE;
-    return true;
-}
-
-bool GazeboYarpLaserSensorDriver::getDeviceStatus (Device_status &status)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    status = m_device_status;
-    return true;
-}
-
-bool GazeboYarpLaserSensorDriver::getDistanceRange (double &min, double &max)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    min = m_min_gazebo_range;
-    max = m_max_gazebo_range;
-    return true;
-}
-
 bool GazeboYarpLaserSensorDriver::setDistanceRange (double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yError() << "setDistanceRange() Not yet implemented";
     return false;
-}
-
-bool GazeboYarpLaserSensorDriver::getScanLimits (double &min, double &max)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    min = m_min_angle;
-    max = m_max_angle;
-    return true;
 }
 
 bool GazeboYarpLaserSensorDriver::setScanLimits (double min, double max)
@@ -302,25 +119,11 @@ bool GazeboYarpLaserSensorDriver::setScanLimits (double min, double max)
     return false;
 }
 
-bool GazeboYarpLaserSensorDriver::getHorizontalResolution (double &step)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    step = fabs(m_max_angle-m_min_angle)/m_samples;
-    return true;
-}
-
 bool GazeboYarpLaserSensorDriver::setHorizontalResolution (double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yError() << "setHorizontalResolution() Not yet implemented";
     return false;
-}
-
-bool GazeboYarpLaserSensorDriver::getScanRate (double &rate)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
-    rate = m_rate;
-    return true;
 }
 
 bool GazeboYarpLaserSensorDriver::setScanRate (double rate)
@@ -332,12 +135,6 @@ bool GazeboYarpLaserSensorDriver::setScanRate (double rate)
       return false;
     }
     m_parentSensor->SetUpdateRate(rate);
-    m_rate = rate;
-    return true;
-}
-
-bool GazeboYarpLaserSensorDriver::getDeviceInfo (std::string &device_info)
-{
-    std::lock_guard<std::mutex> guard(m_mutex);
+    m_scan_rate = rate;
     return true;
 }


### PR DESCRIPTION
* laserSensorDriver now derives from Lidar2DDeviceBase
* DoubleLaser is now able to parse [SENSOR] and [SKIP] sections

requires robotology/yarp#2205