### PR TITLE
Suppress 4251 warning on Microsoft Visual C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ include(AddDebugMacro)
 # Enable all possible warning if CMAKE_BUILD_TYPE is debug
 include(AddDebugWarnings)
 
+# Suppress not relevant warnings
+if(MSVC)
+    add_compile_options("/wd4251")
+endif()
+
 #this is required for all plugins
 link_directories(${GAZEBO_LIBRARY_DIRS} ${SDFORMAT_LIBRARY_DIRS} ${PROTOBUF_LIBRARY_DIRS})
 


### PR DESCRIPTION
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/629 . Please ignore Linux tests fails, they are unrelated (it seems).