### PR TITLE
Add velocityControlImplementationType option to gazebo_yarp_controlboard plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Added
+- Add `velocityControlImplementationType` option to the `VELOCITY_CONTROL` group of the `gazebo_yarp_controlboard` plugin
+  configuration. This option permits to switch between `direct_velocity_pid`, that is using a velocity PID for the Velocity Control Mode
+  (what has been implemented until now) and `integrator_and_position_pid` that uses an integrator that integrates the velocity reference and then uses the position low level PID, similarly to what is implement on real YARP-powered robot such as iCub or R1.
+  The setting is now optional and if not present will default to `direct_velocity_pid`, but it will be compulsory in
+  gazebo-yarp-plugins 4.x (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
+
+### Fixed 
+- Fixed use of the `VOCAB_CM_MIXED` control mode when the physics timestep is different from 1 millisecond (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
+
 ## [3.5.0] - 2020-08-26
 
 ### Added

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -413,6 +413,8 @@ private:
     std::vector<BaseCouplingHandler*>  m_coupling_handler;
     std::vector<RampFilter*> m_speed_ramp_handler;
     std::vector<Watchdog*> m_velocity_watchdog;
+    std::vector<Watchdog*> m_velocityControl;
+
 
     yarp::sig::Vector m_trajectoryGenerationReferencePosition; /**< reference position for trajectory generation in position mode [Degrees] */
     yarp::sig::Vector m_trajectoryGenerationReferenceSpeed; /**< reference speed for trajectory generation in position mode [Degrees/Seconds]*/
@@ -428,7 +430,18 @@ private:
 
     std::vector<gazebo::common::PID> m_impedancePosPDs;
 
+    enum VelocityControlImplementationType {
+        // DirectVelocityPID: use a low level velocity PID
+        DirectVelocityPID,
+        // IntegratorAndPositionPID: integrate the velocity reference
+        // and use the low level Position PID already used for the
+        // IPositionDirect implementation
+        IntegratorAndPositionPID
+    };
+    VelocityControlImplementationType m_velocity_control_type{DirectVelocityPID};
     std::vector<std::string> m_position_control_law;
+    // Type of the velocity low level control, ignored
+    // if m_velocity_control_type is IntegratorAndPositionPID
     std::vector<std::string> m_velocity_control_law;
     std::vector<std::string> m_impedance_control_law;
     std::vector<std::string> m_torque_control_law;
@@ -460,7 +473,7 @@ private:
     bool configureJointType();
     bool setMinMaxPos();  //NOT TESTED
     bool setMinMaxVel();
-    bool setJointNames();  //WORKS
+    bool setJointNames();
     bool setPIDsForGroup(std::string, PIDMap::mapped_type&, enum PIDFeedbackTerm pidTerms);
     bool setPIDsForGroup_POSITION(  std::vector<std::string>& control_law, PIDMap::mapped_type&);
     bool setPIDsForGroup_VELOCITY(  std::vector<std::string>& control_law, PIDMap::mapped_type&);

--- a/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
@@ -127,6 +127,9 @@ bool GazeboYarpControlBoardDriver::changeControlMode(const int j, const int mode
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             break;
         case VOCAB_CM_VELOCITY :
+            if (m_velocity_control_type == IntegratorAndPositionPID) {
+                m_jntReferencePositions[j] = m_positions[j];
+            }
             m_jntReferenceVelocities[j] = 0.0;
             m_speed_ramp_handler[j]->stop();
             break;


### PR DESCRIPTION
This option permits to switch between using a velocity PID for the Velocity Control Mode (what has been implemented until now) or the use of an integrator that integrates the velocity reference and then uses the position low level PID.

The setting is now optional and if not present will default to `direct_velocity_pid`, but it will be compulsory in gazebo-yarp-plugins 4.x .

Fix https://github.com/robotology/gazebo-yarp-plugins/issues/240 .