### PR TITLE
Add linkattacher initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - Add external wrench smoothing feature for `externalwrench` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/495)
+- Add the possibility to define initial configuration for `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/497)
 
 ## [3.4.0] - 2020-05-19
 

--- a/plugins/linkattacher/README.md
+++ b/plugins/linkattacher/README.md
@@ -5,8 +5,9 @@ Additionally, this plugin also provides control over _gravity_ of the models spa
 Currently, this plugin is used for coupling the hands of two robots, or those robot model and human model in pHRI experiments. Also, this plugin can be used to attach objects to the robot links.
 
 ### Usage
-Create a `linkattacher.ini` configuration file defining the rpc port name for communicating with the linkattacher plugin, and defining the desired type of joint (optional: default type is `fixed`).
-e.g.
+Create a `.ini` configuration file defining the rpc port name for communicating with the linkattacher plugin, and defining the desired type of joint (optional: default type is `fixed`).
+
+e.g. `linkattacher.ini`
 
 ```
 name /<model-name>/linkattacher/rpc:i
@@ -14,7 +15,7 @@ jointType ball
 ```
 Now, add the following lines to the sdf model
 
-```
+```xml
 <plugin name='link_attacher' filename='libgazebo_yarp_linkattacher.so'>
   <yarpConfigurationFile>model://<path-to-model-configuration-files>/linkattacher.ini</yarpConfigurationFile>
 </plugin>
@@ -26,4 +27,19 @@ The available commands are:
 - `attachUnscoped <parent_model_name> <parent_model_link_name> <child_model_name> <child_model_link_name>`
 - `detachUnscoped <model_name> <link_name>`
 - `enableGravity <model_name> <enable>`
-The `link_name` can be both the scoped or unscoped name of the link.
+
+(The `link_name` can be both the scoped or unscoped name of the link)
+
+### Startup Configuration
+It is possible to apply a set of choosen command at the startup of Gazebo. In order to do so, it is required to add a `[STARTUP]` group in the `.ini` file with the desired commands and argouments.
+
+e.g.
+```
+name /<model-name>/linkattacher/rpc:i
+jointType ball
+
+[STARTUP]
+attachUnscoped <parent_model_name> <link1> <child_model_name> <link2>
+attachUnscoped <parent_model_name> <link3> <child_model_name> <link4>
+enableGravity  <model_name> <enable>
+```

--- a/plugins/linkattacher/src/linkattacher.cc
+++ b/plugins/linkattacher/src/linkattacher.cc
@@ -88,8 +88,6 @@ void LinkAttacher::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 
   if(m_parameters.check("STARTUP"))
   {
-      yInfo() << LogPrefix << "Applying commands at startup";
-
       yarp::os::Bottle startupConfig = m_parameters.findGroup("STARTUP");
 
       for(size_t i=1; i<startupConfig.size(); i++)

--- a/plugins/linkattacher/src/linkattacher.cc
+++ b/plugins/linkattacher/src/linkattacher.cc
@@ -86,5 +86,35 @@ void LinkAttacher::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     return;
   }
 
+  if(m_parameters.check("STARTUP"))
+  {
+      yInfo() << LogPrefix << "Applying commands at startup";
+
+      yarp::os::Bottle startupConfig = m_parameters.findGroup("STARTUP");
+
+      for(size_t i=1; i<startupConfig.size(); i++)
+      {
+          if(startupConfig.get(i).check("attachUnscoped") && startupConfig.get(i).find("attachUnscoped").isList() && startupConfig.get(i).find("attachUnscoped").asList()->size()==4)
+          {
+              yarp::os::Bottle* attachConfigList = startupConfig.get(i).find("attachUnscoped").asList();
+              m_la_server.attachUnscoped(attachConfigList->get(0).asString(), attachConfigList->get(1).asString(), attachConfigList->get(2).asString(), attachConfigList->get(3).asString());
+          }
+          else if(startupConfig.get(i).check("detachUnscoped") && startupConfig.get(i).find("detachUnscoped").isList() && startupConfig.get(i).find("detachUnscoped").asList()->size()==2)
+          {
+              yarp::os::Bottle* detachConfigList = startupConfig.get(i).find("detachUnscoped").asList();
+              m_la_server.detachUnscoped(detachConfigList->get(0).asString(), detachConfigList->get(1).asString());
+          }
+          else if(startupConfig.get(i).check("enableGravity") && startupConfig.get(i).find("enableGravity").isList() && startupConfig.get(i).find("enableGravity").asList()->size()==2)
+          {
+              yarp::os::Bottle* enableGravityConfigList = startupConfig.get(i).find("enableGravity").asList();
+              m_la_server.enableGravity(enableGravityConfigList->get(0).asString(), enableGravityConfigList->get(1).asBool());
+          }
+          else
+          {
+              yWarning() << LogPrefix << "Failed to load startup configuration line [" << i << "]";
+          }
+      }
+  }
+
   m_la_server.yarp().attachAsServer(*m_rpcport);
 }


### PR DESCRIPTION
This PR adds the possibility to apply a desired set of `linkattacher` command at the startup.

The usage documentation can be found in [`plugins/linkattacher/README.md#startup-configuration`](https://github.com/lrapetti/gazebo-yarp-plugins/blob/add-linkattacher-initialization/plugins/linkattacher/README.md#startup-configuration).