### PR TITLE
Add trapezoidal speed trajectory generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ build*/
 *.kdev4
 
 .DS_Store
-
+.project
+.cproject
+.settings/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Added
+- Add `refSpeed` and `refAcceleration` options to the `TRAJECTORY_GENERATION` group of the `gazebo_yarp_controlboard` plugin
+  configuration. They are expected to hold exactly n_joints values (an error is reported otherwise) describing reference speeds
+  and accelerations, respectively, for use by the selected trajectory generator (if necessary).
+- Add `trapezoidal_speed` as a new supported value for option `trajectory_type` of the `gazebo_yarp_controlboard` plugin
+  configuration. This generator enables the trajectory to follow a trapezoidal speed profile in position control mode, limited
+  by provided reference speed (saturation) and acceleration (both ramps) values. If already executing a trajectory in this manner,
+  newly generated trajectories take into account previous joint velocities and update the motion accordingly.
+
 ## [3.5.1] - 2020-10-05
 
 ### Added
@@ -15,9 +24,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
   The setting is now optional and if not present will default to `direct_velocity_pid`, but it will be compulsory in
   gazebo-yarp-plugins 4.x (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
 
-### Fixed 
+### Fixed
 - Fixed use of the `VOCAB_CM_MIXED` control mode when the physics timestep is different from 1 millisecond (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
-- Fixed missing initialization of a pointer in `gazebo_yarp_controlboard` . In some cases this was causing crashes when a model that contained a `gazebo_yarp_controlboard` 
+- Fixed missing initialization of a pointer in `gazebo_yarp_controlboard` . In some cases this was causing crashes when a model that contained a `gazebo_yarp_controlboard`
   plugin was removed from the simulation (https://github.com/robotology/gazebo-yarp-plugins/pull/514).
 
 ## [3.5.0] - 2020-08-26
@@ -37,12 +46,12 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [3.4.2] - 2020-08-25
 
-### Fixed 
+### Fixed
 - Removed Windows end of lines (https://github.com/robotology/gazebo-yarp-plugins/pull/507).
 
 ## [3.4.1] - 2020-08-24
 
-### Fixed 
+### Fixed
 - Fixed compilation with Boost 1.73 (https://github.com/robotology/gazebo-yarp-plugins/pull/505).
 
 ## [3.4.0] - 2020-05-19

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriver.h
@@ -255,7 +255,7 @@ public:
     virtual bool setRefCurrents(const int n_joint, const int *joints, const double *t) override;
     virtual bool getRefCurrents(double *t) override;
     virtual bool getRefCurrent(int j, double *t) override;
-    
+
     // Virtual Analog Sensor Interface
     virtual VAS_status getVirtualAnalogSensorStatus(int ch) override;
     virtual int getVirtualAnalogSensorChannels() override;
@@ -290,7 +290,7 @@ public:
     /*
      * Probably useless stuff here
      */
-    
+
     //AMPLIFIER CONTROL (inside comanOthers.cpp)
     virtual bool enableAmp(int j) override; //NOT IMPLEMENTED
     virtual bool disableAmp(int j) override; //NOT IMPLEMENTED
@@ -390,7 +390,7 @@ private:
 
     yarp::sig::VectorOf<JointType> m_jointTypes;
     yarp::sig::Vector m_amp;
-    
+
     //Desired Control variables
     yarp::sig::Vector m_jntReferencePositions; /**< desired reference positions.
                                                  Depending on the position mode,
@@ -418,7 +418,7 @@ private:
 
     yarp::sig::Vector m_trajectoryGenerationReferencePosition; /**< reference position for trajectory generation in position mode [Degrees] */
     yarp::sig::Vector m_trajectoryGenerationReferenceSpeed; /**< reference speed for trajectory generation in position mode [Degrees/Seconds]*/
-    yarp::sig::Vector m_trajectoryGenerationReferenceAcceleration; /**< reference acceleration for trajectory generation in position mode. Currently NOT USED in trajectory generation! [Degrees/Seconds^2] */
+    yarp::sig::Vector m_trajectoryGenerationReferenceAcceleration; /**< reference acceleration for trajectory generation in position mode [Degrees/Seconds^2] */
 
     std::vector<std::string> m_jointNames;
     std::vector<std::string> controlboard_joint_names;
@@ -459,7 +459,7 @@ private:
     bool* m_isMotionDone;
     int * m_controlMode;
     int * m_interactionMode;
-    
+
     bool m_useVirtualAnalogSensor = false;
     bool m_started;
     int m_clock;
@@ -473,6 +473,7 @@ private:
     bool configureJointType();
     bool setMinMaxPos();  //NOT TESTED
     bool setMinMaxVel();
+    bool setTrajectoryReferences();
     bool setJointNames();
     bool setPIDsForGroup(std::string, PIDMap::mapped_type&, enum PIDFeedbackTerm pidTerms);
     bool setPIDsForGroup_POSITION(  std::vector<std::string>& control_law, PIDMap::mapped_type&);

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
@@ -109,6 +109,8 @@ private:
     double m_tb;
     double m_tf;
     double m_tick;
+    double m_v0;
+    double m_computed_reference_velocity;
 
     double p_computeTrajectoryStep();
 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverTrajectory.h
@@ -16,7 +16,8 @@ namespace yarp {
         enum TrajectoryType
         {
             TRAJECTORY_TYPE_CONST_SPEED = 0,
-            TRAJECTORY_TYPE_MIN_JERK = 1
+            TRAJECTORY_TYPE_MIN_JERK = 1,
+            TRAJECTORY_TYPE_TRAP_SPEED = 2
         };
     }
 }
@@ -60,6 +61,7 @@ protected:
     double m_x0;
     double m_xf;
     double m_speed;
+    double m_acceleration;
     double m_computed_reference;
     double m_controllerPeriod;
     double m_joint_min;
@@ -68,7 +70,7 @@ protected:
 
 public:
     virtual ~TrajectoryGenerator();
-    virtual bool initTrajectory (double current_pos, double final_pos, double speed) = 0;
+    virtual bool initTrajectory(double current_pos, double final_pos, double speed, double acceleration) = 0;
     virtual bool abortTrajectory(double limit) = 0;
     virtual double computeTrajectory() = 0;
     virtual double computeTrajectoryStep() = 0;
@@ -87,9 +89,31 @@ private:
     double p_computeTrajectory();
     double p_computeTrajectoryStep();
     bool   p_abortTrajectory (double limit);
-      
+
 public:
-    bool initTrajectory(double current_pos, double final_pos, double speed);
+    bool initTrajectory(double current_pos, double final_pos, double speed, double acceleration);
+    bool abortTrajectory(double limit);
+    double computeTrajectory();
+    double computeTrajectoryStep();
+    yarp::dev::TrajectoryType getTrajectoryType();
+};
+
+class TrapezoidalSpeedTrajectoryGenerator: public TrajectoryGenerator
+{
+public:
+    TrapezoidalSpeedTrajectoryGenerator(gazebo::physics::Model* model);
+    virtual ~TrapezoidalSpeedTrajectoryGenerator();
+
+private:
+    double m_ta;
+    double m_tb;
+    double m_tf;
+    double m_tick;
+
+    double p_computeTrajectoryStep();
+
+public:
+    bool initTrajectory(double current_pos, double final_pos, double speed, double acceleration);
     bool abortTrajectory(double limit);
     double computeTrajectory();
     double computeTrajectoryStep();
@@ -116,13 +140,13 @@ private:
     double p_computeTrajectory();
     double p_computeTrajectoryStep();
     bool   p_abortTrajectory (double limit);
-        
+
     double p_compute_p5f(double t);
     double p_compute_p5f_vel(double t);
     double p_compute_current_vel();
 
 public:
-    bool initTrajectory(double current_pos, double final_pos, double speed);
+    bool initTrajectory(double current_pos, double final_pos, double speed, double acceleration);
     bool abortTrajectory(double limit);
     double computeTrajectory();
     double computeTrajectoryStep();

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -128,7 +128,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
     m_useVirtualAnalogSensor = m_pluginParameters.check("useVirtualAnalogSensor", yarp::os::Value(false)).asBool();
 
     VectorOf<int> trajectory_generator_type;
-    trajectory_generator_type.resize(m_numberOfJoints);
+    trajectory_generator_type.resize(m_numberOfJoints, yarp::dev::TRAJECTORY_TYPE_MIN_JERK);
 
     yarp::os::Bottle& traj_bottle = m_pluginParameters.findGroup("TRAJECTORY_GENERATION");
     if (!traj_bottle.isNull())
@@ -137,26 +137,20 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         if (!traj_type.isNull())
         {
             std::string traj_type_s = traj_type.get(1).asString();
-            if      (traj_type_s == "minimum_jerk")      {for (size_t i = 0; i < m_numberOfJoints; ++i) {trajectory_generator_type[i] = yarp::dev::TRAJECTORY_TYPE_MIN_JERK;}}
-            else if (traj_type_s == "constant_speed")    {for (size_t i = 0; i < m_numberOfJoints; ++i) {trajectory_generator_type[i] = yarp::dev::TRAJECTORY_TYPE_CONST_SPEED;}}
+            if      (traj_type_s == "constant_speed")    {for (size_t i = 0; i < m_numberOfJoints; ++i) {trajectory_generator_type[i] = yarp::dev::TRAJECTORY_TYPE_CONST_SPEED;}}
             else if (traj_type_s == "trapezoidal_speed") {for (size_t i = 0; i < m_numberOfJoints; ++i) {trajectory_generator_type[i] = yarp::dev::TRAJECTORY_TYPE_TRAP_SPEED;}}
-            else                                         {for (size_t i = 0; i < m_numberOfJoints; ++i) {trajectory_generator_type[i] = yarp::dev::TRAJECTORY_TYPE_MIN_JERK;}}
+            else if (traj_type_s == "minimum_jerk")      {/* default */}
+            else                                         {yError() << "Unsupported trajectory_type:" << traj_type_s; return false;}
+            yDebug() << "trajectory_type:" << traj_type_s;
         }
         else
         {
             yWarning() << "Missing TRAJECTORY_GENERATION group. Missing trajectory_type param. Assuming minimum_jerk";
-            for (size_t i = 0; i < m_numberOfJoints; ++i) {
-                trajectory_generator_type[i]=yarp::dev::TRAJECTORY_TYPE_MIN_JERK;
-            }
         }
     }
     else
     {
         yWarning() << "Missing trajectory_type param. Assuming minimum_jerk";
-        for(size_t i = 0; i < m_numberOfJoints; ++i)
-        {
-            trajectory_generator_type[i]=yarp::dev::TRAJECTORY_TYPE_MIN_JERK;
-        }
     }
 
     for (size_t j = 0; j < m_numberOfJoints; ++j)

--- a/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverControlMode.cpp
@@ -120,7 +120,10 @@ bool GazeboYarpControlBoardDriver::changeControlMode(const int j, const int mode
             m_jntReferencePositions[j] = m_positions[j];
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             m_trajectory_generator[j]->setLimits(limit_min, limit_max);
-            m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
+            m_trajectory_generator[j]->initTrajectory(m_positions[j],
+                                                      m_trajectoryGenerationReferencePosition[j],
+                                                      m_trajectoryGenerationReferenceSpeed[j],
+                                                      m_trajectoryGenerationReferenceAcceleration[j]);
             break;
         case VOCAB_CM_POSITION_DIRECT :
             m_jntReferencePositions[j] = m_positions[j];
@@ -139,7 +142,10 @@ bool GazeboYarpControlBoardDriver::changeControlMode(const int j, const int mode
             m_jntReferenceVelocities[j] = 0.0;
             m_speed_ramp_handler[j]->stop();
             m_trajectory_generator[j]->setLimits(limit_min, limit_max);
-            m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
+            m_trajectory_generator[j]->initTrajectory(m_positions[j],
+                                                      m_trajectoryGenerationReferencePosition[j],
+                                                      m_trajectoryGenerationReferenceSpeed[j],
+                                                      m_trajectoryGenerationReferenceAcceleration[j]);
             break;
         case VOCAB_CM_TORQUE :
         case VOCAB_CM_PWM :

--- a/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverInteractionMode.cpp
@@ -60,7 +60,10 @@ bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::Inter
             m_jntReferencePositions[j] = m_positions[j];
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             m_trajectory_generator[j]->setLimits(limit_min, limit_max);
-            m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
+            m_trajectory_generator[j]->initTrajectory(m_positions[j],
+                                                      m_trajectoryGenerationReferencePosition[j],
+                                                      m_trajectoryGenerationReferenceSpeed[j],
+                                                      m_trajectoryGenerationReferenceAcceleration[j]);
             break;
         case VOCAB_CM_POSITION_DIRECT :
             m_jntReferencePositions[j] = m_positions[j];
@@ -74,7 +77,10 @@ bool GazeboYarpControlBoardDriver::changeInteractionMode(int j, yarp::dev::Inter
             m_trajectoryGenerationReferencePosition[j] = m_positions[j];
             m_jntReferenceVelocities[j] = 0.0;
             m_trajectory_generator[j]->setLimits(limit_min, limit_max);
-            m_trajectory_generator[j]->initTrajectory(m_positions[j],m_trajectoryGenerationReferencePosition[j],m_trajectoryGenerationReferenceSpeed[j]);
+            m_trajectory_generator[j]->initTrajectory(m_positions[j],
+                                                      m_trajectoryGenerationReferencePosition[j],
+                                                      m_trajectoryGenerationReferenceSpeed[j],
+                                                      m_trajectoryGenerationReferenceAcceleration[j]);
             break;
         case VOCAB_CM_TORQUE :
         case VOCAB_CM_PWM :

--- a/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverPositionControl.cpp
@@ -19,7 +19,10 @@ bool GazeboYarpControlBoardDriver::positionMove(int j, double ref) //WORKS
         double limit_min, limit_max;
         getUserDOFLimit(j, limit_min, limit_max);
         m_trajectory_generator[j]->setLimits(limit_min, limit_max);
-        m_trajectory_generator[j]->initTrajectory (m_positions[j], m_trajectoryGenerationReferencePosition[j], m_trajectoryGenerationReferenceSpeed[j]);
+        m_trajectory_generator[j]->initTrajectory(m_positions[j],
+                                                  m_trajectoryGenerationReferencePosition[j],
+                                                  m_trajectoryGenerationReferenceSpeed[j],
+                                                  m_trajectoryGenerationReferenceAcceleration[j]);
         return true;
     }
     return false;


### PR DESCRIPTION
The `TrapezoidalSpeedTrajectoryGenerator` class is added for use by `GazeboYarpControlBoardDriver`. It is meant to generate a trapezoidal profile capped at the provided reference speed and using fixed acceleration in both ramps. The signature of `TrajectoryGenerator::initTrajectory` has been expanded to accomodate said reference acceleration value. This generator is also capable of appending new trajectories to ongoing joint motion, that is, whenever a setpoint is updated (e.g. by issuing a `positionMove` command while a previous one has not yet completed), last computed joint velocity is used to calculate the initial motion of the new trajectory.

In order to configure a control board to use this new generator, set the `TRAJECTORY_GENERATION::trajectory_type` property to `trapezoidal_speed`.

Additional changes:
* `GazeboYarpControlBoardDriver` has learned to fetch reference speed and acceleration data from initial configuration via `TRAJECTORY_GENERATION::refSpeed` and `TRAJECTORY_GENERATION::refAcceleration` properties, respectively. Existing code has been factored out and conveniently improved in a new `setTrajectoryReferences` method.
* Previous defaults have been preserved, except for now using `0.01` m/s² as max acceleration for prismatic joints.
* The control board no longer silently falls back to `minimum_jerk` if an unsupported value was passed to `TRAJECTORY_GENERATION::trajectory_type`; an error is reported instead.
* The code that initializes `trajectory_type` from config has been slightly simplified and now reports is value in a `yDebug` line.
* Added IDE-related stuff to *.gitignore* (Eclipse & VS Code).