### PR TITLE
Use ctest --repeat --until-pass:5 to tolerate some test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,7 @@ jobs:
       shell: bash
       run: |
         cd build
-        # Workaround for https://github.com/robotology/gazebo-yarp-plugins/issues/536
-        ctest --output-on-failure -C ${{ matrix.build_type }} -E "ControlBoardControlTest" . 
+        ctest  --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }} . 
 
     - name: Install [Ubuntu]
       if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -79,5 +79,5 @@ jobs:
       shell: bash -l {0}
       run: |
         cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }}
+        ctest --repeat until-pass:5 --output-on-failure -C ${{ matrix.build_type }}
 


### PR DESCRIPTION
By their nature, the kind of tests used in gazebo-yarp-plugins are quite flaky. For this reason, we are only interested in actual failures, i.e. case in which the test fails for many times consecutively and in a consistent way.