### PR TITLE
Avoid to append GAZEBO_CXX_FLAGS to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ if(MSVC)
     add_definitions(-D__TBB_NO_IMPLICIT_LINKAGE=1)
 endif()
 
-
-# Add Gazebo CXX flags, to support Gazebo 6 reckless dependency on C++11
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
-
 # On Windows, export all symbols by default as *nix
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 


### PR DESCRIPTION
GAZEBO_CXX_FLAGS was added to CMAKE_CXX_FLAGS in https://github.com/robotology/gazebo-yarp-plugins/pull/190 to support compilation against Gazebo 6 that required C++11, and unfortunately since then Gazebo did not switch to a modern way of specifying C++ standard requirement in consuming libraries. Now that YARP requires C++14, passing GAZEBO_CXX_FLAGS  (that contains `-std=c++11`) basically bypass the CMake logic to compute the correct C++ standard with which to compile the plugins, and forces to compile them with C++11. 

As the only reason for which GAZEBO_CXX_FLAGS was added to CMAKE_CXX_FLAGS was to enable C++11 support, and as that is already passed as a requirement by YARP targets, I think we can just remove it.

Related SDFormat PR: https://github.com/osrf/sdformat/pull/251 .
Fix https://github.com/robotology/robotology-superbuild/issues/426 .