### PR TITLE
gazebo_yarp_controlboard: Add coupling icub_left_hand_mk4 to model iCub mk4 left hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - In `gazebo_yarp_camera` parse the `yarpDeviceName` option to enable its use with `gazebo_yarp_robotinterface` (https://github.com/robotology/gazebo-yarp-plugins/pull/614).
+- In `gazebo_yarp_controlboard` add the `icub_hand_mk4` coupling that models the iCub mk4 hand (https://github.com/robotology/gazebo-yarp-plugins/pull/620). 
 
 ### Changed
 - Migrate the example models under the tutorial directory to avoid the use of implicit network wrapper servers, and use the `gazebo_yarp_robotinterface` plugin to spawn their network wrapper servers (https://github.com/robotology/gazebo-yarp-plugins/pull/615 and https://github.com/robotology/gazebo-yarp-plugins/pull/616). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Added
 - In `gazebo_yarp_camera` parse the `yarpDeviceName` option to enable its use with `gazebo_yarp_robotinterface` (https://github.com/robotology/gazebo-yarp-plugins/pull/614).
-- In `gazebo_yarp_controlboard` add the `icub_hand_mk4` coupling that models the iCub mk4 hand (https://github.com/robotology/gazebo-yarp-plugins/pull/620). 
+- In `gazebo_yarp_controlboard` add the `icub_left_hand_mk4` coupling that models the iCub mk4 left hand (https://github.com/robotology/gazebo-yarp-plugins/pull/620). 
 
 ### Changed
 - Migrate the example models under the tutorial directory to avoid the use of implicit network wrapper servers, and use the `gazebo_yarp_robotinterface` plugin to spawn their network wrapper servers (https://github.com/robotology/gazebo-yarp-plugins/pull/615 and https://github.com/robotology/gazebo-yarp-plugins/pull/616). 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -172,6 +172,31 @@ public:
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
 };
 
+class HandMk3CouplingHandler : public BaseCouplingHandler
+{
+
+public:
+    HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
+
+public:
+    bool decouplePos (yarp::sig::Vector& current_pos);
+    bool decoupleVel (yarp::sig::Vector& current_vel);
+    bool decoupleAcc (yarp::sig::Vector& current_acc);
+    bool decoupleTrq (yarp::sig::Vector& current_trq);
+
+    yarp::sig::Vector decoupleRefPos (yarp::sig::Vector& pos_ref);
+    yarp::sig::Vector decoupleRefVel (yarp::sig::Vector& vel_ref);
+    yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
+    
+protected:
+    double decouple (double q2, std::vector<double>& lut);
+
+    const int LUTSIZE;
+
+    std::vector<double> thumb_lut;
+    std::vector<double> index_lut;
+};
+
 class HandMk4CouplingHandler : public BaseCouplingHandler
 {
 

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -172,11 +172,11 @@ public:
     yarp::sig::Vector decoupleRefTrq (yarp::sig::Vector& trq_ref);
 };
 
-class HandMk3CouplingHandler : public BaseCouplingHandler
+class HandMk4CouplingHandler : public BaseCouplingHandler
 {
 
 public:
-    HandMk3CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
+    HandMk4CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
     bool decouplePos (yarp::sig::Vector& current_pos);

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -195,6 +195,7 @@ protected:
 
     std::vector<double> thumb_lut;
     std::vector<double> index_lut;
+    std::vector<double> pinkie_lut;
 };
 
 #endif //GAZEBOYARP_COUPLING_H

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -327,9 +327,15 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
             }
             else if (coupling_bottle->get(0).asString()=="icub_hand_mk3")
             {
-                BaseCouplingHandler* cpl = new HandMk4CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
+                BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk3";
+            }
+            else if (coupling_bottle->get(0).asString()=="icub_hand_mk4")
+            {
+                BaseCouplingHandler* cpl = new HandMk4CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
+                m_coupling_handler.push_back(cpl);
+                yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk4";
             }
             else if (coupling_bottle->get(0).asString()=="none")
             {

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -175,7 +175,8 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
         m_velocity_watchdog[j] = new Watchdog(0.200); //watchdog set to 200ms
     }
 
-    yCDebug(GAZEBOCONTROLBOARD) << "done";
+    yCDebug(GAZEBOCONTROLBOARD) << "Trajectory successfully generated.";
+
     for (size_t j = 0; j < m_numberOfJoints; ++j)
     {
         m_controlMode[j] = VOCAB_CM_POSITION;

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -327,7 +327,7 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
             }
             else if (coupling_bottle->get(0).asString()=="icub_hand_mk3")
             {
-                BaseCouplingHandler* cpl = new HandMk3CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
+                BaseCouplingHandler* cpl = new HandMk4CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
                 yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk3";
             }

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -331,11 +331,11 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
                 m_coupling_handler.push_back(cpl);
                 yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk3";
             }
-            else if (coupling_bottle->get(0).asString()=="icub_hand_mk4")
+            else if (coupling_bottle->get(0).asString()=="icub_left_hand_mk4")
             {
                 BaseCouplingHandler* cpl = new HandMk4CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
                 m_coupling_handler.push_back(cpl);
-                yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk4";
+                yCInfo(GAZEBOCONTROLBOARD) << "using icub_left_hand_mk4";
             }
             else if (coupling_bottle->get(0).asString()=="none")
             {

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -602,10 +602,10 @@ yarp::sig::Vector CerHandCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq
 }
 
 //------------------------------------------------------------------------------------------------------------------
-// HandMk3CouplingHandler
+// HandMk4CouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 
-HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
 : BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits), LUTSIZE(4096)
 {
     const double RAD2DEG = 180.0/atan2(0.0,-1.0);
@@ -736,7 +736,7 @@ HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, ya
     }
 }
 
-bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
+bool HandMk4CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     current_pos[m_coupledJoints[2]] = current_pos[m_coupledJoints[2]] + current_pos[m_coupledJoints[3]];
@@ -747,7 +747,7 @@ bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
     return true;
 }
 
-bool HandMk3CouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
+bool HandMk4CouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     current_vel[m_coupledJoints[2]] = current_vel[m_coupledJoints[2]] + current_vel[m_coupledJoints[3]];
@@ -758,7 +758,7 @@ bool HandMk3CouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
     return true;
 }
 
