### PR TITLE
Update coupling parameters for thumb and pinkie of Hand Mk4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Fixed
 - Removed implicit conversions from the depth data quantization in `GazeboYarpDepthCameraDriver::getDepthImage` which in at least one occasion caused an unexpected crash of the `rgbdSensor_nws_yarp`. Also, the calculation of the scalar coefficient (involving `math::pow`), used to cut the decimal figures from the depth data, has been moved outside the for loop that cycles through the whole image (https://github.com/robotology/gazebo-yarp-plugins/pull/623).
+- In `gazebo_yarp_controlboard` update the parameters in `icub_left_hand_mk4` regarding pinkie and thumb which are used to generate the look-up table to approximate the coupling laws. (https://github.com/robotology/gazebo-yarp-plugins/pull/624)
 
 ## [4.3.0] - 2022-04-04
 

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -866,7 +866,7 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
         
-        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        double offset = 180;
         
         for (double q1 = 0.0; q1 <= 85.5; q1 += 0.01)
         {
@@ -923,7 +923,6 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
         
-        //double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
         double offset = 173.35;
 
         for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
@@ -982,7 +981,6 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
         
-        //double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
         double offset = 170.54;
         for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
         {

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -852,17 +852,16 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
     
     std::vector<double> num(LUTSIZE);
     
+    // thumb
     for (int n = 0; n < LUTSIZE; ++n)
     {
         num[n] = 0.0;
         thumb_lut[n] = 0.0;
     }
-
-    // thumb
     {        
-        double L0x = -0.00555,          L0y = 0.00195+0.0009;
-        double P1x =  0.020,            P1y = 0.0015;
-        double L1x =  P1x-0.0055-0.003, L1y = P1y-0.002+0.0019;
+        double L0x = -0.00555,    L0y = 0.00285;
+        double P1x =  0.02,       P1y = 0.0015;
+        double L1x =  0.0115,     L1y = 0.0015;
         
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -909,14 +909,13 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
             }
         }
     }
-        
+
+    // index, middle, ring   
     for (int n = 0; n < LUTSIZE; ++n)
     {
         num[n] = 0.0;
         index_lut[n] = 0.0;
     }
-    
-    // finger
     {    
         double P1x =  0.0300, P1y = 0.0015;
         double L0x = -0.0050, L0y = 0.0040;
@@ -971,6 +970,11 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
     }
 
     // pinkie
+    for (int n = 0; n < LUTSIZE; ++n)
+    {
+        num[n] = 0.0;
+        pinkie_lut[n] = 0.0;
+    }
     {    
         double P1x =  0.0250, P1y = 0.0015;
         double L0x = -0.0050, L0y = 0.0040;

--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -925,8 +925,9 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
         
-        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
-        
+        //double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        double offset = 173.35;
+
         for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
         {
             double cq1 = cos(DEG2RAD*q1);
@@ -971,15 +972,15 @@ HandMk4CouplingHandler::HandMk4CouplingHandler(gazebo::physics::Model* model, ya
 
     // pinkie
     {    
-        double P1x =  0.0300, P1y = 0.0015;
+        double P1x =  0.0250, P1y = 0.0015;
         double L0x = -0.0050, L0y = 0.0040;
-        double L1x =  0.0240, L1y = 0.0008;
+        double L1x =  0.0190, L1y = 0.0005;
         
         double l2 = (P1x - L1x)*(P1x - L1x) + (P1y - L1y)*(P1y - L1y);
         double k2 = (L1x - L0x)*(L1x - L0x) + (L1y - L0y)*(L1y - L0y);
         
-        double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
-        
+        //double offset = RAD2DEG*atan2(L1y-P1y, L1x-P1x);
+        double offset = 170.54;
         for (double q1 = 0.0; q1 <= 95.5; q1 += 0.01)
         {
             double cq1 = cos(DEG2RAD*q1);


### PR DESCRIPTION
This PR aims to change the parameters used to compute the coupling law between the degree of actuation and the finger joints of thumb and pinkie of the new Mk4 hand.
The measurements are taken directly from the CAD models.

Here is a video of the result:

https://user-images.githubusercontent.com/38140169/163136337-217b62d2-8611-4147-be59-5dec5ce693b9.mp4

