### PR TITLE
Implement limits for coupled joints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Fixed wrong measurements feedback used for coupled joints in `gazebo_yarp_controlboard`(https://github.com/robotology/gazebo-yarp-plugins/pull/492).
+- Fixed mismatched behavior, with respect to the real robot, of coupling handler FingersAbductionCouplingHandler in 'gazebo_yarp_controlboard' plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/499)
 
 ### Added
 - Add external wrench smoothing feature for `externalwrench` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/495)
 - Add the possibility to define initial configuration for `linkattacher` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/497)
+- Add the possibility to specify limits for coupled joints for `gazebo_yarp_controlboard` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/499)
 
 ## [3.4.0] - 2020-05-19
 

--- a/plugins/controlboard/CMakeLists.txt
+++ b/plugins/controlboard/CMakeLists.txt
@@ -33,11 +33,12 @@ set(controlBoard_source     src/ControlBoard.cc
 
 set(controlBoard_headers    include/gazebo/ControlBoard.hh
                             include/yarp/dev/ControlBoardDriver.h
+                            include/yarp/dev/ControlBoardDriverRange.h
                             include/yarp/dev/ControlBoardDriverTrajectory.h
                             include/yarp/dev/ControlBoardDriverCoupling.h)
-                            
-                            
-                            
+
+
+
 add_gazebo_yarp_plugin_target(LIBRARY_NAME controlboard
                               INCLUDE_DIRS include/gazebo include/yarp/dev
                               SYSTEM_INCLUDE_DIRS ${GAZEBO_YARP_COMMON_HEADERS} ${Boost_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS}  ${SDFORMAT_INCLUDE_DIRS} ${PROTOBUF_INCLUDE_DIRS}

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -471,6 +471,8 @@ private:
     bool setPositionsToleranceRevolute();
     bool setPositionsToleranceLinear();
 
+    bool isValidUserDOF(int joint_index);
+
     bool findMotorControlGroup(yarp::os::Bottle& motorControlGroup_bot) const;
 
     bool check_joint_within_limits_override_torque(int i, double&ref );

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -472,6 +472,8 @@ private:
     bool setPositionsToleranceLinear();
 
     bool isValidUserDOF(int joint_index);
+    void setUserDOFLimit(int joint_index, const double& min, const double& max);
+    void getUserDOFLimit(int joint_index, double& min, double& max);
 
     bool findMotorControlGroup(yarp::os::Bottle& motorControlGroup_bot) const;
 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -25,6 +25,7 @@
 #include <yarp/os/Stamp.h>
 
 #include <boost/shared_ptr.hpp>
+#include <ControlBoardDriverRange.h>
 #include <ControlBoardDriverTrajectory.h>
 #include <ControlBoardDriverCoupling.h>
 
@@ -347,12 +348,6 @@ private:
         JointType_Unknown = 0,
         JointType_Revolute,
         JointType_Prismatic
-    };
-
-    struct Range {
-        Range() : min(0), max(0){}
-        double min;
-        double max;
     };
 
     std::string m_deviceName;

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -7,7 +7,11 @@
 #ifndef GAZEBOYARP_COUPLING_H
 #define GAZEBOYARP_COUPLING_H
 
+#include <ControlBoardDriverRange.h>
+
 #include <gazebo/physics/Model.hh>
+
+#include <unordered_map>
 
 namespace yarp {
     namespace dev {
@@ -24,10 +28,11 @@ protected:
     gazebo::physics::Model* m_robot;
     yarp::sig::VectorOf<int> m_coupledJoints;
     std::vector<std::string> m_coupledJointNames;
+    std::unordered_map<int, Range> m_coupledJointLimits;
     unsigned int m_controllerPeriod;
     unsigned int m_couplingSize;
-    BaseCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
-    
+    BaseCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
+
 public:
     virtual ~BaseCouplingHandler();
 
@@ -43,13 +48,16 @@ public:
     virtual yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref) = 0;
     virtual yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref) = 0;
     virtual yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref) = 0;
+
+    virtual void setCoupledJointLimit(int joint, const double& min, const double& max);
+    virtual void getCoupledJointLimit(int joint, double& min, double& max);
 };
 
 class EyesCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    EyesCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    EyesCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -66,7 +74,7 @@ class ThumbCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    ThumbCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    ThumbCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -83,7 +91,7 @@ class IndexCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    IndexCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    IndexCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -100,7 +108,7 @@ class MiddleCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    MiddleCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    MiddleCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -117,7 +125,7 @@ class PinkyCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    PinkyCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    PinkyCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -134,7 +142,7 @@ class FingersAbductionCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    FingersAbductionCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    FingersAbductionCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -151,7 +159,7 @@ class CerHandCouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    CerHandCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    CerHandCouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);
