### PR TITLE
Fix Windows Conda CI job

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-2019, macos-latest]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The job uses Visual Studio 2019, but that is only contained in windows-2019 image. 