### PR TITLE
Cleanup use of the GazeboYarpPlugins::Handler::getHandler() object to actually remove a device once is deleted

### DIFF
--- a/libraries/singleton/src/Handler.cc
+++ b/libraries/singleton/src/Handler.cc
@@ -271,8 +271,6 @@ bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yar
                 inserted_yarpDeviceName2deviceDatabaseKey.insert({yarpDeviceName, deviceDatabaseKey});
                 list.push(devicesMapElem.second.object(), yarpDeviceName.c_str());
                 deviceScopedNames.push_back(deviceDatabaseKey);
-                // Increase usage counter
-                setDevice(deviceDatabaseKey, devicesMapElem.second.object());
             } else {
                 // If a name collision is found, print a clear error and return
                 yError() << "GazeboYARPPlugins robotinterface getDevicesAsPolyDriverList error: ";
@@ -282,7 +280,6 @@ bool Handler::getDevicesAsPolyDriverList(const std::string& modelScopedName, yar
                 yError() << "Second instance: " << deviceDatabaseKey;
                 yError() << "Please eliminate or rename one of the two instances. ";
                 list = yarp::dev::PolyDriverList();
-                releaseDevicesInList(deviceScopedNames);
                 deviceScopedNames.resize(0);
                 return false;
             }

--- a/plugins/camera/include/gazebo/Camera.hh
+++ b/plugins/camera/include/gazebo/Camera.hh
@@ -55,6 +55,8 @@ namespace gazebo
         yarp::dev::PolyDriver m_cameraDriver;
         std::string m_sensorName;
         sensors::CameraSensor *m_sensor;
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
 
         yarp::dev::IFrameGrabberImage*      iFrameGrabberImage;
     };

--- a/plugins/controlboard/include/gazebo/ControlBoard.hh
+++ b/plugins/controlboard/include/gazebo/ControlBoard.hh
@@ -59,6 +59,7 @@ private:
     bool m_useVirtAnalogSensor = false;
     #endif
     yarp::dev::PolyDriver m_controlboardDriver;
+    bool m_deviceRegistered;
     std::string m_scopedDeviceName;
     std::string m_yarpDeviceName;
 

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -54,12 +54,20 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             m_virtAnalogSensorWrapper.close();
         }
 
-        for (int n = 0; n < m_controlBoards.size(); n++) {
-            std::string scopedDeviceName = m_robotName + "::" + m_controlBoards[n]->key.c_str();
-            GazeboYarpPlugins::Handler::getHandler()->removeDevice(scopedDeviceName);
+        if (m_deviceRegistered) {
+            if (m_parameters.check("disableImplicitNetworkWrapper")) {
+                GazeboYarpPlugins::Handler::getHandler()->removeDevice(m_scopedDeviceName);
+            } else {
+                for (int n = 0; n < m_controlBoards.size(); n++) {
+                    std::string scopedDeviceName = m_robotName + "::" + m_controlBoards[n]->key.c_str();
+                    GazeboYarpPlugins::Handler::getHandler()->removeDevice(scopedDeviceName);
+                }
+            }
         }
         #else
-        GazeboYarpPlugins::Handler::getHandler()->removeDevice(m_scopedDeviceName);
+        if (m_deviceRegistered) {
+            GazeboYarpPlugins::Handler::getHandler()->removeDevice(m_scopedDeviceName);
+        }
         #endif
 
         GazeboYarpPlugins::Handler::getHandler()->removeRobot(m_robotName);
@@ -191,6 +199,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     else
                 {
                     scopedDeviceName = m_robotName + "::" + m_parameters.find("yarpDeviceName").asString();
+                    m_scopedDeviceName = scopedDeviceName;
                 }
             
                 newPoly.poly = GazeboYarpPlugins::Handler::getHandler()->getDevice(scopedDeviceName);
@@ -239,8 +248,8 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     yCError(GAZEBOCONTROLBOARD) << "failed setting scopedDeviceName(=" << scopedDeviceName << ")";
                     return;
                 }
+                m_deviceRegistered = true;
                 yCInfo(GAZEBOCONTROLBOARD) << "Registered YARP device with instance name:" << scopedDeviceName;
-
                 m_controlBoards.push(newPoly);
             }
 
@@ -315,6 +324,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 yCError(GAZEBOCONTROLBOARD) << "failed setting scopedDeviceName(=" << m_scopedDeviceName << ")";
                 return;
             }
+            m_deviceRegistered = true;
             yCInfo(GAZEBOCONTROLBOARD) << "Registered YARP device with instance name:" << m_scopedDeviceName;
         }
         #else
@@ -350,6 +360,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             yCError(GAZEBOCONTROLBOARD) << "failed setting scopedDeviceName(=" << m_scopedDeviceName << ")";
             return;
         }
+        m_deviceRegistered = true;
         yCInfo(GAZEBOCONTROLBOARD) << "Registered YARP device with instance name:" << m_scopedDeviceName;
         #endif
     }

--- a/plugins/depthCamera/include/gazebo/DepthCamera.hh
+++ b/plugins/depthCamera/include/gazebo/DepthCamera.hh
@@ -63,7 +63,8 @@ namespace gazebo
         yarp::dev::PolyDriver m_cameraDriver;
         std::string m_sensorName;
         sensors::DepthCameraSensor *m_sensor;
