### PR TITLE
Fix crash when gazebo_yarp_controlboard is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed 
 - Fixed use of the `VOCAB_CM_MIXED` control mode when the physics timestep is different from 1 millisecond (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
+- Fixed missing initialization of a pointer in `gazebo_yarp_controlboard` . In some cases this was causing crashes when a model that contained a `gazebo_yarp_controlboard` 
+  plugin was removed from the simulation (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
 
 ## [3.5.0] - 2020-08-26
 

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -24,7 +24,7 @@ namespace gazebo
 GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
 
     GazeboYarpControlBoard::GazeboYarpControlBoard() : m_iWrap(0),
-                                                       m_iVirtAnalogSensorWrap(0)
+                                                       m_iVirtAnalogSensorWrap(nullptr)
     {}
 
     GazeboYarpControlBoard::~GazeboYarpControlBoard()

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -23,7 +23,8 @@ namespace gazebo
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
 
-    GazeboYarpControlBoard::GazeboYarpControlBoard() : m_iWrap(0)
+    GazeboYarpControlBoard::GazeboYarpControlBoard() : m_iWrap(0),
+                                                       m_iVirtAnalogSensorWrap(0)
     {}
 
     GazeboYarpControlBoard::~GazeboYarpControlBoard()


### PR DESCRIPTION
This is a regression introduced in https://github.com/robotology/gazebo-yarp-plugins/pull/403 . When a `gazebo_yarp_controlboard`  was closed, a pointer was checked if it was 0, but if the configuration flag `useVirtualAnalogSensor` was set to false, the pointer was not initialized, so it could be different from 0 even if it was not a valid pointer. 