### PR TITLE
Fix for GazeboYarpDepthCameraDriver::getDepthImage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ## [Unreleased]
 
 ### Fixed
-- Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image.
+- Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image (https://github.com/robotology/gazebo-yarp-plugins/pull/623).
 
 ## [4.3.0] - 2022-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 - It is now possible to remove and add again to the simulation models that use `gazebo_yarp_robotinterface` without any crash (https://github.com/robotology/gazebo-yarp-plugins/pull/618, https://github.com/robotology/gazebo-yarp-plugins/pull/619).
 - Fixed value returned by getDeviceStatus method in `gazebo_yarp_laser` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/617).
 
+### Fixed
+- Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image.
+
+
 ## [4.2.0] - 2022-02-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Fixed
+- Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image.
+
 ## [4.3.0] - 2022-04-04
 
 ### Added
@@ -17,10 +20,6 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 ### Fixed 
 - It is now possible to remove and add again to the simulation models that use `gazebo_yarp_robotinterface` without any crash (https://github.com/robotology/gazebo-yarp-plugins/pull/618, https://github.com/robotology/gazebo-yarp-plugins/pull/619).
 - Fixed value returned by getDeviceStatus method in `gazebo_yarp_laser` plugin (https://github.com/robotology/gazebo-yarp-plugins/pull/617).
-
-### Fixed
-- Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image.
-
 
 ## [4.2.0] - 2022-02-28
 

--- a/plugins/depthCamera/src/DepthCameraDriver.cpp
+++ b/plugins/depthCamera/src/DepthCameraDriver.cpp
@@ -421,18 +421,19 @@ bool GazeboYarpDepthCameraDriver::getDepthImage(depthImageType& depthImage, Stam
         memcpy(depthImage.getRawImage(), m_depthFrame_Buffer, m_width * m_height * sizeof(float));
     }
     else {
-        double nearPlane = m_depthCameraSensorPtr->DepthCamera()->NearClip();
-        double farPlane = m_depthCameraSensorPtr->DepthCamera()->FarClip();
+        float nearPlane = (float) m_depthCameraSensorPtr->DepthCamera()->NearClip();
+        float farPlane = (float) m_depthCameraSensorPtr->DepthCamera()->FarClip();
 
         int intTemp;
         float value;
+        float powCoeff = pow(10.0f, (float) m_depthDecimalNum);
 
         auto pxPtr = reinterpret_cast<float*>(depthImage.getRawImage());
         for(int i=0; i<m_height*m_width; i++){
             value = m_depthFrame_Buffer[i];
 
-            intTemp = (int) (value * pow(10.0, (float) m_depthDecimalNum));
-            value = (float) intTemp / pow(10.0, (float) m_depthDecimalNum);
+            intTemp = (int) (value * powCoeff);
+            value = ((float) intTemp) / powCoeff;
 
             if (value < nearPlane) { value = nearPlane; }
             if (value > farPlane) { value = farPlane; }


### PR DESCRIPTION
Removed implicit conversions from the depth data quantization in
`GazeboYarpDepthCameraDriver::getDepthImage` which in at least one
occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`.

Also, the calculation of the scalar coefficient (involving `math::pow`),
used to cut the decimal figures from the depth data, has been moved
outside the for loop that cycles through the whole image.