### PR TITLE
Remove lonely cmake_minimum_required in depthCamera folder

### DIFF
--- a/plugins/depthCamera/CMakeLists.txt
+++ b/plugins/depthCamera/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Authors: Alberto Cardellino, Enrico Mingo, Alessio Rocchi, Mirko Ferrati, Silvio Traversaro, Alessandro Settimi and Francesco Romano
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 2.8.7)
-
 PROJECT(Plugin_DepthCamera)
 
 include(AddGazeboYarpPluginTarget)


### PR DESCRIPTION
This should ensure compatibility with CMake 4.0, that removed compatibility with `cmake_minimum_required` set a CMake version < 3.5 (see https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features).