### PR TITLE
Migrate camera, multicamera, laser and depthcamera example models to use gazebo_yarp_robotinterface plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ### Added
 - In `gazebo_yarp_camera` parse the `yarpDeviceName` option to enable its use with `gazebo_yarp_robotinterface` (https://github.com/robotology/gazebo-yarp-plugins/pull/614).
 
+### Changed
+- Migrate the example models under the tutorial directory to avoid the use of implicit network wrapper servers, and use the `gazebo_yarp_robotinterface` plugin to spawn their network wrapper servers (https://github.com/robotology/gazebo-yarp-plugins/pull/615). 
+
 ## [4.2.0] - 2022-02-28
 
 ### Added

--- a/plugins/camera/src/Camera.cc
+++ b/plugins/camera/src/Camera.cc
@@ -76,6 +76,11 @@ void GazeboYarpCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
 
     m_parameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
 
+    // If the device is not specified in the configuration passed, specify it to gazebo_camera
+    if (!m_parameters.check("device")) {
+        m_parameters.put("device", "gazebo_camera");
+    }
+
     //Open the driver
     if (m_cameraDriver.open(m_parameters)) {
         yInfo() << "Loaded GazeboYarpCamera Plugin correctly";

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -37,7 +37,8 @@ void GazeboYarpLaserSensorDriver::onUpdate(const gazebo::common::UpdateInfo& _in
     
     if (tmp.size() != m_laser_data.size())
     {
-        yCError(GAZEBOLASER) << "size error";
+        yCError(GAZEBOLASER) << "Size error, expected: " << m_laser_data.size() 
+                             << ", got: " << tmp.size();
     }
 
 #if 0

--- a/plugins/multicamera/src/MultiCamera.cc
+++ b/plugins/multicamera/src/MultiCamera.cc
@@ -75,6 +75,11 @@ void GazeboYarpMultiCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
     m_parameters.put(YarpScopedName.c_str(), m_sensorName.c_str());
 
+    // If the device is not specified in the configuration passed, specify it to gazebo_multicamera
+    if (!m_parameters.check("device")) {
+        m_parameters.put("device", "gazebo_multicamera");
+    }
+
     //Open the driver
     if (m_cameraDriver.open(m_parameters)) {
         yCInfo(GAZEBOMULTICAMERA) << "Loaded GazeboYarpMultiCamera Plugin correctly";

--- a/tutorial/model/camera/camera.ini
+++ b/tutorial/model/camera/camera.ini
@@ -1,5 +1,0 @@
-device frameGrabber_nws_yarp
-subdevice gazebo_camera
-name /camera
-framerate 30
-stamp 1

--- a/tutorial/model/camera/camera_nws.xml
+++ b/tutorial/model/camera/camera_nws.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="camera" portprefix="camera" build="0"  xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="camera_nws_yarp" type="frameGrabber_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classFrameGrabber__nws__yarp.html#details for parameter documentation -->
+            <param name="name"> /camera </param>
+            <param name="period"> 0.033333 </param>
+            <param name="capabilities"> COLOR </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the camera plugin -->
+                <param name="device"> camera_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/camera/model.sdf
+++ b/tutorial/model/camera/model.sdf
@@ -26,10 +26,15 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
+        <!-- Create an instance the gazebo_camera YARP device called "camera_plugin_device"-->
         <plugin name="camera_plugin" filename="libgazebo_yarp_camera.so">
-          <yarpConfigurationFile>model://camera/camera.ini</yarpConfigurationFile>
+          <yarpConfigurationString>(yarpDeviceName camera_plugin_device) (disableImplicitNetworkWrapper)</yarpConfigurationString>
         </plugin>
       </sensor>
     </link>
+    <!-- Launch the other YARP devices, in this case a frameGrabber_nws_yarp to expose the images on a YARP port -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://camera/camera_nws.xml</yarpRobotInterfaceConfigurationFile>
+    </plugin>
   </model>
 </sdf>

--- a/tutorial/model/depthcamera/depthcamera.ini
+++ b/tutorial/model/depthcamera/depthcamera.ini
@@ -1,8 +1,0 @@
-device RGBDSensorWrapper
-period 30
-imagePort /camera
-depthPort /depthcamera
-name /depthcamera
-
-[QUANT_PARAM]
-depth_quant 2

--- a/tutorial/model/depthcamera/depthcamera_nws.xml
+++ b/tutorial/model/depthcamera/depthcamera_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="depthcamera" portprefix="depthcamera" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="depthcamera_nws_yarp" type="rgbdSensor_nws_yarp">
+            <!-- See https://www.yarp.it/git-master/classRgbdSensor__nws__yarp.html#details for parameter documentation -->
+            <param name="name"> /depthcamera </param>
+            <param name="period"> 0.033333 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the depthcamera plugin -->
+                <param name="device"> depthcamera_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/depthcamera/model.sdf
+++ b/tutorial/model/depthcamera/model.sdf
@@ -23,13 +23,18 @@
             <far>100</far>
           </clip>
         </camera>
-        <plugin name='depthcamera_plugin' filename='libgazebo_yarp_depthCamera.so'>
-          <yarpConfigurationFile>model://depthcamera/depthcamera.ini</yarpConfigurationFile>
+        <!-- Create an instance the gazebo_depthcamera YARP device called "depthcamera_plugin_device"-->
+        <plugin name="depthcamera_plugin" filename="libgazebo_yarp_depthCamera.so">
+          <yarpConfigurationString>(yarpDeviceName depthcamera_plugin_device) (disableImplicitNetworkWrapper)</yarpConfigurationString>
         </plugin>
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
       </sensor>
     </link>
+    <!-- Launch the other YARP devices, in this case a rgbdSensor_nws_yarp to expose the images on a YARP port -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://depthcamera/depthcamera_nws.xml</yarpRobotInterfaceConfigurationFile>
+    </plugin>
   </model>
 </sdf>

--- a/tutorial/model/laser/laser.ini
+++ b/tutorial/model/laser/laser.ini
@@ -1,4 +1,11 @@
-device Rangefinder2DWrapper
-subdevice gazebo_lasersensor
-name /laser
-period 10
+yarpDeviceName laser_plugin_device
+disableImplicitNetworkWrapper
+
+# IMPORTANT: make sure that this values match the one specified in the .sdf
+[SENSOR]
+max_distance    5.0
+min_distance    0.1
+max_angle       360
+min_angle       0
+resolution      1
+allow_infinity  1

--- a/tutorial/model/laser/laser_nws.xml
+++ b/tutorial/model/laser/laser_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="laser" portprefix="laser" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="laser_nws_yarp" type="rangefinder2D_nws_yarp">
+            <!-- See https://www.yarp.it/latest//classRangefinder2D__nws__yarp.html#details for parameter documentation -->
+            <param name="name"> /laser </param>
+            <param name="period"> 0.033333 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the laser plugin -->
+                <param name="device"> laser_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/laser/model.sdf
+++ b/tutorial/model/laser/model.sdf
@@ -14,6 +14,7 @@
       </visual>
       <sensor name ='laser_sensor' type='ray'>
         <ray>
+          <!-- IMPORTANT: Make sure that this values matches specified in laser.ini -->
           <scan>
             <horizontal>
               <samples>360</samples>
@@ -36,10 +37,15 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
-        <plugin name='laser_plugin' filename='libgazebo_yarp_lasersensor.so'>
-           <yarpConfigurationFile>model://laser/laser.ini</yarpConfigurationFile>
+        <!-- Create an instance the gazebo_laser YARP device called "laser_plugin_device"-->
+        <plugin name="laser_plugin" filename="libgazebo_yarp_lasersensor.so">
+          <yarpConfigurationFile>model://laser/laser.ini</yarpConfigurationFile>
         </plugin>
       </sensor>
     </link>
+    <!-- Launch the other YARP devices, in this case a Rangefinder2D_nws_yarp to expose the images on a YARP port -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://laser/laser_nws.xml</yarpRobotInterfaceConfigurationFile>
+    </plugin>
   </model>
 </sdf>

--- a/tutorial/model/multicamera/model.sdf
+++ b/tutorial/model/multicamera/model.sdf
@@ -39,10 +39,15 @@
         <always_on>1</always_on>
         <update_rate>30</update_rate>
         <visualize>true</visualize>
+        <!-- Create an instance the gazebo_multicamera YARP device called "multicamera_plugin_device"-->
         <plugin name="multicamera_plugin" filename="libgazebo_yarp_multicamera.so">
-          <yarpConfigurationFile>model://multicamera/multicamera.ini</yarpConfigurationFile>
+          <yarpConfigurationString>(yarpDeviceName multicamera_plugin_device) (disableImplicitNetworkWrapper)</yarpConfigurationString>
         </plugin>
       </sensor>
     </link>
+    <!-- Launch the other YARP devices, in this case a frameGrabber_nws_yarp to expose the images on a YARP port -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://multicamera/multicamera_nws.xml</yarpRobotInterfaceConfigurationFile>
+    </plugin>
   </model>
 </sdf>

--- a/tutorial/model/multicamera/multicamera.ini
+++ b/tutorial/model/multicamera/multicamera.ini
@@ -1,5 +1,0 @@
-device frameGrabber_nws_yarp
-subdevice gazebo_multicamera
-name /multicamera
-framerate 30
-stamp 1

--- a/tutorial/model/multicamera/multicamera_nws.xml
+++ b/tutorial/model/multicamera/multicamera_nws.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="multicamera" portprefix="multicamera" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="multicameracamera_nws_yarp" type="frameGrabber_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classFrameGrabber__nws__yarp.html#details for parameter documentation -->
+            <param name="name"> /multicamera </param>
+            <param name="period"> 0.033333 </param>
+            <param name="capabilities"> COLOR </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the multicamera plugin -->
+                <param name="device"> multicamera_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>


### PR DESCRIPTION
By using the gazebo_yarp_robotinterface plugin, it is possible to avoid the use of implict network wrappers that will be removed in gazebo-yarp-plugins 5 (see https://github.com/robotology/gazebo-yarp-plugins/issues/594).

This PR requires to merge before:
* https://github.com/robotology/gazebo-yarp-plugins/pull/613
* https://github.com/robotology/gazebo-yarp-plugins/pull/614

Furthermore, it also contains the following minor fixes:
* laser: Improve size error message with got and expected sizes ( https://github.com/robotology/gazebo-yarp-plugins/commit/4a5d167a2cae56b0b24c423d300f4e2a56768e79 )
*  Avoid the need to specify redundant device name in camera and multicamera devices ( https://github.com/robotology/gazebo-yarp-plugins/commit/b745de8649a748825db92bd13b0d953fa9336765 )