### PR TITLE
Remove experimental namespace and prefix from libYARP_robotinterface use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         # YCM
         git clone https://github.com/robotology/ycm
         cd ycm
-        git checkout ycm-0.12
+        git checkout ycm-0.13
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..

--- a/plugins/robotinterface/include/gazebo/GazeboYarpRobotInterface.hh
+++ b/plugins/robotinterface/include/gazebo/GazeboYarpRobotInterface.hh
@@ -9,7 +9,7 @@
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/Time.hh>
 
-#include <yarp/robotinterface/experimental/XMLReader.h>
+#include <yarp/robotinterface/XMLReader.h>
 
 namespace gazebo
 {
@@ -29,8 +29,8 @@ public:
     void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
 private:
-    yarp::robotinterface::experimental::XMLReader m_xmlRobotInterfaceReader;
-    yarp::robotinterface::experimental::XMLReaderResult m_xmlRobotInterfaceResult;
+    yarp::robotinterface::XMLReader m_xmlRobotInterfaceReader;
+    yarp::robotinterface::XMLReaderResult m_xmlRobotInterfaceResult;
     std::vector<std::string> m_deviceScopedNames;
 };
 

--- a/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
+++ b/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
@@ -24,11 +24,11 @@ GazeboYarpRobotInterface::GazeboYarpRobotInterface()
 GazeboYarpRobotInterface::~GazeboYarpRobotInterface()
 {
     // Close robotinterface 
-    bool ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseInterrupt1);
+    bool ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
     if (!ok) {
         yError() << "GazeboYarpRobotInterface: impossible to run phase ActionPhaseInterrupt1 robotinterface";
     }
-    ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseShutdown);
+    ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
     if (!ok) {
         yError() << "GazeboYarpRobotInterface: impossible  to run phase ActionPhaseShutdown in robotinterface";
     }
@@ -98,11 +98,11 @@ void GazeboYarpRobotInterface::Load(physics::ModelPtr _parentModel, sdf::Element
     }
 
     // Start robotinterface 
-    ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseStartup);
+    ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseStartup);
     if (!ok) {
         yError() << "GazeboYarpRobotInterface : impossible to start robotinterface";
-        m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseInterrupt1);
-        m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseShutdown);
+        m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
+        m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseShutdown);
         return;
     }
 }


### PR DESCRIPTION
Without this, the build is failing with error (see https://github.com/robotology/robotology-superbuild/runs/3014928864?check_suite_focus=true)
~~~
[4:42 PM] Silvio Traversaro
    
2021-07-08T13:18:43.7169616Z /home/runner/work/robotology-superbuild/robotology-superbuild/src/GazeboYARPPlugins/plugins/robotinterface/src/GazeboYarpRobotInterface.cc:27:94: error: 'ActionPhaseInterrupt1' is not a member of 'yarp::robotinterface::experimental'; did you mean 'yarp::robotinterface::ActionPhaseInterrupt1'?
2021-07-08T13:18:43.7172098Z    27 |     bool ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseInterrupt1);
2021-07-08T13:18:43.7173202Z       |                                                                                              ^~~~~~~~~~~~~~~~~~~~~
2021-07-08T13:18:43.7174381Z In file included from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/Action.h:12,
2021-07-08T13:18:43.7176079Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/Device.h:12,
2021-07-08T13:18:43.7177636Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/Robot.h:13,
2021-07-08T13:18:43.7179221Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/XMLReader.h:13,
2021-07-08T13:18:43.7180902Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/experimental/XMLReader.h:19,
2021-07-08T13:18:43.7182881Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/src/GazeboYARPPlugins/plugins/robotinterface/include/gazebo/GazeboYarpRobotInterface.hh:12,
2021-07-08T13:18:43.7185007Z                  from /home/runner/work/robotology-superbuild/robotology-superbuild/src/GazeboYARPPlugins/plugins/robotinterface/src/GazeboYarpRobotInterface.cc:7:
2021-07-08T13:18:43.7187359Z /home/runner/work/robotology-superbuild/robotology-superbuild/build/install/include/yarp/robotinterface/Types.h:49:5: note: 'yarp::robotinterface::ActionPhaseInterrupt1' declared here
2021-07-08T13:18:43.7188621Z    49 |     ActionPhaseInterrupt1,
2021-07-08T13:18:43.7189061Z       |     ^~~~~~~~~~~~~~~~~~~~~
2021-07-08T13:18:43.7191343Z /home/runner/work/robotology-superbuild/robotology-superbuild/src/GazeboYARPPlugins/plugins/robotinterface/src/GazeboYarpRobotInterface.cc:31:89: error: 'ActionPhaseShutdown' is not a member of 'yarp::robotinterface::experimental'; did you mean 'yarp::robotinterface::ActionPhaseShutdown'?
2021-07-08T13:18:43.7193734Z    31 |     ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::experimental::ActionPhaseShutdown);
~~~