### PR TITLE
ControlBoardDriverCoupling.cpp: include array header as array is used in the code

### DIFF
--- a/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
+++ b/plugins/controlboard/src/ControlBoardDriverCoupling.cpp
@@ -9,6 +9,7 @@
 #include <GazeboYarpPlugins/common.h>
 
 #include <ControlBoardDriverCoupling.h>
+#include <array>
 #include <cstdio>
 #include <cmath>
 #include <gazebo/physics/Model.hh>


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1489 .