### PR TITLE
Add support for loading vector from configuration files with parenthesis

### DIFF
--- a/libraries/common/include/GazeboYarpPlugins/common.h
+++ b/libraries/common/include/GazeboYarpPlugins/common.h
@@ -9,6 +9,11 @@
 
 #include <string>
 #include <cmath>
+#include <vector>
+
+#include <yarp/os/LogStream.h>
+#include <yarp/os/Searchable.h>
+#include <yarp/os/Value.h>
 
 namespace GazeboYarpPlugins {
 
@@ -70,8 +75,89 @@ namespace GazeboYarpPlugins {
         if (pos == std::string::npos) {
             return fullString;
         } else {
-            return fullString.substr(pos + separator.size() - 1); 
+            return fullString.substr(pos + separator.size() - 1);
         }
+    }
+
+    template<typename T>
+    inline T readElementFromValue(yarp::os::Value& val);
+
+    template<>
+    inline double readElementFromValue<double>(yarp::os::Value& val)
+    {
+        return val.asFloat64();
+    }
+
+    template<>
+    inline std::string readElementFromValue<std::string>(yarp::os::Value& val)
+    {
+        return val.asString();
+    }
+
+    /**
+     * Get a vector from a parameter, using both the recommended style:
+     * nameOfList (elem1 elem2 elem3)
+     * or the deprecated (since YARP 3.10):
+     * nameOfList elem1 elem2 elem3
+     *
+     *
+     * \brief Get vector from YARP configuration
+     * \return true if the parsing was successful, false otherwise
+     */
+    template <typename T>
+    inline bool readVectorFromConfigFile(const yarp::os::Searchable& params, const std::string&listName, std::vector<T>& outputList)
+    {
+        bool vectorPopulated = false;
+        outputList.resize(0);
+        yarp::os::Value& val = params.find(listName);
+        if (!val.isNull() && val.isList())
+        {
+            yarp::os::Bottle* listBot = val.asList();
+            outputList.resize(listBot->size());
+
+            for (size_t i=0; i < outputList.size(); i++)
+            {
+                outputList[i] = readElementFromValue<T>(listBot->get(i));
+            }
+
+            vectorPopulated = true;
+        }
+        else
+        {
+            // Try to interpreter the list via findGroup
+            yarp::os::Bottle listBottleAndKey = params.findGroup(listName);
+            if (!listBottleAndKey.isNull())
+            {
+                yWarning() << "Parameter " << listName << " should be a list, but its format is deprecated as parenthesis are missing."
+                           << " Please add parentesis to the list, as documented in https://github.com/robotology/yarp/discussions/3092 .";
+
+                outputList.resize(listBottleAndKey.size()-1);
+
+                for (size_t i=0; i < outputList.size(); i++)
+                {
+                    outputList[i] = readElementFromValue<T>(listBottleAndKey.get(i+1));
+                }
+                vectorPopulated = true;
+            }
+        }
+        return vectorPopulated;
+    }
+
+    /**
+      * Convert a vector to a string for printing.
+      */
+    template <typename T>
+    inline std::string vectorToString(std::vector<T>& outputList)
+    {
+        std::stringstream ss;
+        for (size_t i = 0; i < outputList.size(); ++i) {
+            ss << outputList[i];
+            if (i != outputList.size() - 1)
+            {
+                ss << " ";
+            }
+        }
+        return ss.str();
     }
 }
 

