### PR TITLE
Fix use of yarpConfigurationString parameter in gazebo_yarp_worldinterface plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Removed `getLastInputStamp` method from `LaserSensorDriver` class in `gazebo_yarp_lasersensor`. Furthermore, fix bug in `gazebo_yarp_lasersensor`, by adding the update to the variable `m_timestamp` inherited from `yarp::dev::Lidar2DDeviceBase` (https://github.com/robotology/gazebo-yarp-plugins/pull/604).
+- Fix use of yarpConfigurationString parameter in `gazebo_yarp_worldinterface` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/609).
 
 ## [4.1.2] - 2022-01-19
 

--- a/plugins/worldinterface/src/worldinterface.cpp
+++ b/plugins/worldinterface/src/worldinterface.cpp
@@ -12,6 +12,7 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 #include <GazeboYarpPlugins/common.h>
+#include <GazeboYarpPlugins/ConfHelpers.hh>
 
 using namespace gazebo;
 using namespace std;
@@ -54,18 +55,7 @@ void WorldInterface::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   //pass reference to server
   m_wi_server.attachWorldProxy(&m_proxy);
 
-  //Getting .ini configuration file from sdf
-  bool configuration_loaded = false;
-
-  if (_sdf->HasElement("yarpConfigurationFile")) {
-        std::string ini_file_name = _sdf->Get<std::string>("yarpConfigurationFile");
-        std::string ini_file_path = gazebo::common::SystemPaths::Instance()->FindFileURI(ini_file_name);
-
-        if (ini_file_path != "" && m_parameters.fromConfigFile(ini_file_path.c_str())) {
-            yInfo() << "Found yarpConfigurationFile: loading from " << ini_file_path ;
-            configuration_loaded = true;
-        }
-  }
+  bool configuration_loaded = GazeboYarpPlugins::loadConfigModelPlugin(_model, _sdf, m_parameters);
 
   if (!configuration_loaded) {
     yError() << "WorldInterface::Load error could not load configuration file";


### PR DESCRIPTION
The use of `yarpConfigurationString` element to pass configuration parameters to YARP plugins via an inline string instead of an external `.ini` YARP file was discussed in https://github.com/robotology/gazebo-yarp-plugins/issues/142 has been added in:
* https://github.com/robotology/gazebo-yarp-plugins/pull/394
* https://github.com/robotology/gazebo-yarp-plugins/pull/396

However, this option was never supported in `gazebo_yarp_worldinterface` plugin. This PR ensures that even for that plugin configuration parameters can be passed via `yarpConfigurationString`.