@@ -168,7 +176,7 @@ class HandMk3CouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names);
+    HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverRange.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverRange.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2013-2015 Fondazione Istituto Italiano di Tecnologia RBCS & iCub Facility & ADVR
+ * Authors: see AUTHORS file.
+ * CopyPolicy: Released under the terms of the LGPLv2.1 or any later version, see LGPL.TXT or LGPL3.TXT
+ */
+
+#ifndef GAZEBOYARP_CONTROLBOARDDRIVERRANGE_HH
+#define GAZEBOYARP_CONTROLBOARDDRIVERRANGE_HH
+
+struct Range {
+    Range() : min(0), max(0){}
+    double min;
+    double max;
+};
+
+#endif

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -177,6 +177,28 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         m_velocity_watchdog[j] = new Watchdog(0.200); //watchdog set to 200ms
     }
 
+    yDebug() << "done";
+    for (size_t j = 0; j < m_numberOfJoints; ++j)
+    {
+        m_controlMode[j] = VOCAB_CM_POSITION;
+        m_interactionMode[j] = VOCAB_IM_STIFF;
+        m_jointTypes[j] = JointType_Unknown;
+        m_isMotionDone[j] = true;
+    }
+    // End zeroing of vectors
+
+    // This must be after zeroing of vectors
+    if(!configureJointType() )
+        return false;
+
+    if (!setMinMaxPos())
+    {
+        yError()<<"Failed to get joint limits";
+        return false;
+    }
+
+    // This must be after calling setMinMaxPos as we need to access m_jointPosLimits variables
+    // once they are initialized
     yarp::os::Bottle& coupling_group_bottle = m_pluginParameters.findGroup("COUPLING");
     if (!coupling_group_bottle.isNull())
     {
@@ -192,7 +214,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         {
             yarp::os::Bottle* coupling_bottle = coupling_group_bottle.get(cnt).asList();
 
-            if (coupling_bottle == 0 || coupling_bottle->size() != 3)
+            if (coupling_bottle == 0 || (coupling_bottle->size() != 3 && coupling_bottle->size() != 5))
             {
                 yError() << "Error parsing coupling parameter"; return false;
             }
@@ -215,55 +237,98 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
                 yError() << "Error parsing coupling parameter, wrong size of the joint names list";
                 return false;
             }
+            std::size_t number_coupled_joints = 0;
             for (int is=0;is<b2->size();is++) {
-                coupled_joint_names.push_back(b2->get(is).asString());
+                const std::string& joint_name = b2->get(is).asString();
+                coupled_joint_names.push_back(joint_name);
+
+                if (joint_name != "reserved")
+                    number_coupled_joints++;
+            }
+
+            // Fill limits for coupled joints
+            std::vector<Range> coupled_joint_limits;
+            if (coupling_bottle->size() == 5)
+            {
+                // Min limits of coupled joints.
+                Bottle* b3 = coupling_bottle->get(3).asList();
+                if (b3==0 || b3->size()!=number_coupled_joints)
+                {
+                    yError() << "Error parsing coupling parameter, wrong size of the joint min limits list";
+                    return false;
+                }
+
+                // Max limits of coupled joints.
+                Bottle* b4 = coupling_bottle->get(4).asList();
+                if (b4==0 || b4->size()!=number_coupled_joints)
+                {
+                    yError() << "Error parsing coupling parameter, wrong size of the joint max limits list";
+                    return false;
+                }
+
+                // Populate vector of limits
+                for (std::size_t i=0; i<b3->size(); i++)
+                {
+                    Range range;
+                    range.min = b3->get(i).asDouble();
+                    range.max = b4->get(i).asDouble();
+
+                    coupled_joint_limits.push_back(range);
+                }
+            }
+            else
+            {
+                yWarning() << "The coupling handler entry does not specify coupled limits. The limits available in the [LIMITS] section will be employed instead. Please consider filling up the limits section in the coupling handler to avoid misbheaviors.";
+
+                for (unsigned int i = 0; i < coupled_joints.size(); ++i)
+                    coupled_joint_limits.push_back(m_jointPosLimits[coupled_joints[i]]);
             }
 
             if (coupling_bottle->get(0).asString()=="eyes_vergence_control")
             {
-                BaseCouplingHandler* cpl = new EyesCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new EyesCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using eyes_vergence_control";
             }
             else if (coupling_bottle->get(0).asString()=="fingers_abduction_control")
             {
-                BaseCouplingHandler* cpl = new FingersAbductionCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new FingersAbductionCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using fingers_abduction_control";
             }
             else if (coupling_bottle->get(0).asString()=="thumb_control")
             {
-                BaseCouplingHandler* cpl = new ThumbCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new ThumbCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using thumb_control";
             }
             else if (coupling_bottle->get(0).asString()=="index_control")
             {
-                BaseCouplingHandler* cpl = new IndexCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new IndexCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using index_control";
             }
             else if (coupling_bottle->get(0).asString()=="middle_control")
             {
-                BaseCouplingHandler* cpl = new MiddleCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new MiddleCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using middle_control";
             }
             else if (coupling_bottle->get(0).asString()=="pinky_control")
             {
-                BaseCouplingHandler* cpl = new PinkyCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new PinkyCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using pinky_control";
             }
             else if (coupling_bottle->get(0).asString()=="cer_hand")
             {
-                BaseCouplingHandler* cpl = new CerHandCouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new CerHandCouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using cer_hand_control";
             }
             else if (coupling_bottle->get(0).asString()=="icub_hand_mk3")
             {
-                BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names);
+                BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yInfo() << "using icub_hand_mk3";
             }
