### PR TITLE
Migrate controlboard example models to use gazebo_yarp_robotinterface_plugin

### DIFF
--- a/tutorial/model/coupled_pendulum/conf/coupled_pendulum_nws.xml
+++ b/tutorial/model/coupled_pendulum/conf/coupled_pendulum_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="coupled_pendulum" portprefix="coupled_pendulum" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="coupled_pendulum_nws_yarp" type="controlBoard_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classControlBoard__nws__yarp.html for parameter documentation -->
+            <param name="name"> /coupledPendulumGazebo/body </param>
+            <param name="period"> 0.01 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the gazebo_controlboard plugin -->
+                <param name="device"> controlboard_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/coupled_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/model/coupled_pendulum/conf/gazebo_controlboard.ini
@@ -1,32 +1,12 @@
-[WRAPPER]
-# name of the wrapper device to be instatiated by the factory
-device controlboardwrapper2
-# rate of output streaming from ports in ms
-period 10
-# output port name 
-name /coupledPendulumGazebo/body
-# Total number of joints
-joints 2
-# list of MotorControl device to use
-networks ( pendulum )
-# for each network specify the joint map
-pendulum  0 1 0 1
-# Verbose output (on if present, off if commented out)
-# verbose
+disableImplicitNetworkWrapper
+yarpDeviceName controlboard_plugin_device
+jointNames upper_joint lower_joint
 
 [TRAJECTORY_GENERATION]
 trajectory_type constant_speed
 
 [COUPLING]
 eyes_vergence_control (0 1) (upper_joint lower_joint)
-
-# Specify configuration of MotorControl devices
-[pendulum]
-# name of the device to be instatiated by the factory
-device gazebo_controlboard
-#jointNames list
-jointNames upper_joint lower_joint
-name pendulum
 
 #PIDs:
 # this information is used to set the PID values in simulation for GAZEBO, we need only the first three values

--- a/tutorial/model/coupled_pendulum/model.urdf
+++ b/tutorial/model/coupled_pendulum/model.urdf
@@ -81,9 +81,14 @@
   </joint>
   
   <gazebo>
+    <!-- Create an instance the gazebo_controlboard YARP device called "controlboard_plugin_device"-->
     <plugin name="controlboard" filename="libgazebo_yarp_controlboard.so">
         <yarpConfigurationFile>model://coupled_pendulum/conf/gazebo_controlboard.ini</yarpConfigurationFile>
         <initialConfiguration>0.0 0.0</initialConfiguration>
+    </plugin>
+    <!-- Launch the other YARP devices, in this case a controlboardwrapper2 to expose the controlboard functionalities via YARP ports -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://coupled_pendulum/conf/coupled_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
     </plugin>
   </gazebo>
 </robot>

--- a/tutorial/model/double_pendulum/conf/double_pendulum_nws.xml
+++ b/tutorial/model/double_pendulum/conf/double_pendulum_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="double_pendulum" portprefix="double_pendulum" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="double_pendulum_nws_yarp" type="controlBoard_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classControlBoard__nws__yarp.html for parameter documentation -->
+            <param name="name"> /doublePendulumGazebo/body </param>
+            <param name="period"> 0.01 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the gazebo_controlboard plugin -->
+                <param name="device"> controlboard_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/double_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/model/double_pendulum/conf/gazebo_controlboard.ini
@@ -1,26 +1,6 @@
-[WRAPPER]
-# name of the wrapper device to be instatiated by the factory
-device controlboardwrapper2
-# rate of output streaming from ports in ms
-period 10
-# output port name 
-name /doublePendulumGazebo/body
-# Total number of joints
-joints 2
-# list of MotorControl device to use
-networks ( pendulum )
-# for each network specify the joint map
-pendulum  0 1 0 1
-# Verbose output (on if present, off if commented out)
-# verbose
-
-# Specify configuration of MotorControl devices
-[pendulum]
-# name of the device to be instatiated by the factory
-device gazebo_controlboard
-#jointNames list
+disableImplicitNetworkWrapper
+yarpDeviceName controlboard_plugin_device
 jointNames upper_joint lower_joint
