### PR TITLE
HandMk5CouplingHandler: refactor it in order to make it configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+- The `icub_hand_mk5` coupling handler has been refactored, it now requires the group `COUPLING_PARAMS` that allows to differentiate between the coupling mk5.0 and mk5.1(https://github.com/robotology/gazebo-yarp-plugins/pull/662).
+
 ## [4.8.0] - 2023-07-31
 
 ### Added

--- a/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
+++ b/plugins/controlboard/include/yarp/dev/ControlBoardDriverCoupling.h
@@ -230,6 +230,8 @@ public:
     HandMk5CouplingHandler (gazebo::physics::Model* model, yarp::sig::VectorOf<int> coupled_joints, std::vector<std::string> coupled_joint_names, std::vector<Range> coupled_joint_limits);
 
 public:
+
+    bool parseFingerParameters(yarp::os::Bottle& hand_params);
     bool decouplePos (yarp::sig::Vector& current_pos);
     bool decoupleVel (yarp::sig::Vector& current_vel);
     bool decoupleAcc (yarp::sig::Vector& current_acc);
@@ -247,8 +249,6 @@ private:
     {
         double L0x;
         double L0y;
-        double L1x;
-        double L1y;
         double q2bias;
         double q1off;
         double k;
@@ -257,41 +257,7 @@ private:
         double b;
     };
 
-    const FingerParameters mParamsThumb =
-    {
-        .L0x = -0.00555,
-        .L0y = 0.00285,
-        .q2bias = 180.0,
-        .q1off = 4.29,
-        .k = 0.0171,
-        .d = 0.02006,
-        .l = 0.0085,
-        .b = 0.00624
-    };
-
-    const FingerParameters mParamsIndex =
-    {
-        .L0x = -0.0050,
-        .L0y = 0.0040,
-        .q2bias = 173.35,
-        .q1off = 2.86,
-        .k = 0.02918,
-        .d = 0.03004,
-        .l = 0.00604,
-        .b = 0.0064
-    };
-
-    const FingerParameters mParamsPinky =
-    {
-        .L0x = -0.0050,
-        .L0y = 0.0040,
-        .q2bias = 170.54,
-        .q1off = 3.43,
-        .k = 0.02425,
-        .d = 0.02504,
-        .l = 0.00608,
-        .b = 0.0064
-    };
+    std::map<std::string, FingerParameters> mFingerParameters;
 
     /*
      * This method implements the law q2 = q2(q1) from
@@ -300,29 +266,7 @@ private:
      *
      * The inputs q1 and the return value of the function are in degrees.
      */
-    double evaluateCoupledJoint(const double& q1, const FingerParameters& parameters);
-
-    /*
-     * This method evalutes the relative angle between the proximal and distal joints of the thumb finger.
-     *
-     * The input q1 and the return value of the function are in degrees.
-     */
-    double evaluateCoupledJointThumb(const double& q1);
-
-    /*
-     * This method evalutes the relative angle between the proximal and distal joints of the index finger.
-     * This is also valid for the middle and ring fingers.
-     *
-     * The input q1 and the return value of the function are in degrees.
-     */
-    double evaluateCoupledJointIndex(const double& q1);
-
-    /*
-     * This method evalutes the relative angle between the proximal and distal joints of the pinky finger.
-     *
-     * The input q1 and the return value of the function are in degrees.
-     */
-    double evaluateCoupledJointPinky(const double& q1);
+    double evaluateCoupledJoint(const double& q1, const std::string& finger_name);
 
     /*
      * This method implements the law \frac{\partial{q2}}{\partial{q1}} from
@@ -332,33 +276,8 @@ private:
      *
      * The input q1 is in degrees.
      */
-    double evaluateCoupledJointJacobian(const double& q1, const FingerParameters& parameters);
+    double evaluateCoupledJointJacobian(const double& q1, const std::string& finger_name);
 
-    /*
-     * This method evalutes the jacobian of the relative angle between the proximal and distal joints of the thumb finger
-     * with respect to the proximal joint.
-     *
-     * The input q1 is in degrees.
-     */
-    double evaluateCoupledJointJacobianThumb(const double& q1);
-
-    /*
-     * This method evalutes the jacobian of the relative angle between the proximal and distal joints of the index finger
-     * with respect to the proximal joint.
-     *
-     * This is also valid for the middle and ring fingers.
-     *
-     * The input q1 is in degrees.
-     */
-    double evaluateCoupledJointJacobianIndex(const double& q1);
-
-    /*
-     * This method evalutes the jacobian of the relative angle between the proximal and distal joints of the pinky finger
-     * with respect to the proximal joint.
-     *
-     * The input q1 is in degrees.
-     */
-    double evaluateCoupledJointJacobianPinky(const double& q1);
 };
 
 #endif //GAZEBOYARP_COUPLING_H

--- a/plugins/controlboard/src/ControlBoard.cc
+++ b/plugins/controlboard/src/ControlBoard.cc
@@ -43,12 +43,12 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
             m_wrapper.close();
         }
 