@@ -279,26 +344,6 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
 
         }
     }
-    yDebug() << "done";
-    for (size_t j = 0; j < m_numberOfJoints; ++j)
-    {
-        m_controlMode[j] = VOCAB_CM_POSITION;
-        m_interactionMode[j] = VOCAB_IM_STIFF;
-        m_jointTypes[j] = JointType_Unknown;
-        m_isMotionDone[j] = true;
-    }
-    // End zeroing of vectors
-
-    // This must be after zeroing of vectors
-    if(!configureJointType() )
-        return false;
-
-    if (!setMinMaxPos())
-    {
-        yError()<<"Failed to get joint limits";
-        return false;
-    }
-
 
     if (!setMinMaxVel())
     {

--- a/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
@@ -110,12 +110,16 @@ bool GazeboYarpControlBoardDriver::changeControlMode(const int j, const int mode
     resetAllPidsForJointAtIndex(j);
     m_controlMode[j] = desired_mode;
 
+    // get limits for trajectory generation
+    double limit_min, limit_max;
+    getUserDOFLimit(j, limit_min, limit_max);
+
     // mode specific switching actions
     switch (desired_mode) {
         case VOCAB_CM_POSITION :
             m_jntReferencePositions[j] = m_positions[j];
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
-            m_trajectory_generator[j]->setLimits(m_jointPosLimits[j].min,m_jointPosLimits[j].max);
+            m_trajectory_generator[j]->setLimits(limit_min, limit_max);
             m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
             break;
         case VOCAB_CM_POSITION_DIRECT :
@@ -131,7 +135,7 @@ bool GazeboYarpControlBoardDriver::changeControlMode(const int j, const int mode
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             m_jntReferenceVelocities[j] = 0.0;
             m_speed_ramp_handler[j]->stop();
-            m_trajectory_generator[j]->setLimits(m_jointPosLimits[j].min,m_jointPosLimits[j].max);
+            m_trajectory_generator[j]->setLimits(limit_min, limit_max);
             m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
             break;
         case VOCAB_CM_TORQUE :

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -23,11 +23,23 @@ using namespace yarp::dev;
 // BaseCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-BaseCouplingHandler::BaseCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
+BaseCouplingHandler::BaseCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
 {
     m_robot = model;
     m_coupledJoints=coupled_joints;
     m_coupledJointNames=coupled_joint_names;
+
+    // Configure a map between coupled joints and limits
+    for (std::size_t i = 0, j = 0; i < coupled_joints.size(); i++)
+    {
+        const int coupled_joint_index = coupled_joints(i);
+        const std::string coupled_joint_name = getCoupledJointName(coupled_joint_index);
+        if (coupled_joint_name != "gyp_invalid" && coupled_joint_name != "reserved")
+        {
+            m_coupledJointLimits[coupled_joints[i]] = coupled_joint_limits[j];
+            j++;
+        }
+    }
     //m_couplingSize = m_coupledJoints.size();
 }
 
@@ -65,12 +77,34 @@ std::string BaseCouplingHandler::getCoupledJointName(int joint)
     }
 }
 
+void BaseCouplingHandler::setCoupledJointLimit(int joint, const double& min, const double& max)
+{
+    const std::string coupled_joint_name = getCoupledJointName(joint);
+
+    if (coupled_joint_name != "reserved" && coupled_joint_name != "gyp_invalid")
+    {
+        m_coupledJointLimits.at(joint).min = min;
+        m_coupledJointLimits.at(joint).max = max;
+    }
+}
+
+void BaseCouplingHandler::getCoupledJointLimit(int joint, double& min, double& max)
+{
+    const std::string coupled_joint_name = getCoupledJointName(joint);
+
+    if (coupled_joint_name != "reserved" && coupled_joint_name != "gyp_invalid")
+    {
+        min = m_coupledJointLimits.at(joint).min;
+        max = m_coupledJointLimits.at(joint).max;
+    }
+}
+
 //------------------------------------------------------------------------------------------------------------------
 // EyesCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-EyesCouplingHandler::EyesCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+EyesCouplingHandler::EyesCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize = 2;
 }
@@ -139,8 +173,8 @@ yarp::sig::Vector EyesCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_re
 // ThumbCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-ThumbCouplingHandler::ThumbCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+ThumbCouplingHandler::ThumbCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize = 4;
 }
