### PR TITLE
Fix compilation with YARP master branch (future YARP 3.12) as of 2025/02/25

### DIFF
--- a/libraries/common/include/GazeboYarpPlugins/YarpDevReturnValueCompat.h
+++ b/libraries/common/include/GazeboYarpPlugins/YarpDevReturnValueCompat.h
@@ -1,0 +1,44 @@
+#ifndef YARP_DEV_RETURN_VALUE_COMPAT_H
+#define YARP_DEV_RETURN_VALUE_COMPAT_H
+
+// Defines YARP_VERSION_* macro
+#include <yarp/conf/version.h>
+
+// These macros simplify the migration of the devices implementation from YARP 3.11 to YARP 3.12,
+// where the interfaces migrated from using bool as return values to use yarp::dev::ReturnValue,
+// see https://github.com/robotology/yarp/discussions/3168
+//
+// For the latest version of this header, check https://gist.github.com/traversaro/ab7ab377c70c50d312a7b5edd4da6242
+//
+// The _CH312 suffix is used as this macro are used in the interface that migrated from bool
+// to yarp::dev::ReturnValue in YARP 3.12, if more interfaces will migrate in YARP 3.13
+// _CH313 macro could be added
+#if (YARP_VERSION_MAJOR > 3) || \
+    (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR > 11) || \
+    (YARP_VERSION_MAJOR == 3 && YARP_VERSION_MINOR == 11 && YARP_VERSION_PATCH >= 100)
+
+#define YARP_DEV_RETURN_VALUE_TYPE_CH312 yarp::dev::ReturnValue
+#define YARP_DEV_RETURN_VALUE_OK_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_ok)
+#define YARP_DEV_RETURN_VALUE_ERROR_GENERIC_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_generic)
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_not_implemented_by_device)
+#define YARP_DEV_RETURN_VALUE_ERROR_NWS_NWC_COMMUNICATION_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_nws_nwc_communication_error)
+#define YARP_DEV_RETURN_VALUE_ERROR_DEPRECATED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_deprecated)
+#define YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_method_failed)
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_READY_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_error_not_ready)
+#define YARP_DEV_RETURN_VALUE_ERROR_UNITIALIZED_CH312 yarp::dev::ReturnValue(yarp::dev::ReturnValue::return_code::return_value_uninitialized)
+
+#else
+
+#define YARP_DEV_RETURN_VALUE_TYPE_CH312 bool
+#define YARP_DEV_RETURN_VALUE_OK_CH312 true
+#define YARP_DEV_RETURN_VALUE_ERROR_GENERIC_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NWS_NWC_COMMUNICATION_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_DEPRECATED_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_NOT_READY_CH312 false
+#define YARP_DEV_RETURN_VALUE_ERROR_UNITIALIZED_CH312 false
+
+#endif
+
+#endif

--- a/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
+++ b/plugins/lasersensor/include/yarp/dev/LaserSensorDriver.h
@@ -15,6 +15,8 @@
 
 #include <gazebo/common/Plugin.hh>
 
+#include <GazeboYarpPlugins/YarpDevReturnValueCompat.h>
+
 #include <mutex>
 
 namespace yarp {
@@ -45,7 +47,7 @@ class yarp::dev::GazeboYarpLaserSensorDriver:
 public:
     GazeboYarpLaserSensorDriver();
     virtual ~GazeboYarpLaserSensorDriver();
-    
+
     void onUpdate(const gazebo::common::UpdateInfo& /*_info*/);
 
     /**
@@ -57,15 +59,15 @@ public:
     virtual bool close() override;
 
     //IRangefinder2D
-    virtual bool setDistanceRange (double min, double max) override;
-    virtual bool setScanLimits (double min, double max) override;
-    virtual bool setHorizontalResolution (double step) override;
-    virtual bool setScanRate (double rate) override;
+    virtual YARP_DEV_RETURN_VALUE_TYPE_CH312 setDistanceRange (double min, double max) override;
+    virtual YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanLimits (double min, double max) override;
+    virtual YARP_DEV_RETURN_VALUE_TYPE_CH312 setHorizontalResolution (double step) override;
+    virtual YARP_DEV_RETURN_VALUE_TYPE_CH312 setScanRate (double rate) override;
 
 public:
     //Lidar2DDeviceBase
     bool acquireDataFromHW() override final;
-    
+
 private:
     double m_gazebo_max_angle;
     double m_gazebo_min_angle;
@@ -75,7 +77,7 @@ private:
     size_t m_gazebo_samples;
     double m_gazebo_scan_rate;
     bool   m_first_run;
-    
+
     gazebo::sensors::RaySensor* m_parentSensor;
     gazebo::event::ConnectionPtr m_updateConnection;
 

--- a/plugins/lasersensor/src/LaserSensorDriver.cpp
+++ b/plugins/lasersensor/src/LaserSensorDriver.cpp
@@ -114,36 +114,36 @@ bool GazeboYarpLaserSensorDriver::acquireDataFromHW()
     return true;
 }
 
-bool GazeboYarpLaserSensorDriver::setDistanceRange (double min, double max)
+YARP_DEV_RETURN_VALUE_TYPE_CH312 GazeboYarpLaserSensorDriver::setDistanceRange (double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCError(GAZEBOLASER) << "setDistanceRange() Not yet implemented";
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
 }
 
-bool GazeboYarpLaserSensorDriver::setScanLimits (double min, double max)
+YARP_DEV_RETURN_VALUE_TYPE_CH312 GazeboYarpLaserSensorDriver::setScanLimits (double min, double max)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCError(GAZEBOLASER) << "setScanLimits() Not yet implemented";
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
 }
 
-bool GazeboYarpLaserSensorDriver::setHorizontalResolution (double step)
+YARP_DEV_RETURN_VALUE_TYPE_CH312 GazeboYarpLaserSensorDriver::setHorizontalResolution (double step)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     yCError(GAZEBOLASER) << "setHorizontalResolution() Not yet implemented";
-    return false;
+    return YARP_DEV_RETURN_VALUE_ERROR_NOT_IMPLEMENTED_BY_DEVICE_CH312;
 }
 
-bool GazeboYarpLaserSensorDriver::setScanRate (double rate)
+YARP_DEV_RETURN_VALUE_TYPE_CH312 GazeboYarpLaserSensorDriver::setScanRate (double rate)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     if (rate<0)
     {
       yCError(GAZEBOLASER) << "Invalid setScanRate";
-      return false;
+      return YARP_DEV_RETURN_VALUE_ERROR_METHOD_FAILED_CH312;
     }
     m_parentSensor->SetUpdateRate(rate);
     m_scan_rate = rate;
-    return true;
+    return YARP_DEV_RETURN_VALUE_OK_CH312;
 }


### PR DESCRIPTION
This PR switches migrate the Laser plugin to the use of yarp::dev::ReturnValue-based interface, as a follow up of:
* https://github.com/robotology/yarp/discussions/3168
* https://github.com/robotology/yarp/pull/3180
* https://github.com/robotology/yarp-device-rplidar/pull/7

To avoid the need to keep two branches, one for compatibility with YARP 3.11.* and one for the future YARP 3.12.*, I prepared a `YarpDevReturnValueCompat.h` header that can be useful to implement an interface that works in both cases. As these header can be useful also for other repos, but I do not think it make sense to install in an a reusable library as it is a temporary solution, I will store it in https://gist.github.com/traversaro/ab7ab377c70c50d312a7b5edd4da6242, so that interested users can copy it in their repo as a private (non-installed) header to simplify the support of the future YARP 3.12

Similar to https://github.com/robotology/gz-sim-yarp-plugins/pull/240 .