### PR TITLE
Declared properly the Bind placeholders (_1, _2, ...) with the boost::placeholders namespace

### DIFF
--- a/plugins/clock/src/Clock.cc
+++ b/plugins/clock/src/Clock.cc
@@ -8,6 +8,7 @@
 #include "Clock.hh"
 #include "ClockServerImpl.h"
 
+#include <boost/bind/bind.hpp>
 #include <gazebo/gazebo_config.h>
 #include <gazebo/common/Events.hh>
 #include <gazebo/physics/PhysicsEngine.hh>
@@ -21,6 +22,8 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <iostream>
+
+using namespace boost::placeholders;
 
 namespace gazebo
 {

--- a/plugins/forcetorque/src/ForceTorqueDriver.cpp
+++ b/plugins/forcetorque/src/ForceTorqueDriver.cpp
@@ -8,9 +8,12 @@
 #include "ForceTorqueDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 
+#include <boost/bind/bind.hpp>
 #include <gazebo/sensors/ForceTorqueSensor.hh>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
+using namespace boost::placeholders;
 
 using namespace yarp::dev;
 

--- a/plugins/imu/src/IMUDriver.cpp
+++ b/plugins/imu/src/IMUDriver.cpp
@@ -9,9 +9,12 @@
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
 
+#include <boost/bind/bind.hpp>
 #include <gazebo/sensors/ImuSensor.hh>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
+using namespace boost::placeholders;
 
 using namespace yarp::dev;
 

--- a/plugins/inertialmtbPart/src/inertialMTBPartDriver.cpp
+++ b/plugins/inertialmtbPart/src/inertialMTBPartDriver.cpp
@@ -9,9 +9,12 @@
 #include <GazeboYarpPlugins/Handler.hh>
 #include <GazeboYarpPlugins/common.h>
 
+#include <boost/bind/bind.hpp>
 #include <gazebo/sensors/ImuSensor.hh>
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
+
+using namespace boost::placeholders;
 
 using namespace yarp::dev;
 

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -8,9 +8,12 @@
 #include "LaserSensorDriver.h"
 #include <GazeboYarpPlugins/Handler.hh>
 
+#include <boost/bind/bind.hpp>
 #include <yarp/os/LogStream.h>
 #include <gazebo/sensors/sensors.hh>
 #include <yarp/os/LogStream.h>
+
+using namespace boost::placeholders;
 
 using namespace yarp::dev;
 


### PR DESCRIPTION
This fixes #504 .

More precisely...
The practice of declaring the Bind placeholders (_1, _2, ...) in the global
namespace is deprecated. Use <boost/bind/bind.hpp> + using namespace boost::placeholders,
or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.
(Refer to Boost 1.73 release notes https://www.boost.org/users/history/version_1_73_0.html)