@@ -209,8 +243,8 @@ yarp::sig::Vector ThumbCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_r
 // IndexCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-IndexCouplingHandler::IndexCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+IndexCouplingHandler::IndexCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize = 3;
 }
@@ -276,8 +310,8 @@ yarp::sig::Vector IndexCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_r
 // MiddleCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-MiddleCouplingHandler::MiddleCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+MiddleCouplingHandler::MiddleCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize=3;
 }
@@ -343,8 +377,8 @@ yarp::sig::Vector MiddleCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_
 // PinkyCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-PinkyCouplingHandler::PinkyCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+PinkyCouplingHandler::PinkyCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize=6;
 }
@@ -419,8 +453,8 @@ yarp::sig::Vector PinkyCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_r
 // FingersAbductionCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-FingersAbductionCouplingHandler::FingersAbductionCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+FingersAbductionCouplingHandler::FingersAbductionCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize = 4;
 }
@@ -490,8 +524,8 @@ yarp::sig::Vector FingersAbductionCouplingHandler::decoupleRefTrq (yarp::sig::Ve
 // CerHandCouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-CerHandCouplingHandler::CerHandCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names)
+CerHandCouplingHandler::CerHandCouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits)
 {
     m_couplingSize = 4;
 }
@@ -570,8 +604,8 @@ yarp::sig::Vector CerHandCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq
 // HandMk3CouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names)
-: BaseCouplingHandler(model, coupled_joints,coupled_joint_names), LUTSIZE(4096)
+HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits), LUTSIZE(4096)
 {
     const double RAD2DEG = 180.0/atan2(0.0,-1.0);
     const double DEG2RAD = 1.0/RAD2DEG;

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -61,7 +61,7 @@ std::string BaseCouplingHandler::getCoupledJointName(int joint)
     }
     else
     {
-        return std::string("invalid");
+        return std::string("gyp_invalid");
     }
 }
 

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -462,14 +462,14 @@ FingersAbductionCouplingHandler::FingersAbductionCouplingHandler(gazebo::physics
 bool FingersAbductionCouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
-    current_pos[m_coupledJoints[0]] = current_pos[m_coupledJoints[3]];
+    current_pos[m_coupledJoints[0]] = (20.0 - current_pos[m_coupledJoints[2]])*3;
     return true;
 }
 
 bool FingersAbductionCouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
-    current_vel[m_coupledJoints[0]] = current_vel[m_coupledJoints[3]];
+    current_vel[m_coupledJoints[0]] = -current_vel[m_coupledJoints[2]]*3;
     return true;
 }
 