--- a/plugins/fakecontrolboard/src/FakeControlBoardDriver.cpp
+++ b/plugins/fakecontrolboard/src/FakeControlBoardDriver.cpp
@@ -27,20 +27,18 @@ bool GazeboYarpFakeControlBoardDriver::open(yarp::os::Searchable& config)
 {
     m_pluginParameters.fromString(config.toString().c_str());
 
-    yarp::os::Bottle joint_names_bottle = m_pluginParameters.findGroup("jointNames");
+    bool paramOk = GazeboYarpPlugins::readVectorFromConfigFile(m_pluginParameters, "jointNames", m_jointNames);
 
-    if (joint_names_bottle.isNull()) {
-        yError() << "GazeboYarpFakeControlBoardDriver::open(): Error cannot find jointNames." ;
+    if (!paramOk) {
+        yError() << "GazeboYarpControlBoardDriver::setJointNames(): Error cannot find jointNames parameter." ;
         return false;
     }
 
-    m_numberOfJoints = joint_names_bottle.size()-1;
+    m_numberOfJoints = m_jointNames.size();
 
-    m_jointNames.resize(m_numberOfJoints);
     m_jointTypes.resize(m_numberOfJoints);
     
     for (unsigned int i = 0; i < m_jointNames.size(); i++) {
-         m_jointNames[i] = joint_names_bottle.get(i+1).asString().c_str();
          m_jointTypes[i] = yarp::dev::VOCAB_JOINTTYPE_REVOLUTE;
     }
    

--- a/plugins/maissensor/src/MaisSensorDriver.cpp
+++ b/plugins/maissensor/src/MaisSensorDriver.cpp
@@ -150,14 +150,14 @@ void GazeboYarpMaisSensorDriver::onUpdate(const gazebo::common::UpdateInfo& _inf
 
 bool GazeboYarpMaisSensorDriver::setJointNames()  //WORKS
 {
-    yarp::os::Bottle joint_names_bottle = m_pluginParameters.findGroup("jointNames");
+    bool paramOk = GazeboYarpPlugins::readVectorFromConfigFile(m_pluginParameters, "jointNames", controlboard_joint_names);
 
-    if (joint_names_bottle.isNull()) {
-        yError() << "GazeboYarpControlBoardDriver::setJointNames(): Error cannot find jointNames." ;
+    if (!paramOk) {
+        yError() << "GazeboYarpControlBoardDriver::setJointNames(): Error cannot find jointNames parameter." ;
         return false;
     }
 
-    int nr_of_joints = joint_names_bottle.size()-1;
+    int nr_of_joints = controlboard_joint_names.size();
 
     m_jointNames.resize(nr_of_joints);
     m_jointPointers.resize(nr_of_joints);
@@ -173,10 +173,8 @@ bool GazeboYarpMaisSensorDriver::setJointNames()  //WORKS
         //yDebug() << " size of gazebo_models_joints: " <<gazebo_models_joints.size();
     }
 
-    controlboard_joint_names.clear();
     for (unsigned int i = 0; i < m_jointNames.size(); i++) {
         bool joint_found = false;
-        controlboard_joint_names.push_back(joint_names_bottle.get(i+1).asString().c_str());
 
         for (unsigned int gazebo_joint = 0; gazebo_joint < gazebo_models_joints.size() && !joint_found; gazebo_joint++)
         {
@@ -197,7 +195,7 @@ bool GazeboYarpMaisSensorDriver::setJointNames()  //WORKS
         if (!joint_found) {
             yError() << "GazeboYarpControlBoardDriver::setJointNames(): cannot find joint '" << controlboard_joint_names[i]
                      << "' (" << i+1 << " of " << nr_of_joints << ") " << "\n";
-            yError() << "jointNames are " << joint_names_bottle.toString() << "\n";
+            yError() << "jointNames are " << GazeboYarpPlugins::vectorToString(controlboard_joint_names)  << "\n";
             m_jointNames.resize(0);
             m_jointPointers.resize(0);
             return false;

--- a/tutorial/model/single_pendulum/conf/gazebo_controlboard.ini
+++ b/tutorial/model/single_pendulum/conf/gazebo_controlboard.ini
@@ -1,14 +1,30 @@
 disableImplicitNetworkWrapper
 yarpDeviceName controlboard_plugin_device
-jointNames joint
+jointNames (joint)
 
-#PIDs:
-# this information is used to set the PID values in simulation for GAZEBO, we need only the first three values
-[GAZEBO_PIDS]
-#Torso
-Pid0 1000.0 2.0 0.1 9999 9999 9 9
+[POSITION_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+kp            (1000.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)
 
-[GAZEBO_VELOCITY_PIDS]
-#Torso
-Pid0 500.0 2.0 0.1 9999 9999 9 9
-
+[VELOCITY_CONTROL]
+controlUnits  metric_units
+controlLaw    joint_pid_gazebo_v1
+velocityControlImplementationType integrator_and_position_pid
+kp            (500.0)
+kd            (2.0)
+ki            (0.1)
+maxInt        (9999)
+maxOutput     (9999)
+shift         (0.0)
+ko            (0.0)
+stictionUp    (0.0)
+stictionDwn   (0.0)

--- a/tutorial/model/single_pendulum/model.urdf
+++ b/tutorial/model/single_pendulum/model.urdf
@@ -65,7 +65,7 @@
     <!-- Create an instance the gazebo_controlboard YARP device called "controlboard_plugin_device"-->
     <plugin name="controlboard" filename="libgazebo_yarp_controlboard.so">
         <yarpConfigurationFile>model://single_pendulum/conf/gazebo_controlboard.ini</yarpConfigurationFile>
-        <initialConfiguration>0.0 0.0</initialConfiguration>
+        <initialConfiguration>0.0</initialConfiguration>
     </plugin>
     <!-- Launch the other YARP devices, in this case a controlBoard_nws_yarp to expose the controlboard functionalities via YARP ports -->
     <plugin name="robotinterface" filename="libgazebo_yarp_robotinterface.so">


### PR DESCRIPTION
As discussed in https://github.com/robotology/yarp/discussions/3092, it is recommended for future software that uses YARP to use vectors in configuration file by indicating them with parenthesis, i.e. to refer to them with:

~~~
nameOfList (elem1 elem2 elem3)
~~~

instead of:

~~~
nameOfList elem1 elem2 elem3
~~~

gazebo-yarp-plugins used to load the vectors from configuration files expecting no parenthesis. After this PR, now plugins support both the with parentheis and without parenthesis style, printing a warning if the without parenthesis style is used. If you can require gazebo-yarp-plugins 4.11.0, consider switching your configuration files to the vector with parenthesis style.