-bool HandMk3CouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
+bool HandMk4CouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
 {	
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     current_acc[m_coupledJoints[2]] = current_acc[m_coupledJoints[2]] + current_acc[m_coupledJoints[3]];
@@ -769,13 +769,13 @@ bool HandMk3CouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
     return true;
 }
 
-bool HandMk3CouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
+bool HandMk4CouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
 {
     if (m_coupledJoints.size()!=m_couplingSize) return false;
     return false;
 }
 
-double HandMk3CouplingHandler::decouple (double q2, std::vector<double>& lut)
+double HandMk4CouplingHandler::decouple (double q2, std::vector<double>& lut)
 {
 
     double dindex = q2*10.0;
@@ -786,10 +786,10 @@ double HandMk3CouplingHandler::decouple (double q2, std::vector<double>& lut)
     return lut[iindex]*(1.0 - w) + lut[iindex + 1]*w;
 }
 
-yarp::sig::Vector HandMk3CouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
+yarp::sig::Vector HandMk4CouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
 {
     yarp::sig::Vector out = pos_ref;
-    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk4CouplingHandler: Invalid coupling vector"; return out;}
     out[m_coupledJoints[2]]  = decouple(pos_ref[m_coupledJoints[2]], thumb_lut);
     out[m_coupledJoints[3]]  = pos_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
     out[m_coupledJoints[4]]  = pos_ref[m_coupledJoints[3]];
@@ -804,10 +804,10 @@ yarp::sig::Vector HandMk3CouplingHandler::decoupleRefPos (yarp::sig::Vector& pos
     return out;
 }
 
-yarp::sig::Vector HandMk3CouplingHandler::decoupleRefVel (yarp::sig::Vector& vel_ref)
+yarp::sig::Vector HandMk4CouplingHandler::decoupleRefVel (yarp::sig::Vector& vel_ref)
 {
     yarp::sig::Vector out = vel_ref;
-    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk4CouplingHandler: Invalid coupling vector"; return out;}
     out[m_coupledJoints[2]]  = decouple(vel_ref[m_coupledJoints[2]], thumb_lut);
     out[m_coupledJoints[3]]  = vel_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
     out[m_coupledJoints[4]]  = vel_ref[m_coupledJoints[3]];
@@ -822,10 +822,10 @@ yarp::sig::Vector HandMk3CouplingHandler::decoupleRefVel (yarp::sig::Vector& vel
     return out;
 }
 
-yarp::sig::Vector HandMk3CouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_ref)
+yarp::sig::Vector HandMk4CouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_ref)
 {
     yarp::sig::Vector out =trq_ref;
-    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk4CouplingHandler: Invalid coupling vector"; return out;}
     out[m_coupledJoints[2]]  = decouple(trq_ref[m_coupledJoints[2]], thumb_lut);
     out[m_coupledJoints[3]]  = trq_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
     out[m_coupledJoints[4]]  = trq_ref[m_coupledJoints[3]];

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -602,6 +602,239 @@ yarp::sig::Vector CerHandCouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq
 }
 
 //------------------------------------------------------------------------------------------------------------------
