### PR TITLE
Fix continuous integration on devel branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         build_type: [Release, Debug]
         os: [ubuntu-18.04, ubuntu-20.04, macOS-latest]
-        yarp_version: [yarp-3.3]
+        yarp_version: [master]
         # Dummy value to specify additional combination in the include matrix, see
         # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations
         combination: [0]


### PR DESCRIPTION
The devel branch now requires YARP 3.4 .