### PR TITLE
[WIP] Fix timestamp in laserSensorDriver

### DIFF
--- a/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
+++ b/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
@@ -64,9 +64,6 @@ public:
     virtual bool setHorizontalResolution (double step) override;
     virtual bool setScanRate (double rate) override;
 
-    //PRECISELY TIMED
-    virtual yarp::os::Stamp getLastInputStamp() override;
-
 public:
     //Lidar2DDeviceBase
     bool acquireDataFromHW() override final;

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -110,12 +110,6 @@ bool GazeboYarpLaserSensorDriver::acquireDataFromHW()
     return true;
 }
 
-//PRECISELY TIMED
-yarp::os::Stamp GazeboYarpLaserSensorDriver::getLastInputStamp()
-{
-    return m_lastTimestamp;
-}
-
 bool GazeboYarpLaserSensorDriver::setDistanceRange (double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);


### PR DESCRIPTION
after the merge of https://github.com/robotology/yarp/pull/2778 Lidar2DDeviceBase doesn't have anymore the ipreciselytimed interface and so LaserSensorDriver doesn't requires it anymore.