### PR TITLE
Remove spurious print from loadModelFromFile method in WorldInterface plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed 
 - Fixed use of libYARP_robotinterface with YARP devices spawned by sensor plugins (https://github.com/robotology/gazebo-yarp-plugins/pull/544).
-
+- Fixed compilation against YARP 3.5 by removing spurious print in WorldInterface plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/548).
 
 ## [3.6.0] - 2021-02-24
 

--- a/plugins/worldinterface/src/worldproxy.cpp
+++ b/plugins/worldinterface/src/worldproxy.cpp
@@ -1208,8 +1208,6 @@ bool WorldProxy::loadModelFromFile(const std::string& filename)
     yError() << "Pose does not contain 6 values!";
     return false;
   }
-
-  std::cout << pose_tmp << std::endl;
 }
 
 std::string WorldProxy::loadModelFromFileWithPose(const std::string &filename, const GazeboYarpPlugins::Pose& pose, const std::string& object_name, const double timeout)


### PR DESCRIPTION
Leftover from https://github.com/robotology/gazebo-yarp-plugins/pull/467 . 
Should fix https://github.com/robotology/gazebo-yarp-plugins/issues/547 .