@@ -477,7 +477,7 @@ bool FingersAbductionCouplingHandler::decoupleAcc (yarp::sig::Vector& current_ac
 {
 
     if (m_coupledJoints.size()!=m_couplingSize) return false;
-    current_acc[m_coupledJoints[0]] = current_acc[m_coupledJoints[3]];
+    current_acc[m_coupledJoints[0]] = -current_acc[m_coupledJoints[2]]*3;
     return true;
 }
 
@@ -491,10 +491,10 @@ yarp::sig::Vector FingersAbductionCouplingHandler::decoupleRefPos (yarp::sig::Ve
 {
     yarp::sig::Vector out = pos_ref;
     if (m_coupledJoints.size()!=m_couplingSize) {yError() << "FingersAbductionCouplingHandler: Invalid coupling vector"; return out;}
-    out[m_coupledJoints[0]] = -pos_ref[m_coupledJoints[0]]/2;
+    out[m_coupledJoints[0]] = -(20.0 - pos_ref[m_coupledJoints[0]]/3);
     out[m_coupledJoints[1]] = 0.0;
-    out[m_coupledJoints[2]] = pos_ref[m_coupledJoints[0]]/2;
-    out[m_coupledJoints[3]] = pos_ref[m_coupledJoints[0]];
+    out[m_coupledJoints[2]] = 20.0 - pos_ref[m_coupledJoints[0]]/3;
+    out[m_coupledJoints[3]] = 20.0 - pos_ref[m_coupledJoints[0]]/3;
     return out;
 }
 
@@ -502,10 +502,10 @@ yarp::sig::Vector FingersAbductionCouplingHandler::decoupleRefVel (yarp::sig::Ve
 {
     yarp::sig::Vector out = vel_ref;
     if (m_coupledJoints.size()!=m_couplingSize) {yError() << "FingersAbductionCouplingHandler: Invalid coupling vector"; return out;}
-    out[m_coupledJoints[0]] = -vel_ref[m_coupledJoints[0]]/2;
+    out[m_coupledJoints[0]] = vel_ref[m_coupledJoints[0]]/3;
     out[m_coupledJoints[1]] = 0.0;
-    out[m_coupledJoints[2]] = vel_ref[m_coupledJoints[0]]/2;
-    out[m_coupledJoints[3]] = vel_ref[m_coupledJoints[0]];
+    out[m_coupledJoints[2]] = -vel_ref[m_coupledJoints[0]]/3;
+    out[m_coupledJoints[3]] = -vel_ref[m_coupledJoints[0]]/3;
     return out;
 }
 
@@ -513,10 +513,10 @@ yarp::sig::Vector FingersAbductionCouplingHandler::decoupleRefTrq (yarp::sig::Ve
 {
     yarp::sig::Vector out =trq_ref;
     if (m_coupledJoints.size()!=m_couplingSize) {yError() << "FingersAbductionCouplingHandler: Invalid coupling vector"; return out;}
-    out[m_coupledJoints[0]] = -trq_ref[m_coupledJoints[0]]/2;
+    out[m_coupledJoints[0]] = trq_ref[m_coupledJoints[0]]/3;
     out[m_coupledJoints[1]] = 0.0;
-    out[m_coupledJoints[2]] = trq_ref[m_coupledJoints[0]]/2;
-    out[m_coupledJoints[3]] = trq_ref[m_coupledJoints[0]];
+    out[m_coupledJoints[2]] = -trq_ref[m_coupledJoints[0]]/3;
+    out[m_coupledJoints[3]] = -trq_ref[m_coupledJoints[0]]/3;
     return out;
 }
 

--- a/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
@@ -49,13 +49,17 @@ bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::Inter
     resetAllPidsForJointAtIndex(j);
     m_interactionMode[j] = static_cast<int>(mode);
 
+    // get limits for trajectory generation
+    double limit_min, limit_max;
+    getUserDOFLimit(j, limit_min, limit_max);
+
     //the following code (copy and pasted from changeControlMode) is used to reset control references / trajectory generator to the current position etc.
     switch (m_controlMode[j])
     {
         case VOCAB_CM_POSITION :
             m_jntReferencePositions[j] = m_positions[j];
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
-            m_trajectory_generator[j]->setLimits(m_jointPosLimits[j].min,m_jointPosLimits[j].max);
+            m_trajectory_generator[j]->setLimits(limit_min, limit_max);
             m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
             break;
         case VOCAB_CM_POSITION_DIRECT :
@@ -69,7 +73,7 @@ bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::Inter
             m_jntReferencePositions[j] = m_positions[j];
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             m_jntReferenceVelocities[j] = 0.0;
-            m_trajectory_generator[j]->setLimits(m_jointPosLimits[j].min,m_jointPosLimits[j].max);
+            m_trajectory_generator[j]->setLimits(limit_min, limit_max);
             m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
             break;
         case VOCAB_CM_TORQUE :

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -47,16 +47,14 @@ bool GazeboYarpControlBoardDriver::getLimits(int axis, double *min, double *max)
 {
     if (axis < 0 || static_cast<size_t>(axis) >= m_numberOfJoints) return false;
     if (!min || !max) return false;
-    *min = m_jointPosLimits[axis].min;
-    *max = m_jointPosLimits[axis].max;
+    getUserDOFLimit(axis, *min, *max);
     return true;
 }
 
 bool GazeboYarpControlBoardDriver::setLimits(int axis, double min, double max) //WORKS
 {
     if (axis < 0 || static_cast<size_t>(axis) >= m_numberOfJoints) return false;
-    m_jointPosLimits[axis].max = max;
-    m_jointPosLimits[axis].min = min;
+    setUserDOFLimit(axis, min, max);
     return true;
 }
 

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -158,3 +158,31 @@ bool GazeboYarpControlBoardDriver::isValidUserDOF(int joint_index)
 
     return true;
 }
+
+void GazeboYarpControlBoardDriver::setUserDOFLimit(int joint_index, const double& min, const double& max)
+{
+    if (m_coupling_handler.size() > 0 && m_coupling_handler[0]->checkJointIsCoupled(joint_index))
+    {
+        // Only the case of 1 coupling handler is supported
+        m_coupling_handler[0]->setCoupledJointLimit(joint_index, min, max);
+    }
+    else
+    {
+        m_jointPosLimits[joint_index].max = max;
+        m_jointPosLimits[joint_index].min = min;
+    }
+}
+
+void GazeboYarpControlBoardDriver::getUserDOFLimit(int joint_index, double& min, double& max)
+{
+    // Only the case of 1 coupling handler is supported
+    if (m_coupling_handler.size() > 0 && m_coupling_handler[0]->checkJointIsCoupled(joint_index))
+    {
+        m_coupling_handler[0]->getCoupledJointLimit(joint_index, min, max);
+    }
+    else
+    {
+        min = m_jointPosLimits[joint_index].min;
+        max = m_jointPosLimits[joint_index].max;
+    }
+}

--- a/plugins/controlboard/src/ControlBoardDriverOthers.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverOthers.cpp
@@ -137,3 +137,24 @@ bool GazeboYarpControlBoardDriver::calibrationDone(int j) // NOT IMPLEMENTED
     yDebug("fakebot: calibration done on joint %d.\n", j);
     return true;
 }
+
+bool GazeboYarpControlBoardDriver::isValidUserDOF(int joint_index)
+{
+    if (m_coupling_handler.size() > 0)
+    {
+        // Only the case of 1 coupling handler is supported
+        const std::string coupled_joint_name = m_coupling_handler[0]->getCoupledJointName(joint_index);
+
+        // The joint *is not* part of the coupled group
+        // hence it is a normal and *valid* jont from the user point of view
+        if (coupled_joint_name == "gyp_invalid")
+            return true;
+
+        // The joint *is* part of the coupled group but is reserved
+        // hence it cannot be commanded by the user and is invalid
+        if (coupled_joint_name == "reserved")
+            return false;
+    }
+
+    return true;
+}

--- a/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
@@ -15,7 +15,10 @@ bool GazeboYarpControlBoardDriver::positionMove(int j, double ref) //WORKS
     if (j >= 0 && static_cast<size_t>(j) < m_numberOfJoints)
     {
         m_trajectoryGenerationReferencePosition[j] = ref; //we will use this m_trajectoryGenerationReferencePosition in the next simulation onUpdate call to ask gazebo to set PIDs m_trajectoryGenerationReferencePosition to this value
-        m_trajectory_generator[j]->setLimits(m_jointPosLimits[j].min,m_jointPosLimits[j].max);
+
+        double limit_min, limit_max;
+        getUserDOFLimit(j, limit_min, limit_max);
+        m_trajectory_generator[j]->setLimits(limit_min, limit_max);
         m_trajectory_generator[j]->initTrajectory (m_positions[j], m_trajectoryGenerationReferencePosition[j], m_trajectoryGenerationReferenceSpeed[j]);
         return true;
     }


### PR DESCRIPTION
### Limits for coupled joints

This PR aims at adding support for limits for joints having coupling within the `controlboard`  plugin.

A bit of context: at the moment, a sample configuration file of a part to be controlled with the `controlboard` is as follows

```
(...)

[WRAPPER]

joints 6

(...)

[COUPLING]
name_coupling_handler (3 4 5) (name_3 name_4 reserved)

(...)

[LIMITS]
jntPosMax max_0 max_1 max_2 max_3 max_4 max_5
jntPosMin min_0 min_1 min_2 min_3 min_4 min_5

(...)
```
In this example there are 6 joints. Joints with indexes from 3 to 5 are coupled and the user can only control the joint `name_3` and `name_4` which couples joints 4 and 5 (hence the string `reserved`).

Limits are specified in the section `LIMITS` and correctly used within the `controlboard` in some parts, e.g., to enforce torque limits in https://github.com/robotology/gazebo-yarp-plugins/blob/927874bf4184ee1136f7b6061d20572c3db27300/plugins/controlboard/src/ControlBoardDriver.cpp#L1382

The same limits are used to specify the boundaries of the trajectory generators and to implement `ControlBoardWrapper::getLimits`. However, the limits required in these two features, corresponding to the DoFs that the user can effectively control, are different from the limits indicated in `[LIMITS]` if some joints are coupled. Indeed, trajectories are not generated for all the joints actually controlled by Gazebo but only for their coupled counterparts and then the trajectories are converted according to the behavior coded in the `name_coupling_handler` code.

This PR proposes to change the `[COUPLING]` section of the configuration file to

```
(...)

[COUPLING]
name_coupling_handler (3 4 5) (name_3 name_4 reserved) (min_3 min_4) (max_3 max_4)

(...)

```
I.e. the user **needs** to specify the limits for the DoF that they can actually control excluding those indicated as `reserved`. For the remaining joints, that are not part of the coupling section, the limits specified in `[LIMITS]` are used as in the past. The reasons why limits must be specified by the user and cannot be evaluated automatically can be find in the closed PR #472, https://github.com/robotology/gazebo-yarp-plugins/pull/472#issuecomment-635251078

In order to simplify the review, a summary of the changes required to implement this behavior:
- the struct `Range` is moved from `ControlBoardDriver.h` to `ControlBoardDriverRange.h` so that it is available in other parts of the code
- the base class `BaseCouplingHandler` accepts a new mandatory parameter containing the limits of the coupled joints
- method `GazeboYarpControlBoardDriver::isValidUserDOF` is implemented in order to clearly identify DoFs for which a trajectory generator has to be configured (i.e. to skip useless computation for `reserved` joints)
- methods `GazeboYarpControlBoardDriver::{set, get}UserDOFLimit` are implemented in order to set/get the right limit for each joint, being it normal or coupled and avoiding glue code
- limits for coupled joints are loaded in `GazeboYarpControlBoardDriver::gazebo_init`
- correct limits are now employed in `GazeboYarpControlBoardDriver::{resetPositionsAndTrajectoryGenerators, changeControlMode, changeInteractionMode, setLimits, getLimits, positionMove}`
- the `CHANGELOG` still needs to be changed (waiting for the review of the PR)

In order to implement these changes, it is required that configuration files in `https://github.com/robotology/icub-gazebo/tree/master/icub/conf`, `https://github.com/robotology/icub-models/tree/master/iCub/conf` and `https://github.com/robotology/cer-sim/tree/master/gazebo/cer/conf` are reviewed. Other robots like `https://github.com/vislab-tecnico-lisboa/vizzy` might be involved as well.

In some parts of the code I had to limit the implementation with the assumption that at most one coupling handler is available. This is why it is not clear to me/I think it is better to discuss how to handle limits for coupled joints if more than one handler per controlled part is present. By looking at the configuration files I only found multiple coupling handlers in https://github.com/robotology/icub-gazebo/blob/master/icub/conf/gazebo_icub_left_hand_fingers.ini. However, this is not used in any of the model as the solution of having multiple plugins for each finger has been preferred over that of having of a single plugin for all the fingers.

### New behavior of coupling handler FingersAbductionCouplingHandler

Within this PR the behavior of the coupling handler `FingersAbductionCouplingHandler` is changed in order to reflect that the , on the real robot, abduction is minimum when the associated DoF is commanded to `60.0` and maximum when commanded to `0.0` (while, at the moment, the reversed behavior is implemented).

Fixes #348 #474 