-
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
         #ifndef GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS
         yarp::dev::PolyDriver m_cameraWrapper;
         yarp::dev::IMultipleWrapper* m_iWrap;

--- a/plugins/forcetorque/include/gazebo/ForceTorque.hh
+++ b/plugins/forcetorque/include/gazebo/ForceTorque.hh
@@ -57,15 +57,17 @@ namespace gazebo
     public:
         GazeboYarpForceTorque();
         virtual ~GazeboYarpForceTorque();
-        
+
         virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
 
     private:
         yarp::dev::PolyDriver m_forcetorqueWrapper;
         yarp::dev::IMultipleWrapper* m_iWrap;
         yarp::dev::PolyDriver m_forceTorqueDriver;
-        
+
         std::string m_sensorName;
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
     };
 }
 

--- a/plugins/imu/include/gazebo/IMU.hh
+++ b/plugins/imu/include/gazebo/IMU.hh
@@ -67,13 +67,16 @@ namespace gazebo
         void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf) override;
 
     private:
-        yarp::os::Property m_parameters; 
+        yarp::os::Property m_parameters;
         yarp::dev::PolyDriver m_imuDriver;
         yarp::dev::PolyDriver m_MASWrapper;
         yarp::dev::PolyDriver m_AdditionalWrapper; // for the legacy wrapper ServerInertial
         yarp::dev::IMultipleWrapper* m_iWrap{nullptr};
         yarp::dev::IMultipleWrapper* m_iWrapAdditional{nullptr};
         std::string m_scopedSensorName;
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
+
     };
 }
 

--- a/plugins/lasersensor/include/gazebo/LaserSensor.hh
+++ b/plugins/lasersensor/include/gazebo/LaserSensor.hh
@@ -67,6 +67,8 @@ namespace gazebo
         yarp::dev::PolyDriver m_laserDriver;
         
         std::string m_sensorName;
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
     };
 }
 

--- a/plugins/multicamera/include/gazebo/MultiCamera.hh
+++ b/plugins/multicamera/include/gazebo/MultiCamera.hh
@@ -50,6 +50,8 @@ namespace gazebo
         sensors::MultiCameraSensor *m_sensor;
 
         yarp::dev::IFrameGrabberImage*      iFrameGrabberImage;
+        bool m_deviceRegistered;
+        std::string m_scopedDeviceName;
     };
 }
 

--- a/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
+++ b/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
@@ -23,7 +23,7 @@ GazeboYarpRobotInterface::GazeboYarpRobotInterface()
 
 GazeboYarpRobotInterface::~GazeboYarpRobotInterface()
 {
-    // Close robotinterface 
+    // Close robotinterface
     bool ok = m_xmlRobotInterfaceResult.robot.enterPhase(yarp::robotinterface::ActionPhaseInterrupt1);
     if (!ok) {
         yError() << "GazeboYarpRobotInterface: impossible to run phase ActionPhaseInterrupt1 robotinterface";
@@ -32,8 +32,6 @@ GazeboYarpRobotInterface::~GazeboYarpRobotInterface()
     if (!ok) {
         yError() << "GazeboYarpRobotInterface: impossible  to run phase ActionPhaseShutdown in robotinterface";
     }
-
-    GazeboYarpPlugins::Handler::getHandler()->releaseDevicesInList(m_deviceScopedNames);
 
     yarp::os::Network::fini();
 }

--- a/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
+++ b/plugins/robotinterface/src/GazeboYarpRobotInterface.cc
@@ -50,8 +50,6 @@ void GazeboYarpRobotInterface::Load(physics::ModelPtr _parentModel, sdf::Element
         return;
     }
 
-    GazeboYarpPlugins::Handler::getHandler()->setRobot(get_pointer(_parentModel));
-
     // Getting .xml and loading configuration file from sdf
     bool loaded_configuration = false;
     if (_sdf->HasElement("yarpRobotInterfaceConfigurationFile"))


### PR DESCRIPTION
The changes are the following:
* The commit https://github.com/robotology/gazebo-yarp-plugins/commit/f3e035641d99317ea3e88f751d31597d1ef937d0 modifies `gazebo_yarp_robotinterface` to not increase device use counter in singleton when device is returned to robotinterface. The rationale is that the handler is not the owner of the YARP device object, that instead are owned (and eventually destroyed before the handler of the `gazebo_yarp_robotinterface` plugin instance) by the model/sensor plugin that created it.
It does not make sense to have a usage count that does not reflect it the device is actually valid or not. By doing so, we make sure that the device is actually removed when the device is about to be destroyed. 
* The commit https://github.com/robotology/gazebo-yarp-plugins/pull/618/commits/4e2529fff2cea448d3764a8c3f5c79ea760d8c05 removed a setRobot call in `gazebo_yarp_robotinterface` that incremented the usage counter of the robot in the singleton, without a corresponding removeRobot.
* All the other commits just make sure that all the plugins that call `setDevice` in GazeboYarpPlugins::Handler::getHandler() to register a device also call `removeDevice` (with the correct argument) once the device is not available anymore. Several `setDevice` were added recently without a corresponding `removeDevice`.