### PR TITLE
[modelposepublisher] Fix broken link in documentation

### DIFF
--- a/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
+++ b/plugins/modelposepublisher/include/gazebo/ModelPosePublisher.hh
@@ -107,7 +107,7 @@ namespace gazebo
     ///
     /// This plugin __does not__ support [Gazebo nested models](http://gazebosim.org/tutorials?tut=nested_model&cat=build_robot)
     /// since the method `gazebo::physics::WorldPose()` does not work properly
-    /// with nested models (see [issue](https://bitbucket.org/osrf/gazebo/issues/2410/wrong-gazebo-physics-model-worldpose-for")).
+    /// with nested models (see [issue](https://github.com/osrf/gazebo/issues/2410")).
     ///
     class GazeboYarpModelPosePublisher : public ModelPlugin
     {


### PR DESCRIPTION
After #539 and after taking a look at the documentation, I realized that the documentation of plugin `modelposepublisher` contains a link pointing to a Gazebo issue stored in the old bitbucket codebase (and now not accessible since that repository on bitbucket "does not have issue tracking enabled").

I checked on GitHub and the issue is still open. Hence, this PR updates the link to the issue.