### PR TITLE
yarp::dev::IRgbVisualParams in multicamera and depthCamera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Added
+- The multicamera plugin now implements the `yarp::dev::IRgbVisualParams` interface.
+
+### Fixed
+- Fixed the getRgbIntrinsicParam method in the depthCamera plugin when the distortion is not set.
+- The property returned by `getRgbIntrinsicParam()`, now contains `rectificationMatrix` instead of `rectificationMatrix` (See also https://github.com/robotology/yarp/pull/2593).
+
 ## [3.6.1] - 2021-05-19
 
 ### Fixed 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -320,7 +320,7 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
 
     Distortion*  distModel;
     DepthCamera* camPtr;
-    Value        retM;
+    Value        rectM;
 
     intrinsic.put("physFocalLength", 0.0);
     camPtr = m_depthCameraSensorPtr->DepthCamera().get();
@@ -361,7 +361,7 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
         }
 
     }
-    intrinsic.put("retificationMatrix", retM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
+    intrinsic.put("rectificationMatrix", rectM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
     intrinsic.put("distortionModel", "plumb_bob");
     intrinsic.put("stamp", m_colorTimestamp.getTime());
     return true;

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -322,16 +322,15 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
     DepthCamera* camPtr;
     Value        retM;
 
+    intrinsic.put("physFocalLength", 0.0);
     camPtr = m_depthCameraSensorPtr->DepthCamera().get();
-
     if(camPtr)
     {
+        intrinsic.put("focalLengthX",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
+        intrinsic.put("focalLengthY",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
         distModel = camPtr->LensDistortion().get();
         if(distModel)
         {
-            intrinsic.put("physFocalLength", 0.0);
-            intrinsic.put("focalLengthX",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
-            intrinsic.put("focalLengthY",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
 #if GAZEBO_MAJOR_VERSION >= 8
             intrinsic.put("k1",              distModel->K1());
             intrinsic.put("k2",              distModel->K2());
@@ -350,6 +349,17 @@ bool GazeboYarpDepthCameraDriver::getDepthIntrinsicParam(Property& intrinsic)
             intrinsic.put("principalPointY", distModel->GetCenter().y);
 #endif
         }
+        else
+        {
+            intrinsic.put("k1",              0.0);
+            intrinsic.put("k2",              0.0);
+            intrinsic.put("k3",              0.0);
+            intrinsic.put("t1",              0.0);
+            intrinsic.put("t2",              0.0);
+            intrinsic.put("principalPointX", m_width/2.0);
+            intrinsic.put("principalPointY", m_height/2.0);
+        }
+
     }
     intrinsic.put("retificationMatrix", retM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
     intrinsic.put("distortionModel", "plumb_bob");

--- a/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
+++ b/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
@@ -9,6 +9,7 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IRgbVisualParams.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/Time.h>
@@ -44,6 +45,7 @@ extern const std::string YarpScopedName;
 class yarp::dev::GazeboYarpMultiCameraDriver:
     virtual public yarp::dev::DeviceDriver,
     virtual public yarp::dev::IFrameGrabberImage,
+    virtual public yarp::dev::IRgbVisualParams,
     virtual public yarp::dev::IPreciselyTimed
 {
 public:
@@ -66,6 +68,18 @@ public:
     virtual bool getImage(yarp::sig::ImageOf<yarp::sig::PixelRgb>& image);
     virtual int height() const;
     virtual int width() const;
+
+    // yarp::dev::IRgbVisualParams
+    virtual int getRgbHeight();
+    virtual int getRgbWidth();
+    virtual bool getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig>& configurations);
+    virtual bool getRgbResolution(int& width, int& height);
+    virtual bool setRgbResolution(int width, int height);
+    virtual bool getRgbFOV(double& horizontalFov, double& verticalFov);
+    virtual bool setRgbFOV(double horizontalFov, double verticalFov);
+    virtual bool getRgbIntrinsicParam(yarp::os::Property& intrinsic);
+    virtual bool getRgbMirroring(bool& mirror);
+    virtual bool setRgbMirroring(bool mirror);
 
 
     /*

--- a/plugins/multicamera/src/MultiCameraDriver.cpp
+++ b/plugins/multicamera/src/MultiCameraDriver.cpp
@@ -356,8 +356,8 @@ bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbIntrinsicParam(yarp::os::Prop
             intrinsic.put("principalPointY", m_height[0]/2.0);
         }
     }
-    yarp::os::Value retM;
-    intrinsic.put("retificationMatrix", retM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
+    yarp::os::Value rectM;
+    intrinsic.put("rectificationMatrix", rectM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
     intrinsic.put("distortionModel", "plumb_bob");
     intrinsic.put("stamp", m_lastTimestamp[0].getTime());
     return true;

--- a/plugins/multicamera/src/MultiCameraDriver.cpp
+++ b/plugins/multicamera/src/MultiCameraDriver.cpp
@@ -11,6 +11,7 @@
 #include <GazeboYarpPlugins/common.h>
 
 #include <gazebo/sensors/MultiCameraSensor.hh>
+#include <gazebo/rendering/Distortion.hh>
 
 #include <yarp/os/Value.h>
 #include <yarp/os/LogStream.h>
@@ -269,6 +270,108 @@ int yarp::dev::GazeboYarpMultiCameraDriver::width() const
     return (m_vertical ? m_max_width * m_camera_count : m_max_width * m_camera_count);
 }
 
+int yarp::dev::GazeboYarpMultiCameraDriver::getRgbHeight()
+{
+    return height();
+}
+
+int yarp::dev::GazeboYarpMultiCameraDriver::getRgbWidth()
+{
+    return width();
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbSupportedConfigurations(yarp::sig::VectorOf<yarp::dev::CameraConfig>& configurations)
+{
+    configurations.clear();
+    yarp::dev::CameraConfig config {width(), height(), m_parentSensor->Camera(0)->RenderRate(), VOCAB_PIXEL_RGB};
+    configurations.push_back(config);
+    return true;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbResolution(int& width, int& height)
+{
+    width = this->width();
+    height = this->height();
+    return true;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::setRgbResolution(int width, int height)
+{
+    return false;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbFOV(double& horizontalFov, double& verticalFov)
+{
+    using namespace gazebo::rendering;
+    Camera* camPtr = m_parentSensor->Camera(0).get();
+    horizontalFov = camPtr->HFOV().Degree();
+    verticalFov = camPtr->VFOV().Degree();
+    return true;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::setRgbFOV(double horizontalFov, double verticalFov)
+{
+    return false;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbIntrinsicParam(yarp::os::Property& intrinsic)
+{
+    using namespace gazebo::rendering;
+
+    intrinsic.put("physFocalLength", 0.0);
+    Camera* camPtr = m_parentSensor->Camera(0).get();
+    if(camPtr)
+    {
+        intrinsic.put("focalLengthY",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
+        intrinsic.put("focalLengthX",    1. / camPtr->OgreCamera()->getPixelDisplayRatio());
+        Distortion* distModel = camPtr->LensDistortion().get();
+        if(distModel)
+        {
+#if GAZEBO_MAJOR_VERSION >= 8
+            intrinsic.put("k1",              distModel->K1());
+            intrinsic.put("k2",              distModel->K2());
+            intrinsic.put("k3",              distModel->K3());
+            intrinsic.put("t1",              distModel->P1());
+            intrinsic.put("t2",              distModel->P2());
+            intrinsic.put("principalPointX", distModel->Center().X());
+            intrinsic.put("principalPointY", distModel->Center().Y());
+#else
+            intrinsic.put("k1",              distModel->GetK1());
+            intrinsic.put("k2",              distModel->GetK2());
+            intrinsic.put("k3",              distModel->GetK3());
+            intrinsic.put("t1",              distModel->GetP1());
+            intrinsic.put("t2",              distModel->GetP2());
+            intrinsic.put("principalPointX", distModel->GetCenter().x);
+            intrinsic.put("principalPointY", distModel->GetCenter().y);
+#endif
+        }
+        else
+        {
+            intrinsic.put("k1",              0.0);
+            intrinsic.put("k2",              0.0);
+            intrinsic.put("k3",              0.0);
+            intrinsic.put("t1",              0.0);
+            intrinsic.put("t2",              0.0);
+            intrinsic.put("principalPointX", m_width[0]/2.0);
+            intrinsic.put("principalPointY", m_height[0]/2.0);
+        }
+    }
+    yarp::os::Value retM;
+    intrinsic.put("retificationMatrix", retM.makeList("1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"));
+    intrinsic.put("distortionModel", "plumb_bob");
+    intrinsic.put("stamp", m_lastTimestamp[0].getTime());
+    return true;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::getRgbMirroring(bool& mirror)
+{
+    return false;
+}
+
+bool yarp::dev::GazeboYarpMultiCameraDriver::setRgbMirroring(bool mirror)
+{
+    return false;
+}
 
 yarp::os::Stamp yarp::dev::GazeboYarpMultiCameraDriver::getLastInputStamp()
 {


### PR DESCRIPTION
Unfortunately, at the moment, in YARP we don't have an interface for a multicamera. This means that, if the camera parameters are different, this will work properly only for the first camera.

Depends on #560