### PR TITLE
Drop CI on ubuntu-18.04 with apt dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release, Debug]
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         yarp_version: [master]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-gazebo-yarp-plugins [![Build Status](https://travis-ci.org/robotology/gazebo-yarp-plugins.svg?branch=master)](https://travis-ci.org/robotology/gazebo-yarp-plugins)
+gazebo-yarp-plugins
 ===================
 
 The gazebo-yarp-plugins are a set of [Gazebo plugins](http://gazebosim.org/) that expose [YARP interfaces](http://yarp.it/)


### PR DESCRIPTION
The ubuntu-18.04 images are not supported anymore by GitHub Actions.