### PR TITLE
Decimal places limit for depth Camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
-### Changed
-- The possibility to limit the decimal places of the pixels values has been added to the DepthCameraDriver class. The data modification is performed in the `GazeboYarpDepthCameraDriver::getDepthImage` function.
+### Added 
+- The possibility to limit the decimal places of the pixels values has been added to the `gazebo_yarp_depthcamera` plugin, via the `QUANT_PARAM::depth_quant` parameter. The data modification is performed in the `GazeboYarpDepthCameraDriver::getDepthImage` function (https://github.com/robotology/gazebo-yarp-plugins/pull/608).
 
 ### Fixed
 - Removed `getLastInputStamp` method from `LaserSensorDriver` class in `gazebo_yarp_lasersensor`. Furthermore, fix bug in `gazebo_yarp_lasersensor`, by adding the update to the variable `m_timestamp` inherited from `yarp::dev::Lidar2DDeviceBase` (https://github.com/robotology/gazebo-yarp-plugins/pull/604).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+- The possibility to limit the decimal places of the pixels values has been added to the DepthCameraDriver class. The data modification is performed in the `GazeboYarpDepthCameraDriver::getDepthImage` function.
+
 ### Fixed
 - Removed `getLastInputStamp` method from `LaserSensorDriver` class in `gazebo_yarp_lasersensor`. Furthermore, fix bug in `gazebo_yarp_lasersensor`, by adding the update to the variable `m_timestamp` inherited from `yarp::dev::Lidar2DDeviceBase` (https://github.com/robotology/gazebo-yarp-plugins/pull/604).
 

--- a/plugins/depthCamera/include/gazebo/DepthCamera.hh
+++ b/plugins/depthCamera/include/gazebo/DepthCamera.hh
@@ -45,6 +45,7 @@ namespace gazebo
     ///  <TABLE>
     ///  <TR><TD> name </TD><TD> Port name to assign to the wrapper to this device. </TD></TR>
     ///  <TR><TD> period </TD><TD> Update period (in s) of yarp port that publish the measure. </TD></TR>
+    ///  <TR><TD> QUANT_PARAM::depth_quant </TD><TD> The number of decimals for the values of the depth image pixels </TD></TR>
     ///  </TABLE>
     /// If the required parameters are not specified, their value will be the
     /// default one assigned by the yarp::dev::ServerFrameGrabbers wrapper.

--- a/plugins/depthCamera/include/yarp/dev/DepthCameraDriver.h
+++ b/plugins/depthCamera/include/yarp/dev/DepthCameraDriver.h
@@ -17,6 +17,7 @@
 #include <gazebo/sensors/CameraSensor.hh>
 #include <gazebo/rendering/DepthCamera.hh>
 #include <gazebo/sensors/DepthCameraSensor.hh>
+#include <cmath>
 
 #include <mutex>
 
@@ -130,6 +131,10 @@ private:
     gazebo::event::ConnectionPtr              m_updateDepthFrame_Connection;
     gazebo::event::ConnectionPtr              m_updateRGBPointCloud_Connection;
     gazebo::event::ConnectionPtr              m_updateImageFrame_Connection;
+
+    // Data quantization related parameters
+    bool                             m_depthQuantizationEnabled{false};
+    int                              m_depthDecimalNum{0};
 };
 
 #endif // GAZEBOYARP_DEPTHCAMERADRIVER_H

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -28,6 +28,7 @@ using GazeboYarpPlugins::GAZEBODEPTH;
 
 const string YarpScopedName = "sensorScopedName";
 
+
 GazeboYarpDepthCameraDriver::GazeboYarpDepthCameraDriver()
 {
     m_imageFormat                    = VOCAB_PIXEL_RGB;
@@ -75,6 +76,16 @@ GazeboYarpDepthCameraDriver::~GazeboYarpDepthCameraDriver()
 bool GazeboYarpDepthCameraDriver::open(yarp::os::Searchable &config)
 {
     string sensorScopedName((config.find(YarpScopedName.c_str()).asString().c_str()));
+
+    //Manage depth quantization parameter
+    if(config.check("QUANT_PARAM")) {
+        yarp::os::Property quantCfg;
+        quantCfg.fromString(config.findGroup("QUANT_PARAM").toString());
+        m_depthQuantizationEnabled = true;
+        if (quantCfg.check("depth_quant")) {
+            m_depthDecimalNum = quantCfg.find("depth_quant").asInt32();
+        }
+    }
 
     //Get gazebo pointers
     m_conf.fromString(config.toString());
@@ -159,7 +170,7 @@ void GazeboYarpDepthCameraDriver::OnNewImageFrame(const unsigned char* _image, U
 {
     //possible image format (hardcoded (sigh..) in osrf/gazebo/source/gazebo/rendering/Camera.cc )
     /* data type is string. why they didn't use a enum? mystery...
-     * 
+     *
      * L8 = INT8 = 1
      * R8G8B8 = RGB_INT8 = BGR_INT8 = B8G8R8 = 3
      * BAYER_RGGB8 = BAYER_BGGR8 = BAYER_GBRG8 = BAYER_GRBG8 = 1
@@ -406,7 +417,30 @@ bool GazeboYarpDepthCameraDriver::getDepthImage(depthImageType& depthImage, Stam
 
     depthImage.resize(m_width, m_height);
     //depthImage.setPixelCode(m_depthFormat);
-    memcpy(depthImage.getRawImage(), m_depthFrame_Buffer, m_width * m_height * sizeof(float));
+    if(!m_depthQuantizationEnabled) {
+        memcpy(depthImage.getRawImage(), m_depthFrame_Buffer, m_width * m_height * sizeof(float));
+    }
+    else {
+        double nearPlane = m_depthCameraSensorPtr->DepthCamera()->NearClip();
+        double farPlane = m_depthCameraSensorPtr->DepthCamera()->FarClip();
+
+        int intTemp;
+        float value;
+        int i = 0;
+        for (int r = 0; r < m_height; r++) {
+            for (int c = 0; c < m_width; c++) {
+                i = r * m_width + c;
+                value = m_depthFrame_Buffer[i];
+
+                intTemp = (int) (value * pow(10.0, (float) m_depthDecimalNum));
+                value = (float) intTemp / pow(10.0, (float) m_depthDecimalNum);
+
+                if (value < nearPlane) { value = nearPlane; }
+                if (value > farPlane) { value = farPlane; }
+                depthImage.pixel(c, r) = value;
+            }
+        }
+    }
 
     timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
 
@@ -432,7 +466,7 @@ std::string GazeboYarpDepthCameraDriver::getLastErrorMsg(Stamp* timeStamp)
 {
     if(timeStamp)
     {
-	timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
+        timeStamp->update(this->m_depthCameraSensorPtr->LastUpdateTime().Double());
 
     }
     return m_error;

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -426,19 +426,19 @@ bool GazeboYarpDepthCameraDriver::getDepthImage(depthImageType& depthImage, Stam
 
         int intTemp;
         float value;
-        int i = 0;
-        for (int r = 0; r < m_height; r++) {
-            for (int c = 0; c < m_width; c++) {
-                i = r * m_width + c;
-                value = m_depthFrame_Buffer[i];
 
-                intTemp = (int) (value * pow(10.0, (float) m_depthDecimalNum));
-                value = (float) intTemp / pow(10.0, (float) m_depthDecimalNum);
+        auto pxPtr = reinterpret_cast<float*>(depthImage.getRawImage());
+        for(int i=0; i<m_height*m_width; i++){
+            value = m_depthFrame_Buffer[i];
 
-                if (value < nearPlane) { value = nearPlane; }
-                if (value > farPlane) { value = farPlane; }
-                depthImage.pixel(c, r) = value;
-            }
+            intTemp = (int) (value * pow(10.0, (float) m_depthDecimalNum));
+            value = (float) intTemp / pow(10.0, (float) m_depthDecimalNum);
+
+            if (value < nearPlane) { value = nearPlane; }
+            if (value > farPlane) { value = farPlane; }
+
+            *pxPtr = value;
+            pxPtr++;
         }
     }
 

--- a/tutorial/model/depthcamera/depthcamera.ini
+++ b/tutorial/model/depthcamera/depthcamera.ini
@@ -3,3 +3,6 @@ period 30
 imagePort /camera
 depthPort /depthcamera
 name /depthcamera
+
+[QUANT_PARAM]
+depth_quant 2


### PR DESCRIPTION
The possibility to limit the decimal places of the pixels values has
been added to the DepthCameraDriver class.

The main reason behind this PR relies on the great bandwidth consumption of the depth images (32 bit float data and up to 7-8 significant digits.) even after lossless compression.

The following set of tests should provide a good explanation of the benefits of this new feature (thanks to @DatSpace for preforming the tests and for the useful table)

### Data
For the experiment we try different quantization values (significant digits) for a depth image from gazebo, while **_the robot is looking turned 45 degrees at a wall 1m away from the camera. The bandwidth bellow is per frame averaged over 10 seconds, transmitted through LAN with zlib compression_**.

| Significant Digits  | Bandwidth | Percentage Change | Comments |
| :---: | :---: | :---: | :---: |
| 8 | 7.23 Mbps | - |  |
| 7 | 7.35 Mbps | +1.66% | It appears that at that many digits it has no effect and it just seems random |
| 6 | 7.04 Mbps | -4.2% |  |
| 5 | 6.05 Mbps | -14.0% |  |
| 4 | 1.77 Mbps | -70.7% |  |
| 3 | 0.311 Mbps | -82.4% | Millimeter accuracy |
| 2 | 0.11 Mbps | -64.6% | Centimeter accuracy. This seems to be the most logical for our use case with R1 since the camera currently used (Realsense D455) has a theoretical accuracy on the z axis of <2% at 4m, which makes it to have an error of 8cm at worst, at 4m. |
| 1 | 0.099 Mbps | -9.9% | Decimeter accuracy with visible quantitation in the depth image color. |
| 0 | 0.069 Mbps | -29.7% | This represents only integer values in meters and obviously cannot be used. |

**Note:** There was some background data transfer at the range of 30kbps that is significant for the lowest measurements. Still the numbers are so small that it doesn't really matter.


NB: If the configuration parameters passed to the plugin do not contain the group `QUANT_PARAM` this feature is disabled and the plugin will work as it always had.


EDIT: An example of configuration file with the parameters group needed for this feature can be seen in [PR #35](https://github.com/robotology/cer-sim/pull/35) for the `cer-sim` repo.