### PR TITLE
Switch CI to use YCM master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         # YCM
         git clone https://github.com/robotology/ycm
         cd ycm
-        git checkout ycm-0.13
+        git checkout master
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..


### PR DESCRIPTION
This should reduce the mantainance effort (bumping from ycm-0.13, ycm-0.14, etc etc) and avoid problems such as the one described in https://github.com/robotology/ycm/pull/402 .