### PR TITLE
Change references from RGBDSensorWrapper to rgbdSensor_nws_yarp

### DIFF
--- a/plugins/depthCamera/src/DepthCamera.cc
+++ b/plugins/depthCamera/src/DepthCamera.cc
@@ -57,7 +57,7 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
 
     #ifndef GAZEBO_YARP_PLUGINS_DISABLE_IMPLICIT_NETWORK_WRAPPERS
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpDepthCameraDriver>
-                                                ("gazebo_depthCamera", "RGBDSensorWrapper", "GazeboYarpDepthCameraDriver"));
+                                                ("gazebo_depthCamera", "rgbdSensor_nws_yarp", "GazeboYarpDepthCameraDriver"));
     #else
     ::yarp::dev::Drivers::factory().add(new ::yarp::dev::DriverCreatorOf< ::yarp::dev::GazeboYarpDepthCameraDriver>
                                                 ("gazebo_depthCamera", "", "GazeboYarpDepthCameraDriver"));
@@ -98,11 +98,11 @@ void GazeboYarpDepthCamera::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sd
     if (!disable_wrapper)
     {
         ///////////////////////////
-        //Open the wrapper, forcing it to be a "RGBDSensorWrapper"
-        wrapper_properties.put("device","RGBDSensorWrapper");
+        //Open the wrapper, forcing it to be a "rgbdSensor_nws_yarp"
+        wrapper_properties.put("device","rgbdSensor_nws_yarp");
         if(wrapper_properties.check("subdevice"))
         {
-            yCError(GAZEBODEPTH) << "RGBDSensorWrapper:  Do not use 'subdevice' keyword here since the only supported subdevice is <gazebo_depthCamera>. \
+            yCError(GAZEBODEPTH) << "GazeboYarpDepthCamera:  Do not use 'subdevice' keyword here since the only supported subdevice is <gazebo_depthCamera>. \
                      Please remove the line 'subdevice " << wrapper_properties.find("subdevice").asString().c_str() << "' from your config file before proceeding";
             return;
         }


### PR DESCRIPTION
The `RGBDSensorWrapper` device was deprecated in YARP 3.5 and removed in YARP 3.8 (see https://github.com/robotology/yarp/commit/4da405c7fb077b4604029fd87e4e51a633e2d7eb) and it has been substituted by `rgbdSensor_nws_yarp`. Note that the corresponding network wrapper client (`nwc`) device that reads the rgbd data from a YARP port is called `RGBDSensorClient`.

However, there was still code files that were referring to `RGBDSensorWrapper`, this PR fixes those occurrences.

Similar to https://github.com/robotology/yarp/pull/3150 .