### PR TITLE
Fix spelling error in ControlBoardDriverVirtualAnalogSensor

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriverVirtualAnalogSensor.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverVirtualAnalogSensor.cpp
@@ -16,7 +16,7 @@ namespace yarp {
             if (ch < 0 || ch >= this->getVirtualAnalogSensorChannels())
             {
                 yError() << "GazeboYarpControlBoardDriver: VirtualAnalogServer: getState failed: requested channel " << ch << 
-                            "while the client is configured wtih " << this->getVirtualAnalogSensorChannels() << "channels";
+                            "while the client is configured with " << this->getVirtualAnalogSensorChannels() << "channels";
             
                 return VAS_status::VAS_ERROR;
             }


### PR DESCRIPTION
Address pending review from https://github.com/robotology/gazebo-yarp-plugins/pull/403.