### PR TITLE
Fix wrong install include for gazebo_yarp_lib_common library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Fixed 
+
+- Fix wrong install include for gazebo_yarp_lib_common library (https://github.com/robotology/gazebo-yarp-plugins/pull/644).
+
 ## [4.6.0] - 2023-01-13
 
 ### Added

--- a/libraries/common/CMakeLists.txt
+++ b/libraries/common/CMakeLists.txt
@@ -10,7 +10,7 @@ PROJECT(Library_Common)
     add_library(gazebo_yarp_lib_common INTERFACE)
     target_include_directories(gazebo_yarp_lib_common INTERFACE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
 
     install(TARGETS gazebo_yarp_lib_common EXPORT GazeboYARPPlugins)


### PR DESCRIPTION
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/643