### PR TITLE
Disable tests on macOS on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} 
       
     - name: Test
+      # Workaround for https://github.com/robotology/gazebo-yarp-plugins/issues/530
+      if: contains(matrix.os, 'ubuntu')
       shell: bash
       run: |
         cd build


### PR DESCRIPTION
Workaround for https://github.com/robotology/gazebo-yarp-plugins/issues/530 .