+// HandMk3CouplingHandler
+//------------------------------------------------------------------------------------------------------------------
+
+HandMk3CouplingHandler::HandMk3CouplingHandler(gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits)
+: BaseCouplingHandler(model, coupled_joints,coupled_joint_names, coupled_joint_limits), LUTSIZE(4096)
+{
+    const double RAD2DEG = 180.0/atan2(0.0,-1.0);
+    const double DEG2RAD = 1.0/RAD2DEG;
+    
+    m_couplingSize = 11;
+    
+    thumb_lut.resize(LUTSIZE);
+    index_lut.resize(LUTSIZE);
+    
+    std::vector<double> num(LUTSIZE);
+    
+    for (int n = 0; n < LUTSIZE; ++n)
+    {
+        num[n] = 0.0;
+        thumb_lut[n] = 0.0;
+    }
+
+    // thumb
+    {        
+        double L0x = -0.00555,          L0y = 0.00195+0.0009;
+        double P1x =  0.020,            P1y = 0.0015;
+        double L1x =  P1x-0.0055-0.003, L1y = P1y-0.002+0.0019;
+        
+        double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
+        double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
+        
+        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        
+        for (double q1 = 0.0; q1 <= 85.5; q1 += 0.01)
+        {
+            double cq1 = cos(DEG2RAD*q1);
+            double sq1 = sin(DEG2RAD*q1);
+            
+            double P1xr = cq1*P1x-sq1*P1y;
+            double P1yr = sq1*P1x+cq1*P1y;
+            
+            double h2 = (P1xr - L0x)*(P1xr - L0x) + (P1yr - L0y)*(P1yr - L0y);
+            
+            double alfa = RAD2DEG*atan2(L0y - P1yr, L0x - P1xr);
+            
+            double beta = RAD2DEG*acos((h2 + l2 - k2)/(2.0*sqrt(h2*l2)));
+            
+            double q2 = alfa + beta - offset;
+            
+            while (q2 <    0.0) q2 += 360.0;
+            while (q2 >= 360.0) q2 -= 360.0;
+            
+            double dindex = q2*10.0;
+            
+            int iindex = int(dindex);
+            
+            double w = dindex - double(iindex);
+            
+            thumb_lut[iindex] += (1.0 - w)*q1;
+            num[iindex] += (1.0 - w);
+            
+            thumb_lut[iindex + 1] += w*q1;
+            num[iindex + 1] += w;
+        }
+        
+        for (int n = 0; n < LUTSIZE; ++n)
+        {
+            if (num[n] > 0.0)
+            {
+                thumb_lut[n] /= num[n];
+            }
+        }
+    }
+        
+    for (int n = 0; n < LUTSIZE; ++n)
+    {
+        num[n] = 0.0;
+        index_lut[n] = 0.0;
+    }
+    
+    // finger
+    {    
+        double P1x =  0.0300, P1y = 0.0015;
+        double L0x = -0.0050, L0y = 0.0040;
+        double L1x =  0.0240, L1y = 0.0008;
+        
+        double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
+        double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
+        
+        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        
+        for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
+        {
+            double cq1 = cos(DEG2RAD*q1);
+            double sq1 = sin(DEG2RAD*q1);
+            
+            double P1xr = cq1*P1x-sq1*P1y;
+            double P1yr = sq1*P1x+cq1*P1y;
+            
+            double h2 = (P1xr - L0x)*(P1xr - L0x) + (P1yr - L0y)*(P1yr - L0y);
+            
+            double alfa = RAD2DEG*atan2(L0y - P1yr, L0x - P1xr);
+            
+            double beta = RAD2DEG*acos((h2 + l2 - k2)/(2.0*sqrt(h2*l2)));
+            
+            double q2 = alfa + beta - offset;
+            
+            while (q2 <    0.0) q2 += 360.0;
+            while (q2 >= 360.0) q2 -= 360.0;
+            
+            // get decimal part of q2 to find out how to weigh index and index+1
+            double dindex = q2*10.0;
+            int iindex = int(dindex);
+            double w = dindex - double(iindex);
+            
+            // Construct LUT
+            index_lut[iindex] += (1.0 - w)*q1;
+            num[iindex] += (1.0 - w);
+            
+            index_lut[iindex + 1] += w*q1;
+            num[iindex + 1] += w;
+        }
+        
+        // divide each value in the LUT by the weight if it is greater than 0 to extract q1
+        for (int n = 0; n < LUTSIZE; ++n)
+        {
+            if (num[n] > 0.0)
+            {
+                index_lut[n] /= num[n];
+            }
+        }
+    }
+}
+
+bool HandMk3CouplingHandler::decouplePos (yarp::sig::Vector& current_pos)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_pos[m_coupledJoints[2]] = current_pos[m_coupledJoints[2]] + current_pos[m_coupledJoints[3]];
+    current_pos[m_coupledJoints[3]] = current_pos[m_coupledJoints[4]];
+    current_pos[m_coupledJoints[4]] = current_pos[m_coupledJoints[5]] + current_pos[m_coupledJoints[6]];
+    current_pos[m_coupledJoints[5]] = current_pos[m_coupledJoints[7]] + current_pos[m_coupledJoints[8]];
+    current_pos[m_coupledJoints[6]] = current_pos[m_coupledJoints[9]] + current_pos[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleVel (yarp::sig::Vector& current_vel)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_vel[m_coupledJoints[2]] = current_vel[m_coupledJoints[2]] + current_vel[m_coupledJoints[3]];
+    current_vel[m_coupledJoints[3]] = current_vel[m_coupledJoints[4]];
+    current_vel[m_coupledJoints[4]] = current_vel[m_coupledJoints[5]] + current_vel[m_coupledJoints[6]];
+    current_vel[m_coupledJoints[5]] = current_vel[m_coupledJoints[7]] + current_vel[m_coupledJoints[8]];
+    current_vel[m_coupledJoints[6]] = current_vel[m_coupledJoints[9]] + current_vel[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleAcc (yarp::sig::Vector& current_acc)
+{	
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    current_acc[m_coupledJoints[2]] = current_acc[m_coupledJoints[2]] + current_acc[m_coupledJoints[3]];
+    current_acc[m_coupledJoints[3]] = current_acc[m_coupledJoints[4]];
+    current_acc[m_coupledJoints[4]] = current_acc[m_coupledJoints[5]] + current_acc[m_coupledJoints[6]];
+    current_acc[m_coupledJoints[5]] = current_acc[m_coupledJoints[7]] + current_acc[m_coupledJoints[8]];
+    current_acc[m_coupledJoints[6]] = current_acc[m_coupledJoints[9]] + current_acc[m_coupledJoints[10]];
+    return true;
+}
+
+bool HandMk3CouplingHandler::decoupleTrq (yarp::sig::Vector& current_trq)
+{
+    if (m_coupledJoints.size()!=m_couplingSize) return false;
+    return false;
+}
+
+double HandMk3CouplingHandler::decouple (double q2, std::vector<double>& lut)
+{
+
+    double dindex = q2*10.0;
+    int iindex = int(dindex);
+    // get decimal part of q2 to find out how to weigh index and index+1
+    double w = dindex - double(iindex);
+    // interpolate between index and the next with a convex combination weighting
+    return lut[iindex]*(1.0 - w) + lut[iindex + 1]*w;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefPos (yarp::sig::Vector& pos_ref)
+{
+    yarp::sig::Vector out = pos_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(pos_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = pos_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = pos_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(pos_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = pos_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(pos_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = pos_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(pos_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = pos_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
+    return out;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefVel (yarp::sig::Vector& vel_ref)
+{
+    yarp::sig::Vector out = vel_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(vel_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = vel_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = vel_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(vel_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = vel_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(vel_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = vel_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(vel_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = vel_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
+    return out;
+}
+
+yarp::sig::Vector HandMk3CouplingHandler::decoupleRefTrq (yarp::sig::Vector& trq_ref)
+{
+    yarp::sig::Vector out =trq_ref;
+    if (m_coupledJoints.size()!=m_couplingSize) {yCError(GAZEBOCONTROLBOARD) << "HandMk3CouplingHandler: Invalid coupling vector"; return out;}
+    out[m_coupledJoints[2]]  = decouple(trq_ref[m_coupledJoints[2]], thumb_lut);
+    out[m_coupledJoints[3]]  = trq_ref[m_coupledJoints[2]] - out[m_coupledJoints[2]];
+    out[m_coupledJoints[4]]  = trq_ref[m_coupledJoints[3]];
+    out[m_coupledJoints[5]]  = decouple(trq_ref[m_coupledJoints[4]], index_lut);
+    out[m_coupledJoints[6]]  = trq_ref[m_coupledJoints[4]] - out[m_coupledJoints[5]];
+    out[m_coupledJoints[7]]  = decouple(trq_ref[m_coupledJoints[5]], index_lut);
+    out[m_coupledJoints[8]]  = trq_ref[m_coupledJoints[5]] - out[m_coupledJoints[7]];
+    out[m_coupledJoints[9]]  = decouple(trq_ref[m_coupledJoints[6]], index_lut);
+    out[m_coupledJoints[10]] = trq_ref[m_coupledJoints[6]] - out[m_coupledJoints[9]];
+    return out;
+}
+
+//------------------------------------------------------------------------------------------------------------------
 // HandMk4CouplingHandler
 //------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR aims to ~update the coupling rules of the mk3 hand with the new mk4 version given that the former is now obsolete~ add new coupling rules for the new iCub hand mk4, while keeping intact the mk3 version until declared obsolete.
The hand mk4 has 5 fingers, causing an increase in the number of joints. In particular, the ring and pinkie fingers move together, since they are physically actuated by one tendon only. 

The coupling laws that map the degrees of actuation into model joints are kept to the mk3 version, although they need updating since the geometric quantities have changed.

Reference documentation on the subject: 
[FingerkinV2.docx](https://github.com/robotology/gazebo-yarp-plugins/files/8408472/FingerkinV2.docx)