-        if (m_iVirtAnalogSensorWrap) 
+        if (m_iVirtAnalogSensorWrap)
         {
             m_iVirtAnalogSensorWrap->detachAll();
             m_iVirtAnalogSensorWrap = nullptr;
         }
-        
+
         if (m_virtAnalogSensorWrapper.isValid())
         {
             m_virtAnalogSensorWrapper.close();
@@ -110,15 +110,15 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
         }
         #ifndef GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS
         bool disable_wrapper = m_parameters.check("disableImplicitNetworkWrapper");
-        
+
         if (disable_wrapper && !m_parameters.check("yarpDeviceName"))
         {
             yError() << "GazeboYarpControlBoard : missing yarpDeviceName parameter for one device in robot " << m_robotName;
             return;
         }
-        
-        
-        if (!disable_wrapper) 
+
+
+        if (!disable_wrapper)
         {
             yarp::os::Bottle wrapper_group = m_parameters.findGroup("WRAPPER");
             if(wrapper_group.isNull())
@@ -166,8 +166,8 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 virt_group.append(yarp::os::Bottle(networks));
             }
 
-       
-        
+
+
             yarp::os::Bottle *netList = wrapper_group.find("networks").asList();
 
             if (netList->isNull()) {
@@ -175,9 +175,9 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                 m_wrapper.close();
                 return;
             }
-        
 
-            
+
+
             for (int n = 0; n < netList->size(); n++)
             {
                 yarp::dev::PolyDriverDescriptor newPoly;
@@ -201,9 +201,9 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     scopedDeviceName = m_robotName + "::" + m_parameters.find("yarpDeviceName").asString();
                     m_scopedDeviceName = scopedDeviceName;
                 }
-            
+
                 newPoly.poly = GazeboYarpPlugins::Handler::getHandler()->getDevice(scopedDeviceName);
-            
+
                 if( newPoly.poly != NULL)
                 {
                     // device already exists, use it, setting it againg to increment the usage counter.
@@ -276,7 +276,7 @@ GZ_REGISTER_MODEL_PLUGIN(GazeboYarpControlBoard)
                     return;
                 }
             }
-        
+
             if (!m_iWrap || !m_iWrap->attachAll(m_controlBoards))
             {
                 yCError(GAZEBOCONTROLBOARD) << "error while attaching wrapper to device.";

--- a/plugins/controlboard/src/ControlBoardDriver.cpp
+++ b/plugins/controlboard/src/ControlBoardDriver.cpp
@@ -339,7 +339,20 @@ bool GazeboYarpControlBoardDriver::gazebo_init()
             }
             else if (coupling_bottle->get(0).asString()=="icub_hand_mk5")
             {
+                yarp::os::Bottle& coupling_group_bottle = m_pluginParameters.findGroup("COUPLING_PARAMS");
+
+                if(coupling_group_bottle.isNull())
+                {
+                    yCError(GAZEBOCONTROLBOARD) << "Missing param in COUPLING_PARAMS section";
+                    return false;
+                }
+
                 BaseCouplingHandler* cpl = new HandMk5CouplingHandler(m_robot,coupled_joints, coupled_joint_names, coupled_joint_limits);
+                if (! static_cast<HandMk5CouplingHandler*>(cpl)->parseFingerParameters(coupling_group_bottle))
+                {
+                    yCError(GAZEBOCONTROLBOARD) << "Error parsing coupling parameter, wrong size of the finger parameters list";
+                    return false;
+                }
                 m_coupling_handler.push_back(cpl);
                 yCInfo(GAZEBOCONTROLBOARD) << "using icub_hand_mk5";
             }


### PR DESCRIPTION
It fixes #661

This is a first draft, I thoght that the configuration file will become:
```ini
[COUPLING]
icub_hand_mk5 (0 1 2 3 4 5 6 7 8 9 10 11) (l_thumb_add l_thumb_oc l_index_add l_index_oc l_middle_oc l_ring_pinky_oc reserved reserved reserved reserved reserved reserved) (0.0 0.0 0.0 0.0 0.0 0.0) (90.0 82.1 15.0 90.0 90.0 90.0)

[COUPLING_PARAMS]
L0x     -0.00555 -0.00555 -0.00555 -0.00555 -0.00555
L0y      0.00285  0.00285  0.00285  0.00285  0.00285
q2bias     180.0    180.0    180.0    180.0    180.0
q1off       4.29     4.29     4.29     4.29     4.29
k         0.0171   0.0171   0.0171   0.0171   0.0171
d        0.02006  0.02006  0.02006  0.02006  0.02006
l         0.0085   0.0085   0.0085   0.0085   0.0085
b        0.00624  0.00624  0.00624  0.00624  0.00624

```

Right now I am asking to specify all the coefficient for all the fingers, but @xEnVrE said that only thumb index and pinky is required, maybe I can ask only those?

cc @pattacini @traversaro 