### PR TITLE
Use nullptr for initialization of pointer objects of wrappers in ControlBoard instead of 0

### DIFF
--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -23,14 +23,14 @@ namespace gazebo
 
 GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
 
-    GazeboYarpControlBoard::GazeboYarpControlBoard() : m_iWrap(0)
+    GazeboYarpControlBoard::GazeboYarpControlBoard() : m_iWrap(nullptr)
     {}
 
     GazeboYarpControlBoard::~GazeboYarpControlBoard()
     {
         if (m_iWrap) {
             m_iWrap->detachAll();
-            m_iWrap = 0;
+            m_iWrap = nullptr;
         }
 
         if (m_wrapper.isValid()) {
@@ -40,7 +40,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
         if (m_iVirtAnalogSensorWrap) 
         {
             m_iVirtAnalogSensorWrap->detachAll();
-            m_iVirtAnalogSensorWrap = 0;
+            m_iVirtAnalogSensorWrap = nullptr;
         }
         
         if (m_virtAnalogSensorWrapper.isValid())


### PR DESCRIPTION
Change constructor initialization and destructor assignment from 0 to `nullptr` for `m_iWrap` and `m_iVirtAnalogSensorWrap`.

Can be rebased merged after #517.