### PR TITLE
Fix compilation on homebrew by updating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       shell: bash
       run: |
         brew cask install xquartz
+        brew update
+        brew upgrade
         brew install ace eigen opencv@3 osrf/simulation/${{ matrix.gazebo_version }}
     
     - name: Dependencies [Ubuntu]


### PR DESCRIPTION
Since the last week, the CI on macOS/Homebrew started failing complaining that the protobuf version used by some ignition-libraries is different from the installed one. As there is no such problem on the robotology-superbuild CI, I guess the problem is that the homebrew in the GitHub Actions image has the old protobuf (3.13), while the bottles installed by the https://github.com/osrf/homebrew-simulation reference to the new protobuf (3.14). 

This PR adds the `brew update`/`brew upgrade` steps to CI to fix the build on macOS/Homebrew.
