### PR TITLE
Replace deprecated FrameGrabberInterfaces.h header

### DIFF
--- a/plugins/camera/include/gazebo/Camera.hh
+++ b/plugins/camera/include/gazebo/Camera.hh
@@ -13,7 +13,7 @@
 #include <yarp/os/Network.h>
 #include <yarp/dev/PolyDriver.h>
 
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 
 #include <string>
 
@@ -51,7 +51,7 @@ namespace gazebo
 
     private:
         yarp::os::Network m_yarp;
-        yarp::os::Property m_parameters; 
+        yarp::os::Property m_parameters;
         yarp::dev::PolyDriver m_cameraDriver;
         std::string m_sensorName;
         sensors::CameraSensor *m_sensor;

--- a/plugins/camera/include/yarp/dev/CameraDriver.h
+++ b/plugins/camera/include/yarp/dev/CameraDriver.h
@@ -8,7 +8,7 @@
 #define GAZEBOYARP_CAMERADRIVER_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>
 #include <yarp/os/Time.h>
@@ -117,7 +117,7 @@ private:
     gazebo::sensors::CameraSensor* m_parentSensor;
     gazebo::rendering::CameraPtr m_camera;
     gazebo::event::ConnectionPtr m_updateConnection;
-    
+
     struct txt_type
     {
        char data[16];

--- a/plugins/depthCamera/include/gazebo/DepthCamera.hh
+++ b/plugins/depthCamera/include/gazebo/DepthCamera.hh
@@ -15,7 +15,7 @@
 
 #include <yarp/os/Network.h>
 #include <yarp/dev/PolyDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 
 
 namespace yarp {

--- a/plugins/multicamera/include/gazebo/MultiCamera.hh
+++ b/plugins/multicamera/include/gazebo/MultiCamera.hh
@@ -12,7 +12,7 @@
 #include <gazebo/plugins/MultiCameraPlugin.hh>
 #include <yarp/dev/PolyDriver.h>
 
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 
 #include <string>
 
@@ -44,7 +44,7 @@ namespace gazebo
         virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
 
     private:
-        yarp::os::Property m_parameters; 
+        yarp::os::Property m_parameters;
         yarp::dev::PolyDriver m_cameraDriver;
         std::string m_sensorName;
         sensors::MultiCameraSensor *m_sensor;

--- a/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
+++ b/plugins/multicamera/include/yarp/dev/MultiCameraDriver.h
@@ -8,7 +8,7 @@
 #define GAZEBOYARP_MULTICAMERADRIVER_H
 
 #include <yarp/dev/DeviceDriver.h>
-#include <yarp/dev/FrameGrabberInterfaces.h>
+#include <yarp/dev/IFrameGrabberImage.h>
 #include <yarp/dev/IRgbVisualParams.h>
 #include <yarp/os/Stamp.h>
 #include <yarp/dev/IPreciselyTimed.h>


### PR DESCRIPTION
FrameGrabberInterfaces.h has been deprecated long before the currently required YARP 3.9 version.