### PR TITLE
Cleanup dependencies installation

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robotology gazebo opencv yarp>=3.5
+        mamba install -c conda-forge -c robotology gazebo opencv yarp
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge gazebo opencv
+        mamba install -c conda-forge -c robotology gazebo opencv yarp>=3.5
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]
@@ -47,12 +47,6 @@ jobs:
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
-
-    - name: Dependencies
-      shell: bash -l {0}
-      run: |
-        # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp>=3.5
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robotology gazebo opencv yarp>=3.5
+        mamba install -c conda-forge -c robotology yarp gazebo 
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -37,7 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install -c conda-forge -c robotology gazebo opencv yarp
+        mamba install -c conda-forge -c robotology gazebo opencv yarp>=3.5
 
     # Additional dependencies useful only on Linux
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -48,56 +48,11 @@ jobs:
         # See https://github.com/robotology/robotology-superbuild/issues/477
         mamba install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 
-    - name: Dependencies (master)
-      if: |
-        (github.event_name == 'pull_request' && env.GITHUB_BASE_REF_SLUG == 'master') ||
-        env.GITHUB_REF_SLUG == 'master'
+    - name: Dependencies
       shell: bash -l {0}
       run: |
         # Actual dependencies
-        mamba install -c conda-forge -c robotology yarp
-
-    - name: Dependencies (devel) [Conda/Linux&macOS]
-      if: |
-        contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu') &&
-        ((github.event_name == 'pull_request' && env.GITHUB_BASE_REF_SLUG != 'master') ||
-         (github.event_name != 'pull_request' && env.GITHUB_REF_SLUG != 'master'))
-      shell: bash -l {0}
-      run: |
-
-        # YARP & iDynTree dependencies
-        mamba install -c conda-forge ace eigen ycm-cmake-modules
-
-        #YARP
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/yarp
-        cd yarp
-        mkdir build
-        cd build
-        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }}
-        cmake --install . --config ${{ matrix.build_type }}
-
-    - name: Dependencies (devel) [Conda/Windows]
-      if: |
-        contains(matrix.os, 'windows') &&
-        ((github.event_name == 'pull_request' && env.GITHUB_BASE_REF_SLUG != 'master') ||
-         (github.event_name != 'pull_request' && env.GITHUB_REF_SLUG != 'master'))
-      shell: bash -l {0}
-      run: |
-
-        # YARP & iDynTree dependencies
-        mamba install -c conda-forge ace eigen ycm-cmake-modules
-
-        #YARP
-        cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/yarp
-        cd yarp
-        mkdir build
-        cd build
-        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }}
-        cmake --install . --config ${{ matrix.build_type }}
+        mamba install -c conda-forge -c robotology yarp>=3.5
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
* Only install yarp to avoid https://github.com/robotology/gazebo-yarp-plugins/issues/595. OpenCV will be installed as it is a yarp dependency.
* Do not compile from source, even on devel