### PR TITLE
Fix compilation of GazeboYarpLaserSensorDriver with YARP 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - The `gazebo_imu` plugin now handle the `yarpDeviceName` parameter (https://github.com/robotology/gazebo-yarp-plugins/pull/583).
 - The `gazebo_imu` plugin can be now opened without implicit wrapper, by using the `GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS` CMake option (https://github.com/robotology/gazebo-yarp-plugins/pull/583).
 
+### Fixed
+- Fixed compilation with YARP 3.6 (https://github.com/robotology/gazebo-yarp-plugins/pull/599).
+
 ## [4.0.0] - 2021-09-03
 
 ### Added

--- a/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
+++ b/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
@@ -65,7 +65,9 @@ public:
     virtual bool setScanRate (double rate) override;
 
     //PRECISELY TIMED
-    virtual yarp::os::Stamp getLastInputStamp() override;
+    // TODO(traversaro): Remove once we require YARP 3.6
+    // See https://github.com/robotology/gazebo-yarp-plugins/issues/598
+    virtual yarp::os::Stamp getLastInputStamp();
 
 public:
     //Lidar2DDeviceBase


### PR DESCRIPTION
I tought that more changes were necessary, but if this works fine with both YARP 3.5 and 3.6 I think we can simply merge this fix.
With respect to https://github.com/robotology/gazebo-yarp-plugins/pull/597, I created this PR on the latest devel after forward merging https://github.com/robotology/gazebo-yarp-plugins/pull/596 to `devel`, so that we test this change both against YARP 3.5 (in `C++ CI Workflow with conda dependencies`) and YARP 3.6 (in `C++ CI Workflow`).

Fix https://github.com/robotology/gazebo-yarp-plugins/issues/598 .
Fix https://github.com/robotology/robotology-superbuild/issues/959 .