### PR TITLE
Add deprecation notice for gazebo_yarp_jointsensors and gazebo_yarp_doublelaser plugins.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+## Deprecated
+- The `gazebo_yarp_jointsensors` and the `gazebo_yarp_doublelaser` have been deprecated and will be removed in the next major version of `gazebo-yarp-plugins`.
+
 ## [3.6.1] - 2021-05-19
 
 ### Fixed 


### PR DESCRIPTION
`gazebo_yarp_jointsensors` is meant to be removed since 2015, see https://github.com/robotology/gazebo-yarp-plugins/issues/213 .
`gazebo_yarp_doublelaser` should be deprecated according to https://github.com/robotology/gazebo-yarp-plugins/pull/565#issuecomment-889746179 