-name pendulum
 
 #PIDs:
 # this information is used to set the PID values in simulation for GAZEBO, we need only the first three values

--- a/tutorial/model/double_pendulum/model.urdf
+++ b/tutorial/model/double_pendulum/model.urdf
@@ -90,9 +90,14 @@
   
   
   <gazebo>
+    <!-- Create an instance the gazebo_controlboard YARP device called "controlboard_plugin_device"-->
     <plugin name="controlboard" filename="libgazebo_yarp_controlboard.so">
         <yarpConfigurationFile>model://double_pendulum/conf/gazebo_controlboard.ini</yarpConfigurationFile>
         <initialConfiguration>0.0 0.0</initialConfiguration>
+    </plugin>
+    <!-- Launch the other YARP devices, in this case a controlboardwrapper2 to expose the controlboard functionalities via YARP ports -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://double_pendulum/conf/double_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
     </plugin>
   </gazebo>
 </robot>

--- a/tutorial/model/single_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/model/single_pendulum/conf/gazebo_controlboard.ini
@@ -1,24 +1,6 @@
-[WRAPPER]
-# name of the wrapper device to be instatiated by the factory
-device controlboardwrapper2
-# rate of output streaming from ports in ms
-period 10
-# output port name 
-name /singlePendulumGazebo/body
-# Total number of joints
-joints 1
-# list of MotorControl device to use
-networks ( pendulum )
-# for each network specify the joint map
-pendulum  0 0 0 0
-# Verbose output (on if present, off if commented out)
-# verbose
-
-# Specify configuration of MotorControl devices
-[pendulum]
-device gazebo_controlboard
+disableImplicitNetworkWrapper
+yarpDeviceName controlboard_plugin_device
 jointNames joint
-name pendulum
 
 #PIDs:
 # this information is used to set the PID values in simulation for GAZEBO, we need only the first three values

--- a/tutorial/model/single_pendulum/conf/single_pendulum_nws.xml
+++ b/tutorial/model/single_pendulum/conf/single_pendulum_nws.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="single_pendulum" portprefix="single_pendulum" build="0" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+        <device name="single_pendulum_nws_yarp" type="controlBoard_nws_yarp">
+            <!-- See https://www.yarp.it/latest/classControlBoard__nws__yarp.html for parameter documentation -->
+            <param name="name"> /singlePendulumGazebo/body </param>
+            <param name="period"> 0.01 </param>
+            <action phase="startup" level="5" type="attach">
+                <!-- This is the same name that we passed with the yarpDeviceName to the gazebo_controlboard plugin -->
+                <param name="device"> controlboard_plugin_device </param>
+            </action>
+            <action phase="shutdown" level="5" type="detach" />
+        </device>
+    </devices>
+</robot>

--- a/tutorial/model/single_pendulum/model.urdf
+++ b/tutorial/model/single_pendulum/model.urdf
@@ -62,9 +62,14 @@
   
   
   <gazebo>
+    <!-- Create an instance the gazebo_controlboard YARP device called "controlboard_plugin_device"-->
     <plugin name="controlboard" filename="libgazebo_yarp_controlboard.so">
         <yarpConfigurationFile>model://single_pendulum/conf/gazebo_controlboard.ini</yarpConfigurationFile>
         <initialConfiguration>0.0 0.0</initialConfiguration>
+    </plugin>
+    <!-- Launch the other YARP devices, in this case a controlboardwrapper2 to expose the controlboard functionalities via YARP ports -->
+    <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">
+        <yarpRobotInterfaceConfigurationFile>model://single_pendulum/conf/single_pendulum_nws.xml</yarpRobotInterfaceConfigurationFile>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/568 .