### PR TITLE
Reference initial orientation to world frame in IMU plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- Added a new `useWorldReferenceOrientation` config option in the `gazebo_imu` plugin to take account for any initial non-zero orientation of the sensor as measured via `yarp::dev::IOrientationSensors` (https://github.com/robotology/gazebo-yarp-plugins/pull/639).
+- The `gazebo_imu` plugin used to output orientation measurements as if the sensor was zero-aligned with the world frame, regardless of the initial orientation of the part the sensor is attached to. To match most real-world IMUs, the default behavior was changed to allow measuring orientation with regard to the world frame at all times. The old behavior can be restored by setting the `useInitialSensorOrientationAsReference` config option (https://github.com/robotology/gazebo-yarp-plugins/pull/639).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
-### Fixed 
+### Added
+
+- Added a new `useWorldReferenceOrientation` config option in the `gazebo_imu` plugin to take account for any initial non-zero orientation of the sensor as measured via `yarp::dev::IOrientationSensors` (https://github.com/robotology/gazebo-yarp-plugins/pull/639).
+
+### Fixed
 
 - Fix wrong install include for gazebo_yarp_lib_common library (https://github.com/robotology/gazebo-yarp-plugins/pull/644).
 

--- a/plugins/imu/src/IMU.cc
+++ b/plugins/imu/src/IMU.cc
@@ -152,8 +152,8 @@ void GazeboYarpIMU::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
                                           {"sensor_name", ::yarp::os::Value{_sensor->Name()}}
                                         };
 
-    if (m_parameters.check("useWorldReferenceOrientation")) {
-        imu_properties.put("useWorldReferenceOrientation", yarp::os::Value::getNullValue());
+    if (m_parameters.check("useInitialSensorOrientationAsReference")) {
+        imu_properties.put("useInitialSensorOrientationAsReference", yarp::os::Value::getNullValue());
     }
 
     //Open the driver

--- a/plugins/imu/src/IMU.cc
+++ b/plugins/imu/src/IMU.cc
@@ -152,6 +152,9 @@ void GazeboYarpIMU::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
                                           {"sensor_name", ::yarp::os::Value{_sensor->Name()}}
                                         };
 
+    if (m_parameters.check("useWorldReferenceOrientation")) {
+        imu_properties.put("useWorldReferenceOrientation", yarp::os::Value::getNullValue());
+    }
 
     //Open the driver
     if (!m_imuDriver.open(imu_properties)) {

--- a/plugins/imu/src/IMUDriver.cpp
+++ b/plugins/imu/src/IMUDriver.cpp
@@ -90,7 +90,7 @@ bool GazeboYarpIMUDriver::open(yarp::os::Searchable& config)
         return false;
     }
 
-    if (config.check("useWorldReferenceOrientation")) {
+    if (!config.check("useInitialSensorOrientationAsReference")) {
         m_parentSensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
     }
 

--- a/plugins/imu/src/IMUDriver.cpp
+++ b/plugins/imu/src/IMUDriver.cpp
@@ -14,6 +14,8 @@
 #include <yarp/os/Log.h>
 #include <yarp/os/LogStream.h>
 
+#include <ignition/math/Quaternion.hh>
+
 using namespace boost::placeholders;
 
 using namespace yarp::dev;
@@ -86,6 +88,10 @@ bool GazeboYarpIMUDriver::open(yarp::os::Searchable& config)
     if (!m_parentSensor) {
         yError() << "GazeboYarpIMUDriver Error: IMU sensor was not found";
         return false;
+    }
+
+    if (config.check("useWorldReferenceOrientation")) {
+        m_parentSensor->SetWorldToReferenceOrientation(ignition::math::Quaterniond::Identity);
     }
 
     //Connect the driver to the gazebo simulation


### PR DESCRIPTION
**Problem:**
The IMU on our robot is mounted in such a way that the sensor frame does not match the inertial/world frame. Adjustments can be made in the SDF model file so that simulated angular velocities and linear accelerations are expressed in the local sensor frame, as expected. However, orientation measurements will always be set to zero by Gazebo at initialization, whereas the real IMU accounts for the frame mismatch and actually returns non-zero values (according to the influence of gravity).

**Proposed solution:**
The sensor can be configured to measure orientations in terms of the world frame via `ImuSensor::SetWorldToReferenceOrientation`. I adapted the solution from the ros-simulation repo linked below. A new configuration option, "useWorldReferenceOrientation", enables this opt-in behavior.

As a side note, we are using an Xsens MTi-28A53G35 sensor, wrapped by the "xsensmtx" YARP device located in [icub-main](https://github.com/robotology/icub-main/tree/9ecb2a8a6c8c7c15cd6b7e626c58443ac6589aea/src/libraries/icubmod/xsensmtx).

See also:
* https://github.com/gazebosim/gazebo-classic/issues/1959
* https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1051
* https://github.com/robotology/gazebo-yarp-plugins/issues/592#issuecomment-1115892822