### PR TITLE
Fix for getDevicesAsPolyDriverList method used by libYARP_robotinterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed 
+- Fixed use of libYARP_robotinterface with YARP devices spawned by sensor plugins (https://github.com/robotology/gazebo-yarp-plugins/pull/544).
+
 
 ## [3.6.0] - 2021-02-24
 

--- a/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
+++ b/libraries/singleton/include/GazeboYarpPlugins/Handler.hh
@@ -145,7 +145,11 @@ public:
      * If after removing the scope two devices have the same yarpDeviceName, the getModelDevicesAsPolyDriverList
      * prints an error and returns false, while true is returned if everything works as expected.
      */
+    bool getDevicesAsPolyDriverList(const std::string& modelScopedName, yarp::dev::PolyDriverList& list, std::vector<std::string>& deviceScopedNames, const std::string& worldName);
+    
+    // Deprecated variant of getDevicesAsPolyDriverList
     bool getDevicesAsPolyDriverList(const std::string& modelScopedName, yarp::dev::PolyDriverList& list, std::vector<std::string>& deviceScopedNames);
+
     
     /** 
      * \brief Decrease the usage count for the devices that are acquired with the getDevicesAsPolyDriverList

--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -236,8 +236,15 @@ inline bool startsWith(const std::string&completeString,
     // https://stackoverflow.com/a/40441240
     return (completeString.rfind(candidatePrefix, 0) == 0);
 } 
+    
+bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yarp::dev::PolyDriverList& list, 
+                                         std::vector<std::string>& deviceScopedNames)
+{
+    return getDevicesAsPolyDriverList(modelScopedName, list, deviceScopedNames, "default");
+}
 
-bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yarp::dev::PolyDriverList& list, std::vector<std::string>& deviceScopedNames)
+bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yarp::dev::PolyDriverList& list, 
+                                         std::vector<std::string>& deviceScopedNames, const std::string& worldName)
 {
     deviceScopedNames.resize(0);
 
@@ -253,9 +260,9 @@ bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yar
         std::string yarpDeviceName;
         
         // If the deviceDatabaseKey starts with the modelScopedName (device spawned by model plugins), 
-        // or by  "default::" + modelScopedName (device spawned by sensor plugins) then it is eligible for insertion
+        // or by  worldName + "::" + modelScopedName (device spawned by sensor plugins) then it is eligible for insertion
         // in the returned list
-        if (startsWith(deviceDatabaseKey, modelScopedName) || startsWith(deviceDatabaseKey, "default::" + modelScopedName)) {
+        if (startsWith(deviceDatabaseKey, modelScopedName) || startsWith(deviceDatabaseKey, worldName + "::" + modelScopedName)) {
             // Extract yarpDeviceName from deviceDatabaseKey
             yarpDeviceName = deviceDatabaseKey.substr(deviceDatabaseKey.find_last_of(":")+1);
 

--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -252,9 +252,10 @@ bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yar
 
         std::string yarpDeviceName;
         
-        // If the deviceDatabaseKey starts with the modelScopedName, then it is eligible for insertion
+        // If the deviceDatabaseKey starts with the modelScopedName (device spawned by model plugins), 
+        // or by  "default::" + modelScopedName (device spawned by sensor plugins) then it is eligible for insertion
         // in the returned list
-        if (startsWith(deviceDatabaseKey, modelScopedName)) {
+        if (startsWith(deviceDatabaseKey, modelScopedName) || startsWith(deviceDatabaseKey, "default::" + modelScopedName)) {
             // Extract yarpDeviceName from deviceDatabaseKey
             yarpDeviceName = deviceDatabaseKey.substr(deviceDatabaseKey.find_last_of(":")+1);
 

--- a/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
+++ b/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
@@ -86,7 +86,8 @@ void GazeboYarpRobotInterface::Load(physics::ModelPtr _parentModel, sdf::Element
 
     // Extract externalDriverList of  devices from the one that have been already opened in the Gazebo model by other gazebo_yarp plugins 
     yarp::dev::PolyDriverList externalDriverList;
-    GazeboYarpPlugins::Handler::getHandler()->getDevicesAsPolyDriverList(_parentModel->GetScopedName(), externalDriverList, m_deviceScopedNames);
+    GazeboYarpPlugins::Handler::getHandler()->getDevicesAsPolyDriverList(_parentModel->GetScopedName(), externalDriverList, 
+                                                                         m_deviceScopedNames, _parentModel->GetWorld()->Name());
 
     // Set external devices from the one that have been already opened in the Gazebo model by other gazebo_yarp plugins 
     bool ok = m_xmlRobotInterfaceResult.robot.setExternalDevices(externalDriverList);

--- a/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
+++ b/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
@@ -9,6 +9,7 @@
 #include <GazeboYarpPlugins/common.h>
 
 #include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
 
 #include <yarp/os/LogStream.h>
 #include <yarp/os/Network.h>


### PR DESCRIPTION
In particular, ensure that also devices registered by sensor plugins are correctly exposed to libYARP_robotinterface.

Fix https://github.com/robotology/gazebo-yarp-plugins/issues/543 .

cc @drdanz @randaz81 