### PR TITLE
[plugins][maissensor] Fix discrepancy of MAIS analog sensor between simulation and real robot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ### Fixed
 - Fixed wrong measurements feedback used for coupled joints in `gazebo_yarp_controlboard`(https://github.com/robotology/gazebo-yarp-plugins/pull/492).
 - Fixed mismatched behavior, with respect to the real robot, of coupling handler FingersAbductionCouplingHandler in 'gazebo_yarp_controlboard' plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/499)
+- Fixed mismatched behavior, with respect to the real robot, of mais analog sensors in 'gazebo_yarp_maissensor' plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/500)
 
 ### Added
 - Add external wrench smoothing feature for `externalwrench` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/495)

--- a/plugins/maissensor/include/yarp/dev/MaisSensorDriver.h
+++ b/plugins/maissensor/include/yarp/dev/MaisSensorDriver.h
@@ -92,7 +92,14 @@ private:
         JointType_Revolute,
         JointType_Prismatic
     };
-    
+
+    struct Range
+    {
+        Range() : min(0), max(0){}
+        double min;
+        double max;
+    };
+
     std::string deviceName;
     gazebo::physics::Model* m_robot;
     gazebo::event::ConnectionPtr m_updateConnection;
@@ -103,7 +110,7 @@ private:
 
     yarp::sig::Vector m_positions; /**< joint positions [Degrees] */
     unsigned int m_numberOfJoints; /**< number of joints controlled by the control board */
-
+    std::vector<Range> m_jointPositionLimits;
 
     yarp::os::Stamp m_lastTimestamp; /**< timestamp, updated with simulation time at each onUpdate call */
 
@@ -125,6 +132,7 @@ private:
      * Private methods
      */
     bool configureJointType();
+    void configureJointsLimits();
     bool setJointNames();  //WORKS
 
     virtual int read(yarp::sig::Vector &out);


### PR DESCRIPTION
Fixed mismatched behavior, with respect to the real robot, of MAIS analog sensors output

Output is constrained to be between 0 and 255, the former is reached when the joint is >= maximum value, the latter when the joint is <= its minimum value

Maximum and minimum values are obtained from Gazebo hw limits.

Fixes #476 