### PR TITLE
Remove unused include of yarp/dev/LaserMeasurementData.h header

### DIFF
--- a/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
+++ b/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
@@ -9,7 +9,6 @@
 
 #include <yarp/dev/DeviceDriver.h>
 #include <yarp/dev/IRangefinder2D.h>
-#include <yarp/dev/LaserMeasurementData.h>
 #include <yarp/dev/Lidar2DDeviceBase.h>
 #include <yarp/os/Stamp.h>
 #include <boost/shared_ptr.hpp>


### PR DESCRIPTION
Fix https://github.com/robotology/gazebo-yarp-plugins/issues/687 .