### PR TITLE
Fix GitHub Action CI on macOS and other improviments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,14 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest, macOS-latest]
         yarp_version: [yarp-3.3]
         include:
           - os: ubuntu-18.04
-            gazebo_version: [gazebo9, gazebo10]
+            gazebo_version: gazebo9
           - os: ubuntu-20.04
+            gazebo_version: gazebo10
+          - os: ubuntu-latest
             gazebo_version: gazebo11
           - os: macOS-latest
             gazebo_version: gazebo11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,19 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-latest, macOS-latest]
-        gazebo_version: [gazebo9, gazebo10]
-        yarp_version: [devel]
-
+        os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
+        yarp_version: [yarp-3.3]
+        include:
+          - os: ubuntu-18.04
+            gazebo_version: gazebo9
+          - os: ubuntu-18.04
+            gazebo_version: gazebo10
+          - os: ubuntu-20.04
+            gazebo_version: gazebo11
+          - os: macOS-latest
+            gazebo_version: gazebo11
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
         
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
@@ -40,7 +47,7 @@ jobs:
         brew install ace eigen opencv@3 osrf/simulation/${{ matrix.gazebo_version }}
     
     - name: Dependencies [Ubuntu]
-      if: matrix.os == 'ubuntu-latest'
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
@@ -50,13 +57,13 @@ jobs:
         sudo apt-get install lib${{ matrix.gazebo_version }}-dev
         
     - name: Source-based Dependencies [Ubuntu/macOS] 
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         # YCM
         git clone https://github.com/robotology/ycm
         cd ycm
-        git checkout devel
+        git checkout ycm-0.11
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
@@ -76,7 +83,7 @@ jobs:
     # ===================
    
     - name: Configure [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         mkdir -p build
@@ -91,7 +98,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} 
         
     - name: Install [Ubuntu/macOS]
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+      if: contains(matrix.os, 'ubuntu') || matrix.os == 'macOS-latest'
       shell: bash
       run: |
         cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,16 @@ jobs:
     strategy:
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest, macOS-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
         yarp_version: [yarp-3.3]
         include:
           - os: ubuntu-18.04
             gazebo_version: gazebo9
-          - os: ubuntu-20.04
+          # See https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
+          - os: ubuntu-18.04
             gazebo_version: gazebo10
-          - os: ubuntu-latest
+            additional: true
+          - os: ubuntu-20.04
             gazebo_version: gazebo11
           - os: macOS-latest
             gazebo_version: gazebo11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
         combination: [0]
         include:
           - os: ubuntu-18.04
+            combination: 0
             gazebo_version: gazebo9
           - os: ubuntu-18.04
-            gazebo_version: gazebo10
             combination: 1
+            gazebo_version: gazebo10
           - os: ubuntu-20.04
             gazebo_version: gazebo11
           - os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,15 @@ jobs:
         build_type: [Release, Debug]
         os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
         yarp_version: [yarp-3.3]
+        # Dummy value to specify additional combination in the include matrix, see
+        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
+        combination: [0]
         include:
           - os: ubuntu-18.04
             gazebo_version: gazebo9
-          # See https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
           - os: ubuntu-18.04
             gazebo_version: gazebo10
-            additional: true
+            combination: 1
           - os: ubuntu-20.04
             gazebo_version: gazebo11
           - os: macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
         yarp_version: [yarp-3.3]
         include:
           - os: ubuntu-18.04
-            gazebo_version: gazebo9
-          - os: ubuntu-18.04
-            gazebo_version: gazebo10
+            gazebo_version: [gazebo9, gazebo10]
           - os: ubuntu-20.04
             gazebo_version: gazebo11
           - os: macOS-latest


### PR DESCRIPTION
As Gazebo 9 and 10 have been broken on homebrew for a long time (see https://github.com/robotology/robotology-superbuild/issues/420) I think it is just more productive to switch the CI to use Gazebo 11 on macOS . 

Further improvements: 
* Test compilation also on Ubuntu 20.04  
* Use release branches of YARP and YCM instead of the legacy devel  branches that are not going to be updated anymore
* Use fixed version of [`actions/checkout`](https://github.com/actions/checkout) to avoid future regressions