### PR TITLE
Make velocityControlImplementationType parameter compulsory if [VELOCITY_CONTROL] group is present in gazebo_yarp_plugins configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - `gazebo_yarp_multicamera`, `gazebo_yarp_lasersensor`, `gazebo_yarp_doublelaser`, `gazebo_yarp_controlboard` and `gazebo_yarp_depthCamera` plugins now log messages using the ["Log Components" YARP logging feature](http://www.yarp.it/git-master/yarp_logging.html).
 - A cmake option (`GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS`) has been added, if this option is enabled then implicit wrappers present in`gazebo_yarp_multicamera`, `gazebo_yarp_lasersensor`, `gazebo_yarp_controlboard` and `gazebo_yarp_depthCamera` are removed, the new way to have them is to attach the new nws to gazebo devices via yarprobotinterface.
 - `gazebo-yarp-plugins` now requires YARP 3.5 (https://github.com/robotology/gazebo-yarp-plugins/pull/562).
-
+- In the `gazebo_yarp_controlboard` plugin configuration, if the `[VELOCITY_CONTROL]` group is present the `velocityControlImplementationType` parameter is now compulsory, and model loading will fail if it is not set.
 
 ### Fixed
 - Fixed the getRgbIntrinsicParam method in the depthCamera plugin when the distortion is not set (https://github.com/robotology/gazebo-yarp-plugins/pull/558).

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -1109,10 +1109,11 @@ bool GazeboYarpControlBoardDriver::setPIDsForGroup_VELOCITY(std::vector<std::str
         Bottle pidGroup = m_pluginParameters.findGroup("VELOCITY_CONTROL");
 
         // Check velocityControlImplementationType value
-        // If not present, default to direct_velocity_pid for now
+        // If not present, raise an error
         if (pidGroup.find("velocityControlImplementationType").isNull()) {
-            yCWarning(GAZEBOCONTROLBOARD) << "VELOCITY_CONTROL: 'velocityControlImplementationType' param missing. ";
-            yCWarning(GAZEBOCONTROLBOARD) << " Using the default value of 'direct_velocity_pid', but the parameter will be compulsory gazebo-yarp-plugins 4.";
+            yCError(GAZEBOCONTROLBOARD) << "VELOCITY_CONTROL: 'velocityControlImplementationType' param missing. ";
+            yCError(GAZEBOCONTROLBOARD) << " To fix your model to have the same default behaviour  of gazebo-yarp-plugins < 4, just add 'velocityControlImplementationType direct_velocity_pid' in the '[VELOCITY_CONTROL]' group.";
+            return false;
         } else {
             std::string velocityControlImplementationType = pidGroup.find("velocityControlImplementationType").toString();
 


### PR DESCRIPTION
As promised in gazebo-yarp-plugins v3.5.1 release notes. 

Fix https://github.com/robotology/gazebo-yarp-plugins/issues/577 .