### PR TITLE
Fix handling of velocityControlImplementationType option in gazebo_yarp_controlboard

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -1046,11 +1046,11 @@ bool GazeboYarpControlBoardDriver::setPIDsForGroup_VELOCITY(std::vector<std::str
 
         // Check velocityControlImplementationType value
         // If not present, default to direct_velocity_pid for now
-        if (m_pluginParameters.find("velocityControlImplementationType").isNull()) {
+        if (pidGroup.find("velocityControlImplementationType").isNull()) {
             yWarning("VELOCITY_CONTROL: 'velocityControlImplementationType' param missing. "
                      " Using the default value of 'direct_velocity_pid', but the parameter will be compulsory gazebo-yarp-plugins 4.");
         } else {
-            std::string velocityControlImplementationType = m_pluginParameters.find("velocityControlImplementationType").toString();
+            std::string velocityControlImplementationType = pidGroup.find("velocityControlImplementationType").toString();
 
             if (velocityControlImplementationType == "direct_velocity_pid") {
                 m_velocity_control_type = DirectVelocityPID;


### PR DESCRIPTION
The option was added in https://github.com/robotology/gazebo-yarp-plugins/pull/514 and it is meant to be present in the `VELOCITY_CONTROL` group, but before this fix it was checked as part of the global plugin parameter space.